### PR TITLE
docs: define UKI consistency policy

### DIFF
--- a/docs/adr-uki-canonical-asset-states.md
+++ b/docs/adr-uki-canonical-asset-states.md
@@ -1,0 +1,273 @@
+# ADR: UKI canonical wallet and asset states
+
+Estado: aceptado para implementacion inicial.
+Issue: #17 `UKI-001.2`.
+Fecha: 2026-05-12.
+
+## Contexto
+
+La dapp UKI necesita usar NFTs existentes que pueden estar en BSC o Tron, listados en marketplace, en bridge, aportados a pools, usados para cupos Cukie Master o asignados temporalmente a partidas. Si cada modulo interpreta el estado por separado, un mismo NFT podria aparecer disponible en varias superficies incompatibles.
+
+Este ADR fija estados canonicos para assets NFT y reglas de recuperacion cuando Mongo, marketplace, chain o indexers no coinciden. Complementa `docs/adr-uki-economic-operations.md`.
+
+## Decision
+
+Cada NFT normalizado debe tener un unico `canonicalState` operativo en Mongo. Los datos externos pueden producir flags o evidencias, pero el backend debe resolverlos a un estado unico antes de exponer acciones a dapp o juegos.
+
+Estados canonicos:
+
+- `available`
+- `listed`
+- `bridging`
+- `soft_staked`
+- `in_pool`
+- `assigned_to_game`
+- `invalidated`
+- `unknown`
+
+La wallet tambien debe tener estados derivados para UX, pero esos estados no sustituyen los estados de asset.
+
+## Modelo conceptual
+
+```text
+wallet
+  owns/controls many CukieAsset
+
+CukieAsset
+  network: bsc | tron | unknown
+  contractAddress
+  tokenId
+  ownerWallet
+  rarity
+  generation
+  canonicalState
+  stateReason
+  stateUpdatedAt
+  evidence[]
+  locks[]
+```
+
+`canonicalState` decide si el usuario puede listar, aportar a pool, usar para Cukie Master, asignar a juego o retirar.
+
+`evidence[]` registra las senales que llevaron al estado: owner indexado, listing activo, bridge pendiente, lock interno, asignacion de partida, reconciliacion fallida.
+
+## Estados canonicos de asset
+
+| Estado | Significado | Fuente primaria | Acciones permitidas | Recuperacion |
+| --- | --- | --- | --- | --- |
+| `available` | NFT usable por la dapp y sin bloqueo economico activo. | `NftInventoryService` tras reconciliar owner, listing, bridge y locks. | Usar para cupos NFT, aportar a pool, seleccionar para juego si la feature lo permite. | Si aparece evidencia externa incompatible, pasar al estado de mayor precedencia. |
+| `listed` | NFT listado en marketplace o con venta activa. | Marketplace/Mongo operativo del marketplace. | Ver en dashboard, abrir marketplace. No aportar a pool ni asignar a juego. | Si el listing desaparece, reconciliar owner y volver a `available` o al siguiente bloqueo aplicable. |
+| `bridging` | NFT en proceso de bridge o con estado de red no finalizado. | Marketplace/bridge status + indexer. | Solo lectura y aviso. No usar en economia. | Si bridge finaliza, actualizar `network`, owner y recalcular estado. Si queda atascado, marcar `unknown` y crear alerta ops. |
+| `soft_staked` | NFT bloqueado off-chain para participar en Cukie Master o una mecanica equivalente sin moverlo on-chain. | Mongo lock interno. | Ver posicion, retirar si reglas/ventana lo permiten. No listar desde dapp, no aportar a otro pool. | Si owner cambia o listing aparece, invalidar lock y pasar a `invalidated` hasta reconciliar. |
+| `in_pool` | NFT aportado al pool de Cukies para asignacion a partidas/rewards. | Mongo `CukiePoolPosition` + lock interno. | Ver posicion, solicitar salida si no esta asignado. No usar como NFT propio en partida ni listar desde dapp. | Si owner cambia, cerrar posicion como invalidada. Si solicita salida, pasar a `available` solo tras liberar locks. |
+| `assigned_to_game` | NFT reservado temporalmente para una game session. | Mongo `GameSessionEconomy` + lock temporal. | Solo usado por la session asignada. No retirar ni reasignar. | Al finalizar/expirar session, liberar lock y volver a `in_pool`, `soft_staked` o `available` segun `previousState`. |
+| `invalidated` | El asset tenia uso economico activo, pero una evidencia lo invalida. | Reconciliador backend. | Solo lectura, soporte/ops. No acciones economicas. | Requiere job o intervencion ops para cerrar locks, ajustar allocations futuras y recalcular estado. |
+| `unknown` | El sistema no puede determinar estado seguro. | Reconciliador/backend. | Solo lectura. No acciones economicas. | Reintentar indexacion. Si se resuelve owner/listing/bridge/locks, recalcular. Si no, abrir alerta ops. |
+
+## Precedencia de estados
+
+Cuando varias evidencias compiten, se aplica esta precedencia, de mayor a menor:
+
+1. `invalidated`
+2. `unknown`
+3. `bridging`
+4. `assigned_to_game`
+5. `listed`
+6. `in_pool`
+7. `soft_staked`
+8. `available`
+
+Razonamiento:
+
+- `invalidated` y `unknown` bloquean por seguridad.
+- `bridging` bloquea porque owner/red puede cambiar.
+- `assigned_to_game` protege sesiones en curso.
+- `listed` evita usar economicamente un NFT que el usuario intenta vender.
+- `in_pool` y `soft_staked` son locks internos controlables por backend.
+- `available` solo existe cuando no hay evidencia incompatible.
+
+## Exclusiones duras
+
+Un NFT no puede estar simultaneamente en:
+
+- `listed` y `in_pool`
+- `listed` y `soft_staked`
+- `listed` y `assigned_to_game`
+- `bridging` y cualquier estado economico activo
+- `in_pool` y `soft_staked`, salvo que una decision futura defina un pool como subtipo de soft staking
+- `assigned_to_game` y otra `assigned_to_game` activa
+- `invalidated` y cualquier accion economica permitida
+- `unknown` y cualquier accion economica permitida
+
+La implementacion puede guardar locks historicos, pero solo uno puede ser activo para una misma dimension economica.
+
+## Flags derivados permitidos
+
+Estos flags pueden coexistir con `canonicalState`, pero no son estados canonicos:
+
+- `isOwnerVerified`
+- `isOriginalGeneration`
+- `isSecondGeneration`
+- `isEligibleForCukieMaster`
+- `isEligibleForPool`
+- `hasActiveListing`
+- `hasBridgePending`
+- `hasInternalLock`
+- `hasGameReservation`
+- `needsReconciliation`
+- `requiresOpsReview`
+
+La UI debe mostrar acciones desde `canonicalState` + permisos derivados, no desde flags aislados.
+
+## Estados de wallet
+
+La wallet puede tener estados derivados para UX y API:
+
+| Estado wallet | Significado | Impacto |
+| --- | --- | --- |
+| `disconnected` | No hay wallet conectada. | UI pide conectar. No hay acciones economicas. |
+| `wrong_chain` | Wallet EVM conectada a red distinta de BSC para acciones UKI. | UI pide switch a BSC. Puede mostrar datos cacheados solo lectura. |
+| `connected_unverified` | Wallet conectada, pero inventario/indexer no reconciliado. | Solo lectura parcial. Acciones NFT bloqueadas. |
+| `ready` | Wallet conectada, red correcta y datos reconciliados. | Acciones segun estado de cada asset. |
+| `ops_blocked` | Wallet marcada para revision operativa o riesgo. | Acciones economicas bloqueadas hasta resolver. |
+
+Estos estados no sustituyen a los estados de cada NFT. Una wallet `ready` puede tener assets `unknown` o `invalidated`.
+
+## Reglas de recuperacion
+
+### Mongo dice available, marketplace dice listed
+
+Resultado: `listed`.
+
+Accion:
+
+- Bloquear pool/staking/game assignment.
+- Crear audit log `state_reconciled`.
+- Si existia lock interno, marcar lock como `conflicted` y abrir alerta ops.
+
+### Mongo dice in_pool, owner chain/indexer cambio
+
+Resultado: `invalidated`.
+
+Accion:
+
+- Cerrar posicion de pool para periodos futuros.
+- No revertir rewards ya cerrados sin decision ops.
+- Evitar nueva asignacion a partida.
+- Crear alerta con owner anterior, owner nuevo y fuente.
+
+### Mongo dice assigned_to_game, session expirada
+
+Resultado: volver a `previousState` si no hay evidencia externa mas fuerte.
+
+Accion:
+
+- Job libera lock temporal.
+- Registra `game_assignment_expired`.
+- Recalcula estado aplicando precedencia completa.
+
+### Bridge pendiente sin confirmacion
+
+Resultado: `bridging`.
+
+Accion:
+
+- Bloquear acciones economicas.
+- Reintentar por job.
+- Si supera la ventana definida en #18, pasar a `unknown` con `requiresOpsReview`.
+
+### Indexer no responde
+
+Resultado: conservar ultimo estado seguro si no habilita nuevas acciones; si se necesita decidir una accion nueva, usar `unknown`.
+
+Accion:
+
+- La UI puede mostrar datos antiguos con timestamp.
+- No permitir nueva entrada a pool, nueva asignacion o nuevo cupo NFT hasta reconciliar.
+
+### Listing desaparece del marketplace
+
+Resultado: recalcular.
+
+Accion:
+
+- Validar owner.
+- Aplicar locks internos activos.
+- Volver a `available`, `in_pool`, `soft_staked` o `assigned_to_game` segun corresponda.
+
+## Reglas para acciones
+
+| Accion | Estados permitidos | Validacion inmediata |
+| --- | --- | --- |
+| Mostrar en inventario | Todos | Ninguna, pero mostrar warning en `unknown`/`invalidated`. |
+| Usar para cupo NFT | `available`, `soft_staked` si la ruta NFT lo define asi | Owner verificado, rareza conocida, no bridge/listing activo. |
+| Aportar a pool | `available` | Owner verificado, rareza conocida, no listing, no bridge, no lock activo. |
+| Retirar de pool | `in_pool` | No `assigned_to_game`, ventana/regla de salida cumplida. |
+| Asignar a partida propia | `available` o estado especifico futuro | Owner verificado y session reservation atomica. |
+| Asignar desde pool | `in_pool` | Lock temporal atomico y no estar ya asignado. |
+| Liberar asignacion de partida | `assigned_to_game` | Session finalizada, expirada o rechazada. |
+| Listar desde dapp futura | `available` | No lock activo y owner verificado. |
+
+## Auditoria minima
+
+Cada cambio de `canonicalState` debe registrar:
+
+- `assetId`
+- `previousState`
+- `nextState`
+- `reason`
+- `source`
+- `evidenceHash` o referencias a evidencias
+- `actor`: `system`, `job`, `admin`, `user`
+- `jobRunId` si aplica
+- `createdAt`
+
+Los cambios que afecten rewards, cupos o partidas deben ser append-only y nunca sobrescribir el historial.
+
+## Implicaciones para implementacion
+
+### `NftInventoryService`
+
+Debe exponer:
+
+- `getWalletNfts(wallet)`
+- `getAssetState(assetId)`
+- `reconcileAsset(assetId)`
+- `lockAsset(assetId, reason, owner, ttl?)`
+- `unlockAsset(assetId, reason)`
+- `assertActionAllowed(assetId, action)`
+
+### Modelo de datos
+
+El modelo futuro debe separar:
+
+- asset normalizado,
+- evidencias externas,
+- locks internos,
+- cambios de estado,
+- posiciones de pool,
+- asignaciones temporales de partida.
+
+No conviene guardar un unico campo `status` sin historial.
+
+### Dapp
+
+La dapp debe renderizar acciones desde `canonicalState`:
+
+- `available`: acciones principales.
+- `listed`/`bridging`: solo lectura con CTA informativo.
+- `in_pool`/`soft_staked`: gestion de posicion.
+- `assigned_to_game`: estado temporal.
+- `unknown`/`invalidated`: bloqueo y soporte.
+
+### Contratos
+
+Los contratos no deben conocer estos estados NFT. Solo deben exponer eventos de UKI, staking y claims. La excepcion seria una futura decision de mover staking NFT on-chain, que requeriria un ADR nuevo.
+
+## Decisiones pendientes para #18
+
+- Ventana maxima de tolerancia para indexer/bridge no disponible.
+- Numero de confirmaciones BSC antes de considerar eventos finales.
+- Politica de correccion si un NFT invalidado ya genero rewards en un periodo cerrado.
+- Frecuencia de reconciliacion de ownership/listing/bridge.
+

--- a/docs/adr-uki-consistency-policy.md
+++ b/docs/adr-uki-consistency-policy.md
@@ -1,0 +1,234 @@
+# ADR: UKI consistency policy
+
+Estado: aceptado para implementacion inicial.
+Issue: #18 `UKI-001.3`.
+Fecha: 2026-05-12.
+
+## Contexto
+
+La economia UKI combina BNB Smart Chain, Mongo, marketplace, indexers y jobs periodicos. No todos los datos necesitan la misma frescura. Una compra o claim debe depender de BSC; una partida necesita validar recursos justo antes de empezar; un ranking semanal puede cerrarse por snapshot.
+
+Esta politica define ventanas aceptables de sincronizacion, que se calcula por snapshot diario/semanal y que debe comprobarse en tiempo real antes de iniciar partida.
+
+## Decision
+
+Usamos consistencia fuerte solo en los puntos donde se reserva o mueve valor operativo:
+
+- transacciones BSC confirmadas,
+- reserva de creditos,
+- locks de NFT para pool/partida,
+- inicio y cierre de game sessions,
+- generacion de batches de claim.
+
+Usamos consistencia eventual con snapshots versionados para dashboards, ranking, rewards calculadas y cupos agregados. Si un dato no esta suficientemente fresco para una accion economica, la accion se bloquea y la UI muestra estado de reconciliacion.
+
+## Politica por dominio
+
+| Dominio | Fuente canonica | Frescura aceptable para lectura UI | Frescura requerida para accion | Snapshot / cierre |
+| --- | --- | --- | --- | --- |
+| Compra ASM -> UKI | BSC `Presale` | Cache indexado hasta 60s si se muestra tx hash/estado pendiente | Confirmacion BSC antes de mostrar compra finalizada | No aplica; eventos por tx |
+| Vesting UKI | BSC `VestingVault` | Cache hasta 5 min para dashboard | Lectura BSC o indexer confirmado antes de release/claim | Snapshot diario opcional para analytics |
+| UKI staked | BSC `UKIStaking` | Cache hasta 5 min | Revalidar stake antes de crear o renovar cupo Cukie Master | Snapshot diario para cupos y auditoria |
+| Ownership NFT | Mongo/marketplace normalizado + reconciliacion | Cache hasta 15 min con timestamp visible si hay dudas | Revalidar owner/listing/bridge/lock antes de pool, soft staking o game assignment | Snapshot diario de inventario elegible |
+| Listing/bridge NFT | Marketplace/bridge status | Cache hasta 5 min | Revalidar inmediatamente antes de lock economico | Snapshot diario de excepciones |
+| Creditos | Mongo ledger append-only | Lectura materializada hasta 60s | Transaccion atomica al reservar/gastar | Cierre diario para expiracion y grants |
+| Pool de creditos | Mongo ledger + balances por periodo | Lectura hasta 60s | Reserva atomica por session id | Cierre diario y semanal segun reglas |
+| Pool de Cukies | Mongo locks/positions | Lectura hasta 5 min | Lock atomico antes de asignar a partida | Snapshot diario para elegibilidad/rewards |
+| Game session | Mongo `GameSessionEconomy` | Estado actual desde API | Transicion atomica con idempotency key | Expiracion por job; settlement por evento de session |
+| Ranking semanal | Mongo ranking snapshots | Lectura hasta 5 min | No se usa para iniciar partida | Cierre semanal |
+| Reward allocation | Mongo allocations versionadas | Lectura hasta 5 min tras cierre | No claimable hasta batch/root aprobado | Cierre diario/semanal |
+| Reward claim | BSC `RewardsDistributor` | Cache indexado hasta 60s | Evento BSC confirmado para marcar claimed | Batch por periodo |
+
+## Confirmaciones y finalizacion BSC
+
+Valores iniciales:
+
+- BSC testnet: 3 confirmaciones para UI de exito normal.
+- BSC mainnet: 6 confirmaciones para compras, vesting release, staking/unstaking y claims.
+- Operaciones administrativas o multisig: 12 confirmaciones antes de que jobs las usen para cierre.
+
+La UI puede mostrar `pending` antes de esas confirmaciones, pero no debe conceder recursos off-chain definitivos hasta alcanzar la politica de confirmacion.
+
+## Snapshots diarios
+
+Se calculan diariamente:
+
+- Inventario NFT elegible por wallet.
+- Estados conflictivos `unknown`/`invalidated`.
+- Cupos Cukie Master por ruta NFT.
+- Cupos Cukie Master por ruta UKI usando stake indexado.
+- Grants de creditos diarios.
+- Expiracion de creditos no usados.
+- Posiciones activas en pool de Cukies.
+- Allocations diarias si la regla de rewards diaria esta activa.
+
+Cada snapshot debe guardar:
+
+- `period`
+- `snapshotAt`
+- `sourceWatermarks`
+- `ruleVersion`
+- `inputHash`
+- `outputHash`
+- `jobRunId`
+
+## Snapshots semanales
+
+Se calculan semanalmente:
+
+- Ranking por juego/periodo.
+- Movimiento de ranks con limites +2/-2.
+- Elegibilidad por minimo de partidas.
+- Allocations semanales.
+- Batch candidato para rewards claimable si aplica.
+
+Los snapshots semanales no deben depender de datos que aun esten `pending` en BSC. Si hay operaciones pendientes al cierre, se tratan segun una regla explicita de periodo siguiente o bloqueo de batch.
+
+## Checks en tiempo real antes de iniciar partida
+
+Antes de iniciar una partida con economia, el backend debe comprobar en la misma operacion logica:
+
+1. Wallet existe y no esta `ops_blocked`.
+2. Game economy config vigente para `gameId`.
+3. Creditos disponibles propios o creditos prestables del pool.
+4. NFT propio seleccionado sigue en estado permitido, si aplica.
+5. Cukie de pool asignado sigue `in_pool` y no `assigned_to_game`.
+6. No hay listing/bridge/invalidacion conocida para el NFT usado.
+7. Reserva atomica de creditos.
+8. Lock atomico de Cukie si hay asset asignado.
+9. Creacion de `GameSessionEconomy` con idempotency key.
+
+Si cualquiera falla, no se inicia la partida. El cliente recibe motivo recuperable: `insufficient_credits`, `asset_unavailable`, `wallet_blocked`, `stale_inventory`, `pool_empty`, `config_unavailable` o `reconciliation_required`.
+
+## Reglas de degradacion
+
+### Indexer BSC retrasado
+
+- Lectura UI: mostrar ultimo dato con timestamp y estado `syncing`.
+- Accion economica: leer BSC directo si es viable; si no, bloquear.
+- Jobs de cierre: esperar hasta ventana maxima o marcar periodo `pending_reconciliation`.
+
+### Marketplace/bridge no disponible
+
+- Lectura UI: mostrar inventario cacheado con warning.
+- Nueva accion sobre NFT: bloquear salvo que haya evidencia fresca dentro de la ventana.
+- Jobs: registrar fallo y reintentar; si supera ventana, pasar assets afectados a `unknown`.
+
+### Mongo disponible, BSC no disponible
+
+- Se permiten lecturas off-chain.
+- No se permiten compras, staking, releases ni claims.
+- No se deben cerrar batches de rewards si dependen de eventos BSC recientes.
+
+### BSC confirma cambio que contradice Mongo
+
+- BSC gana para valor transferible y staking.
+- Para NFT ownership, se aplica politica de `NftInventoryService` y estado canonico.
+- Locks off-chain afectados pasan a `invalidated` si el cambio rompe elegibilidad.
+
+## Ventanas iniciales
+
+| Proceso | Ventana objetivo | Ventana maxima antes de alerta |
+| --- | --- | --- |
+| Indexar evento `Presale` | 60s | 5 min |
+| Indexar staking/unstaking | 2 min | 10 min |
+| Indexar release/claim | 60s | 5 min |
+| Reconciliar ownership NFT | 15 min | 2 h |
+| Reconciliar listing/bridge | 5 min | 30 min |
+| Liberar lock de game session expirada | 1 min | 10 min |
+| Entrega diaria de creditos | Hora fija + 5 min | Hora fija + 30 min |
+| Cierre semanal ranking | Hora fija + 15 min | Hora fija + 2 h |
+| Generar reward batch | Tras cierre + 30 min | Tras cierre + 6 h |
+
+Estas ventanas son parametros operativos. Deben vivir en config, no hardcodeadas.
+
+## Idempotencia
+
+Toda operacion que reserve, conceda, gaste o cierre valor off-chain debe tener idempotency key:
+
+- Compra indexada: `chainId:txHash:logIndex`.
+- Grant diario: `daily-credit:{wallet}:{slotId}:{period}`.
+- Expiracion: `credit-expire:{wallet}:{period}`.
+- Game session start: `game-start:{wallet}:{gameId}:{clientRequestId}`.
+- Settlement: `game-settle:{sessionId}:{resultHash}`.
+- Ranking close: `ranking-close:{gameId}:{week}`.
+- Reward allocation: `reward-allocation:{period}:{ruleVersion}:{inputHash}`.
+- Claim batch: `claim-batch:{period}:{allocationHash}`.
+
+Reintentar una key debe devolver el resultado previo o fallar sin duplicar efectos.
+
+## Politica de recuperacion
+
+### Periodo abierto
+
+Si se detecta inconsistencia durante un periodo abierto:
+
+- bloquear nuevas acciones afectadas,
+- reconciliar estado canonico,
+- corregir materializaciones,
+- mantener ledger append-only,
+- registrar `reconciliation_event`.
+
+### Periodo cerrado sin batch on-chain
+
+Si el periodo ya cerro pero aun no hay root/batch publicado:
+
+- recalcular allocation si la inconsistencia afecta el resultado,
+- guardar nuevo `inputHash`/`outputHash`,
+- marcar batch anterior como `superseded`.
+
+### Periodo cerrado con batch on-chain
+
+Si el root o batch ya esta publicado:
+
+- no mutar claims ya liquidados,
+- abrir ajuste en periodo futuro si procede,
+- registrar decision ops/legal/treasury,
+- documentar wallet, amount y motivo.
+
+## Reglas para UI
+
+La UI debe distinguir:
+
+- `confirmed`: fuente canonica confirmada.
+- `pending`: tx o job en curso.
+- `syncing`: datos antiguos pero no bloqueantes para lectura.
+- `stale`: datos demasiado antiguos para accion.
+- `blocked`: accion no permitida por consistencia.
+- `needs_reconciliation`: requiere job/ops antes de continuar.
+
+No debe presentar un dato cacheado como definitivo cuando desbloquea una accion economica.
+
+## Impacto por area
+
+### Contratos
+
+- Eventos deben ser indexables por wallet, periodo y batch.
+- Operaciones administrativas necesitan suficiente metadata/eventos para reconciliacion.
+
+### Backend/datos
+
+- Separar ledger append-only de balances materializados.
+- Guardar watermarks de fuentes por snapshot.
+- Implementar jobs reentrantes con idempotency keys.
+- Exponer freshness/timestamps en APIs criticas.
+
+### Juegos
+
+- No iniciar partida sin reserva atomica confirmada.
+- No confiar en recursos enviados por cliente.
+- Expirar sessions incompletas y liberar locks rapidamente.
+
+### Dapp
+
+- Mostrar estados de sincronizacion y bloqueo de forma explicita.
+- Reconsultar antes de acciones criticas.
+- Enlazar tx BscScan cuando una accion depende de BSC.
+
+## Decisiones pendientes
+
+- Parametros finales de confirmaciones y ventanas por entorno.
+- Hora exacta de cierre diario y semanal.
+- Si rewards diarias y semanales comparten batch o tienen batch separado.
+- Politica legal/ops para ajustes post-batch cuando hay claims ya ejecutados.
+

--- a/docs/uki-launch-technical-backlog.md
+++ b/docs/uki-launch-technical-backlog.md
@@ -68,6 +68,7 @@ Issues hijas:
 
 - UKI-001.2 Task - Definir estados canonicos de wallet y assets
   - Estados minimos: `available`, `listed`, `bridging`, `soft_staked`, `in_pool`, `assigned_to_game`, `invalidated`, `unknown`.
+  - Documento de decision: `docs/adr-uki-canonical-asset-states.md`.
   - Acceptance criteria:
     - Un NFT no puede estar simultaneamente en marketplace, bridge, staking y pool.
     - Hay reglas de recuperacion cuando Mongo y chain/indexer discrepan.

--- a/docs/uki-launch-technical-backlog.md
+++ b/docs/uki-launch-technical-backlog.md
@@ -75,6 +75,7 @@ Issues hijas:
 
 - UKI-001.3 Task - Definir politica de consistencia
   - Definir ventanas aceptables de sincronizacion para ownership NFT, staking, credits y rewards.
+  - Documento de decision: `docs/adr-uki-consistency-policy.md`.
   - Acceptance criteria:
     - Queda definido que se calcula en snapshot diario/semanal.
     - Queda definido que se comprueba en tiempo real antes de iniciar partida.


### PR DESCRIPTION
Closes #18\n\nDepends on #150.\n\n## Summary\n- Add an ADR defining consistency windows for BSC, Mongo, marketplace, indexers and jobs.\n- Define what is calculated via daily/weekly snapshots.\n- Define what must be checked in real time before starting an economy game session.\n- Add degradation, idempotency and recovery rules for stale or conflicting data.\n- Link the ADR from the technical backlog.\n\n## Validation\n- `rg -n "ownership NFT|staking|Creditos|rewards|Snapshots diarios|Snapshots semanales|Checks en tiempo real antes de iniciar partida|Ventanas iniciales|Indexar staking|Reconciliar ownership|Reward allocation|idempotency" docs/adr-uki-consistency-policy.md` OK\n- `git diff --check` OK\n\n## Risks / Follow-ups\n- Documentation/architecture only; no runtime behavior changed.\n- This branch is stacked on #150 because it references the canonical asset state ADR.\n- Operational windows are initial parameters and should become config when implemented.