### PR TITLE
docs: specify NFT inventory service

### DIFF
--- a/dapp/scripts/audit-nft-data-quality.mjs
+++ b/dapp/scripts/audit-nft-data-quality.mjs
@@ -1,0 +1,234 @@
+import { MongoClient } from 'mongodb';
+
+const REQUIRED_ENV = 'CUKIES_DATABASE_URL';
+const DEFAULT_DB = 'cukies';
+const DEFAULT_LIMIT = 200;
+const CANDIDATE_COLLECTIONS = ['cukies', 'originals', 'tx_nfts', 'txMarketplace', 'wallets'];
+
+const FIELD_CANDIDATES = {
+  network: ['network', 'chain', 'blockchain'],
+  contract: ['contract', 'contractAddress', 'address', 'collectionAddress'],
+  tokenId: ['tokenId', 'token_id', 'nftId', 'id'],
+  owner: ['owner', 'ownerWallet', 'wallet', 'walletAddress', 'address'],
+  rarity: ['rarity', 'rank', 'tier'],
+  generation: ['generation', 'gen', 'collectionType'],
+  metadata: ['metadata', 'attributes', 'traits'],
+  listingStatus: ['listingStatus', 'listed', 'isListed', 'status'],
+  bridgeStatus: ['bridgeStatus', 'bridge', 'bridging'],
+};
+
+function parseArgs(argv) {
+  const args = {
+    dbName: process.env.CUKIES_DATABASE_NAME || DEFAULT_DB,
+    limit: Number(process.env.NFT_AUDIT_LIMIT || DEFAULT_LIMIT),
+    collections: CANDIDATE_COLLECTIONS,
+    json: false,
+  };
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help') {
+      args.help = true;
+    } else if (arg === '--json') {
+      args.json = true;
+    } else if (arg === '--db') {
+      args.dbName = argv[index + 1];
+      index += 1;
+    } else if (arg === '--limit') {
+      args.limit = Number(argv[index + 1]);
+      index += 1;
+    } else if (arg === '--collections') {
+      args.collections = argv[index + 1].split(',').map((item) => item.trim()).filter(Boolean);
+      index += 1;
+    }
+  }
+
+  if (!Number.isFinite(args.limit) || args.limit < 1) {
+    args.limit = DEFAULT_LIMIT;
+  }
+
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  CUKIES_DATABASE_URL=<mongodb-uri> pnpm --dir dapp node scripts/audit-nft-data-quality.mjs [options]
+
+Options:
+  --db <name>                  Database name. Defaults to CUKIES_DATABASE_NAME or ${DEFAULT_DB}.
+  --limit <number>             Max sampled documents per collection. Defaults to ${DEFAULT_LIMIT}.
+  --collections <a,b,c>        Comma-separated collection list.
+  --json                       Print machine-readable JSON.
+
+The script prints aggregate field coverage only. It does not print wallets, token metadata, full documents, or connection strings.`);
+}
+
+function readPath(value, path) {
+  return path.split('.').reduce((current, key) => {
+    if (current == null) return undefined;
+    return current[key];
+  }, value);
+}
+
+function firstPresent(doc, candidates) {
+  for (const field of candidates) {
+    const direct = readPath(doc, field);
+    if (direct !== undefined && direct !== null && direct !== '') {
+      return { field, value: direct };
+    }
+  }
+
+  for (const [key, value] of Object.entries(doc)) {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      for (const field of candidates) {
+        const nested = readPath(value, field);
+        if (nested !== undefined && nested !== null && nested !== '') {
+          return { field: `${key}.${field}`, value: nested };
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+function detectNetwork(doc) {
+  const networkCandidate = firstPresent(doc, FIELD_CANDIDATES.network);
+  const ownerCandidate = firstPresent(doc, FIELD_CANDIDATES.owner);
+  const contractCandidate = firstPresent(doc, FIELD_CANDIDATES.contract);
+  const values = [networkCandidate?.value, ownerCandidate?.value, contractCandidate?.value]
+    .filter((value) => typeof value === 'string')
+    .map((value) => value.toLowerCase());
+
+  if (values.some((value) => value.includes('bsc') || value.includes('bnb') || value.startsWith('0x'))) {
+    return 'bsc';
+  }
+  if (values.some((value) => value.includes('tron') || value.startsWith('t'))) {
+    return 'tron';
+  }
+  return 'unknown';
+}
+
+function summarizeCollection(collectionName, docs, totalCount) {
+  const summary = {
+    collection: collectionName,
+    totalCount,
+    sampledCount: docs.length,
+    networks: { bsc: 0, tron: 0, unknown: 0 },
+    fields: {},
+    issues: [],
+  };
+
+  for (const normalizedField of Object.keys(FIELD_CANDIDATES)) {
+    summary.fields[normalizedField] = {
+      present: 0,
+      missing: 0,
+      sourceFields: {},
+    };
+  }
+
+  for (const doc of docs) {
+    const network = detectNetwork(doc);
+    summary.networks[network] += 1;
+
+    for (const [normalizedField, candidates] of Object.entries(FIELD_CANDIDATES)) {
+      const found = firstPresent(doc, candidates);
+      if (found) {
+        summary.fields[normalizedField].present += 1;
+        summary.fields[normalizedField].sourceFields[found.field] =
+          (summary.fields[normalizedField].sourceFields[found.field] || 0) + 1;
+      } else {
+        summary.fields[normalizedField].missing += 1;
+      }
+    }
+  }
+
+  for (const [field, stats] of Object.entries(summary.fields)) {
+    if (docs.length > 0 && stats.present === 0) {
+      summary.issues.push(`missing_all:${field}`);
+    } else if (docs.length > 0 && stats.missing > 0) {
+      summary.issues.push(`missing_partial:${field}:${stats.missing}/${docs.length}`);
+    }
+  }
+
+  if (summary.networks.unknown > 0) {
+    summary.issues.push(`unknown_network:${summary.networks.unknown}/${docs.length}`);
+  }
+
+  return summary;
+}
+
+function printTextReport(report) {
+  console.log(`# NFT data quality audit`);
+  console.log(`Database: ${report.dbName}`);
+  console.log(`Sample limit: ${report.limit}`);
+  console.log(`Generated at: ${report.generatedAt}`);
+  console.log('');
+
+  for (const collection of report.collections) {
+    console.log(`## ${collection.collection}`);
+    console.log(`Total documents: ${collection.totalCount}`);
+    console.log(`Sampled documents: ${collection.sampledCount}`);
+    console.log(`Networks: BSC ${collection.networks.bsc}, Tron ${collection.networks.tron}, unknown ${collection.networks.unknown}`);
+    console.log('');
+    console.log('| Field | Present | Missing | Source fields |');
+    console.log('| --- | ---: | ---: | --- |');
+    for (const [field, stats] of Object.entries(collection.fields)) {
+      const sources = Object.entries(stats.sourceFields)
+        .map(([name, count]) => `${name} (${count})`)
+        .join(', ') || '-';
+      console.log(`| ${field} | ${stats.present} | ${stats.missing} | ${sources} |`);
+    }
+    console.log('');
+    console.log(`Issues: ${collection.issues.length ? collection.issues.join(', ') : 'none'}`);
+    console.log('');
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const url = process.env[REQUIRED_ENV];
+  if (!url) {
+    throw new Error(`${REQUIRED_ENV} is required. Refusing to use hardcoded database URLs.`);
+  }
+
+  const client = new MongoClient(url);
+  await client.connect();
+
+  try {
+    const db = client.db(args.dbName);
+    const collections = [];
+
+    for (const collectionName of args.collections) {
+      const collection = db.collection(collectionName);
+      const totalCount = await collection.countDocuments();
+      const docs = await collection.find({}, { limit: args.limit }).toArray();
+      collections.push(summarizeCollection(collectionName, docs, totalCount));
+    }
+
+    const report = {
+      generatedAt: new Date().toISOString(),
+      dbName: args.dbName,
+      limit: args.limit,
+      collections,
+    };
+
+    if (args.json) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      printTextReport(report);
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(`Audit failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/docs/uki-launch-technical-backlog.md
+++ b/docs/uki-launch-technical-backlog.md
@@ -92,6 +92,7 @@ Entender las BDs actuales de Proxmox y marketplace para no duplicar modelos ni r
 Issues hijas:
 
 - UKI-002.1 Task - Inventariar bases, colecciones y campos NFT
+  - Documento de inventario: `docs/uki-nft-data-inventory.md`.
   - Acceptance criteria:
     - Documento con colecciones relevantes por red.
     - Campos: contract/network, tokenId, owner, rarity, generation, metadata, listing status, bridge status.

--- a/docs/uki-launch-technical-backlog.md
+++ b/docs/uki-launch-technical-backlog.md
@@ -105,6 +105,7 @@ Issues hijas:
     - Informe de campos incompletos o inconsistentes.
 
 - UKI-002.3 Task - Definir adaptador `NftInventoryService`
+  - Especificacion: `docs/uki-nft-inventory-service.md`.
   - Acceptance criteria:
     - API interna propuesta con metodos:
       - `getWalletNfts(wallet)`

--- a/docs/uki-launch-technical-backlog.md
+++ b/docs/uki-launch-technical-backlog.md
@@ -98,6 +98,8 @@ Issues hijas:
     - Campos: contract/network, tokenId, owner, rarity, generation, metadata, listing status, bridge status.
 
 - UKI-002.2 Task - Validar calidad de owner y rareza
+  - Informe/metodo: `docs/uki-nft-data-quality-report.md`.
+  - Script seguro: `dapp/scripts/audit-nft-data-quality.mjs`.
   - Acceptance criteria:
     - Muestreo de NFTs BSC y Tron contra fuente esperada.
     - Informe de campos incompletos o inconsistentes.

--- a/docs/uki-nft-data-inventory.md
+++ b/docs/uki-nft-data-inventory.md
@@ -1,0 +1,162 @@
+# UKI NFT data inventory
+
+Estado: inventario inicial para implementacion.
+Issue: #20 `UKI-002.1`.
+Fecha: 2026-05-12.
+
+## Alcance
+
+Este documento inventaria las bases, colecciones y campos NFT relevantes que deben alimentar `NftInventoryService` sin duplicar el marketplace ni romper bridge/listing existentes.
+
+Fuentes revisadas en el repo:
+
+- `dapp/src/lib/mongodb-cukies.ts`
+- `dapp/src/lib/mongodb-hub.ts`
+- `dapp/src/lib/user-sync.ts`
+- `dapp/scripts/inspect-databases.mjs`
+- `dapp/prisma/schema.prisma`
+- `docs/adr-uki-economic-operations.md`
+
+No se incluyen dumps, valores de documentos ni cadenas de conexion.
+
+## Bases detectadas
+
+| Base | Rol actual | Fuente en repo | Uso para UKI |
+| --- | --- | --- | --- |
+| `cukies` | Base historica/operativa de Cukies World y marketplace. | `dapp/src/lib/mongodb-cukies.ts` | Fuente operativa inicial para NFTs, wallets, owners, transacciones NFT y marketplace. |
+| `cukies-hub` | Base de la dapp actual gestionada por Prisma/Mongo. | `dapp/prisma/schema.prisma`, `dapp/src/lib/mongodb-hub.ts` | Usuarios, sesiones, quests, puntos y futuras materializaciones UKI. No debe duplicar ownership NFT sin razon. |
+
+## Colecciones relevantes en `cukies`
+
+Estas colecciones aparecen como helpers explicitos en `dapp/src/lib/mongodb-cukies.ts`.
+
+| Coleccion | Relevancia NFT | Campos esperados para inventario UKI | Observaciones |
+| --- | --- | --- | --- |
+| `users` | Relaciona usuarios historicos con wallets. | `_id`, `username`, `email`, `name`, `lastName`, `wallets[]` | `user-sync.ts` busca usuarios por ids de `wallets`. No debe ser fuente de ownership NFT. |
+| `wallets` | Mapea wallet address a usuario historico. | `_id`, `address`, posible `network`/tipo si existe | `user-sync.ts` normaliza Tron como `T...` uppercase y EVM/BSC como lowercase. Es clave para owner lookup inicial. |
+| `cukies` | Candidata principal para inventario NFT/personajes. | `_id`, `contract`, `network`, `tokenId`, `owner`, `wallet`, `rarity`, `generation`, `metadata`, `image`, `name`, `attributes` | Debe confirmarse contra datos reales. Si no contiene owner final, se cruza con `wallets` o transacciones. |
+| `originals` | Candidata para NFTs originales / generacion 1. | `_id`, `tokenId`, `owner`, `wallet`, `rarity`, `metadata`, `image`, `name`, `attributes` | Necesaria para distinguir Originales vs 2a Generacion en reglas de pool. |
+| `tx_nfts` | Historial de movimientos NFT. | `_id`, `txHash`, `contract`, `network`, `tokenId`, `from`, `to`, `owner`, `timestamp`, `type`, `status` | Util para reconciliacion y auditoria, no como unica fuente de estado actual si hay coleccion materializada. |
+| `txMarketplace` | Historial/estado de marketplace. | `_id`, `txHash`, `contract`, `network`, `tokenId`, `seller`, `buyer`, `price`, `currency`, `listingStatus`, `status`, `timestamp` | Fuente esperada para `listed` y cambios de listing. Confirmar si contiene estado activo o solo eventos. |
+| `processedEvents` | Control de indexacion/eventos procesados. | `_id`, `eventId`, `txHash`, `logIndex`, `contract`, `network`, `processedAt` | Puede servir como watermark de indexers. No es dominio NFT por si solo. |
+| `completedEvents` | Control de eventos completados. | `_id`, `eventId`, `txHash`, `logIndex`, `contract`, `network`, `completedAt` | Similar a `processedEvents`; util para auditoria operacional. |
+| `settings` | Configuracion historica. | `_id`, keys de config | Puede contener direcciones de contratos o flags de marketplace. No asumir sin inspeccion. |
+| `config` | Configuracion historica. | `_id`, keys de config | Candidata para mapping de contracts/networks si existe. |
+
+Colecciones no NFT directas pero existentes en helpers:
+
+- `points`
+- `tx_points`
+- `referrals`
+- `txLottery`
+
+Estas no alimentan ownership NFT inicial, aunque pueden servir para migraciones o analisis historico de usuario.
+
+## Colecciones relevantes en `cukies-hub`
+
+La dapp actual usa Prisma sobre Mongo. En Prisma, las colecciones suelen mapear al nombre del modelo.
+
+| Coleccion/modelo | Relevancia NFT | Campos actuales relevantes | Observaciones |
+| --- | --- | --- | --- |
+| `User` | Identidad principal de la dapp. | `walletAddress`, `username`, socials, `xp`, timestamps | No tiene inventario NFT. Sera consumidor de `NftInventoryService`. |
+| `GameSession` | Sesiones de juego existentes. | `sessionToken`, `sessionId`, `userId`, `gameId`, `startedAt`, `endedAt`, `isActive` | Futura economia debe usar otro modelo o extender con `GameSessionEconomy`. |
+| `GameResult` | Resultados de juego existentes. | `userId`, `gameId`, `finalScore`, `gameTime`, `metadata`, `isValid`, `xpEarned` | No decide rewards UKI. Puede alimentar migracion/compatibilidad. |
+| `PointTransaction` | Ledger actual de puntos XP/quests. | `userId`, `amount`, `type`, `reason`, `metadata`, `createdAt` | No debe mezclarse con `CompetitionCreditTransaction` futuro. |
+
+No hay modelos actuales para:
+
+- `CukieAsset`
+- `CukieAssetLock`
+- `CukiePoolPosition`
+- `CompetitionCreditAccount`
+- `CompetitionCreditTransaction`
+- `GameRewardPeriod`
+- `RewardAllocation`
+- `RewardClaimBatch`
+
+Estos modelos aparecen como propuesta en `docs/uki-launch-technical-backlog.md` y deben depender del inventario normalizado, no reemplazar el marketplace.
+
+## Campos NFT obligatorios para `NftInventoryService`
+
+Todo asset normalizado debe exponer estos campos aunque algunos se deriven de varias colecciones:
+
+| Campo normalizado | Fuente candidata | Requerido para |
+| --- | --- | --- |
+| `assetId` | Derivado: `network:contract:tokenId` o `_id` estable + mapping | Locks, idempotencia, auditoria. |
+| `network` | `cukies`, `originals`, `tx_nfts`, config | Distinguir BSC/TRON y reglas de uso. |
+| `contractAddress` | `cukies`, `originals`, `tx_nfts`, `txMarketplace`, config | Validacion por contrato y exploradores. |
+| `tokenId` | `cukies`, `originals`, `tx_nfts`, `txMarketplace` | Identidad NFT. |
+| `ownerWallet` | `cukies`, `wallets`, ultimo evento `tx_nfts`, marketplace/indexer | Elegibilidad, cupos y pool. |
+| `rarity` | `cukies`, `originals`, `metadata.attributes` | Puntos NFT y ponderacion rewards. |
+| `generation` | `cukies`, `originals`, metadata/config | Prioridad Originales vs 2a Generacion. |
+| `metadata` | `cukies`, `originals`, metadata embebida | UI, soporte, debug. |
+| `listingStatus` | `txMarketplace` o coleccion de listings si existe | Estado canonico `listed`. |
+| `bridgeStatus` | Marketplace/bridge status si existe en `cukies`, `tx_nfts`, config o coleccion externa | Estado canonico `bridging`. |
+| `imageUrl` | `cukies`, `originals`, metadata | UI. |
+| `name` | `cukies`, `originals`, metadata | UI. |
+| `lastSyncedAt` | `NftInventoryService` | Frescura/consistencia. |
+| `sourceRefs` | Referencias a documentos originales | Auditoria y recuperacion. |
+
+## Mapeo por red
+
+| Red | Deteccion esperada | Normalizacion wallet | Riesgos |
+| --- | --- | --- | --- |
+| BSC | Contract EVM, wallet `0x...`, tx hashes EVM. | Lowercase para comparacion interna. | Chain/indexer puede ir retrasado; confirmar antes de lock economico. |
+| Tron | Wallet `T...`, contratos/ids historicos del marketplace. | Uppercase segun `user-sync.ts`. | Bridge puede mover owner/red; bloquear si `bridgeStatus` no esta final. |
+| Unknown | Falta contract/network o fuente inconsistente. | No normalizar como elegible. | Debe resolverse antes de pool, cupos o partida. |
+
+## Gaps que debe confirmar el muestreo real
+
+El codigo actual enumera colecciones, pero no confirma todos los campos reales. Antes de implementar `NftInventoryService`, el muestreo debe confirmar:
+
+1. Si `cukies` contiene owner actual o solo metadata del personaje.
+2. Si `originals` duplica NFTs de `cukies` o representa otra generacion.
+3. Donde vive el estado activo de listing: `txMarketplace` como eventos o una coleccion materializada.
+4. Donde vive el bridge status real.
+5. Si `contract`/`network` estan en cada NFT o deben derivarse por coleccion.
+6. Si `rarity` y `generation` son campos directos o atributos dentro de `metadata`.
+7. Si hay colecciones no expuestas por `mongodb-cukies.ts` usadas por marketplace/bridge.
+
+## Metodo de inspeccion seguro
+
+No usar scripts que impriman documentos completos en logs compartidos. Para confirmar el inventario:
+
+1. Conectar con variables de entorno, no URLs hardcodeadas.
+2. Listar colecciones y conteos.
+3. Para cada coleccion candidata, extraer solo nombres de campos, tipos y porcentaje aproximado de presencia.
+4. Redactar o truncar wallets, emails, tx hashes y metadata extensa.
+5. Guardar solo el resumen de estructura, nunca muestras completas.
+
+Consulta recomendada por coleccion:
+
+```js
+const docs = await db.collection(name).find({}, { limit: 100 }).toArray();
+const fieldStats = {};
+for (const doc of docs) {
+  for (const [key, value] of Object.entries(doc)) {
+    fieldStats[key] ??= { count: 0, types: new Set() };
+    fieldStats[key].count += 1;
+    fieldStats[key].types.add(Array.isArray(value) ? 'array' : value === null ? 'null' : typeof value);
+  }
+}
+```
+
+El resultado aceptable para Git debe ser una tabla de campos/tipos, no datos.
+
+## Recomendacion para `NftInventoryService`
+
+Crear una capa de lectura normalizada con prioridad:
+
+1. Leer asset candidates desde `cukies` y `originals`.
+2. Enriquecer owner desde `wallets` y/o ultimo movimiento valido en `tx_nfts`.
+3. Enriquecer listing desde `txMarketplace` o coleccion activa de marketplace si existe.
+4. Enriquecer bridge status desde fuente de bridge/marketplace.
+5. Resolver `canonicalState` con `docs/adr-uki-canonical-asset-states.md`.
+6. Exponer assets normalizados sin copiar documentos completos al hub.
+
+## Impacto en issues siguientes
+
+- #21 debe validar calidad real de `owner`, `rarity` y `generation` con muestreo BSC/TRON.
+- #22 debe convertir este inventario en contrato de `NftInventoryService`.
+- #51/#54 deben evitar hardcodear Treasure Hunt y consumir assets normalizados.
+

--- a/docs/uki-nft-data-quality-report.md
+++ b/docs/uki-nft-data-quality-report.md
@@ -1,0 +1,129 @@
+# UKI NFT data quality report
+
+Estado: informe inicial reproducible.
+Issue: #21 `UKI-002.2`.
+Fecha: 2026-05-12.
+
+## Objetivo
+
+Validar que las fuentes NFT actuales tienen datos suficientes para construir `NftInventoryService`, especialmente:
+
+- owner por wallet,
+- red BSC/TRON,
+- `tokenId`,
+- rareza,
+- generacion,
+- metadata,
+- listing status,
+- bridge status.
+
+## Metodo seguro
+
+Se añade `dapp/scripts/audit-nft-data-quality.mjs` para muestrear colecciones sin imprimir documentos completos, wallets, emails, metadata extensa ni cadenas de conexion.
+
+Uso:
+
+```bash
+source ~/.zshrc >/dev/null 2>&1 && \
+CUKIES_DATABASE_URL="$CUKIES_DATABASE_URL" \
+pnpm --dir dapp node scripts/audit-nft-data-quality.mjs \
+  --db cukies \
+  --limit 200 \
+  --collections cukies,originals,tx_nfts,txMarketplace,wallets
+```
+
+Salida esperada:
+
+- conteo total por coleccion,
+- conteo muestreado,
+- clasificacion agregada BSC/TRON/unknown,
+- presencia/ausencia por campo normalizado,
+- campos fuente detectados,
+- issues agregados tipo `missing_all`, `missing_partial`, `unknown_network`.
+
+## Fuentes muestreadas
+
+El muestreo debe cubrir estas colecciones, definidas en `docs/uki-nft-data-inventory.md`:
+
+| Coleccion | Motivo | Campos criticos |
+| --- | --- | --- |
+| `cukies` | Candidata principal para NFT/personaje materializado. | network, contract, tokenId, owner, rarity, generation, metadata. |
+| `originals` | Candidata para generacion original. | tokenId, owner, rarity, generation/coleccion, metadata. |
+| `tx_nfts` | Historial de movimientos NFT. | network, contract, tokenId, from, to/owner, status, timestamp. |
+| `txMarketplace` | Listing/ventas marketplace. | network, contract, tokenId, seller/buyer, listingStatus/status. |
+| `wallets` | Relacion wallet usuario historico. | address, posible network/tipo. |
+
+## Criterios de calidad
+
+| Campo | Calidad minima | Bloquea implementacion si falla |
+| --- | --- | --- |
+| `network` | BSC/TRON identificable o derivable para NFTs elegibles. | Si, para pool/cupos/bridge. |
+| `contractAddress` | Presente o derivable por coleccion/red. | Si, para reconciliacion y exploradores. |
+| `tokenId` | Presente para cada NFT elegible. | Si. |
+| `ownerWallet` | Presente o derivable desde wallet/ultimo evento. | Si, antes de cualquier lock economico. |
+| `rarity` | Presente o derivable desde metadata. | Si, para puntos NFT y rewards ponderadas. |
+| `generation` | Presente o derivable como Original/2a Gen. | Si, para prioridad de pool y reglas de Cukie Master. |
+| `metadata` | Presente para UI o al menos asset lookup. | No bloquea contratos, pero bloquea UX completa. |
+| `listingStatus` | Presente o derivable para detectar `listed`. | Si, antes de pool/staking NFT. |
+| `bridgeStatus` | Presente o derivable para detectar `bridging`. | Si, antes de pool/staking NFT. |
+
+## Resultado inicial desde repo
+
+Sin ejecutar muestreo live, el repo confirma:
+
+- `dapp/src/lib/mongodb-cukies.ts` expone helpers para `cukies`, `originals`, `wallets`, `tx_nfts` y `txMarketplace`.
+- `dapp/src/lib/user-sync.ts` confirma que existen wallets TRON (`T...`) y BSC/EVM (`0x...`) y que la normalizacion difiere por red.
+- `dapp/scripts/inspect-databases.mjs` demuestra que ya existia una inspeccion manual de bases, pero imprime muestras de documentos; no debe usarse para reportes compartidos sin sanitizar.
+- `cukies-hub` no contiene modelos NFT actuales en Prisma; los nuevos modelos deben depender de una capa normalizada y no copiar ownership completo sin motivo.
+
+## Riesgos detectados antes del muestreo live
+
+1. `owner` puede no vivir directamente en `cukies`/`originals`; puede requerir cruce con `wallets` o ultimo evento `tx_nfts`.
+2. `txMarketplace` puede ser historial de eventos y no estado activo materializado.
+3. `bridgeStatus` no aparece como helper explicito; puede vivir en una coleccion no expuesta o dentro de metadata/status.
+4. `rarity` y `generation` pueden estar anidados en metadata/attributes con nombres no uniformes.
+5. La deteccion de red puede estar implícita por address (`0x...`/`T...`) o por coleccion, no como campo directo.
+
+## Como interpretar el muestreo
+
+Si el script devuelve:
+
+- `missing_all:owner` en `cukies` y `originals`: usar `tx_nfts` o `wallets` como owner source y documentar precedencia en #22.
+- `missing_all:rarity`: buscar rareza dentro de `metadata.attributes` o fuente externa antes de Cukie Master.
+- `missing_all:generation`: derivar generacion por coleccion (`originals`) o mapping de contratos.
+- `missing_all:listingStatus`: confirmar si hay coleccion de listings activa fuera de helpers.
+- `missing_all:bridgeStatus`: confirmar fuente del bridge antes de permitir pool/staking NFT.
+- `unknown_network` alto: no habilitar acciones economicas hasta definir mapping contract/red.
+
+## Salida requerida para cerrar muestreo live
+
+Cuando haya acceso controlado a Mongo, pegar en el issue o PR solo tablas agregadas como:
+
+```text
+Collection: cukies
+Sampled: 200
+Networks: BSC 120, Tron 74, unknown 6
+owner: present 198 / missing 2
+rarity: present 200 / missing 0
+generation: present 185 / missing 15
+listingStatus: present 0 / missing 200
+bridgeStatus: present 0 / missing 200
+Issues: missing_all:listingStatus, missing_all:bridgeStatus, unknown_network:6/200
+```
+
+No publicar:
+
+- wallets completas,
+- emails,
+- nombres de usuarios,
+- metadata completa,
+- tx hashes completos,
+- cadenas de conexion,
+- documentos JSON sin redaccion.
+
+## Decision para siguientes issues
+
+- #22 debe diseñar `NftInventoryService` asumiendo que owner/listing/bridge pueden venir de varias colecciones.
+- #21 queda listo para cerrarse cuando el muestreo live sanitizado confirme porcentajes reales o documente que el acceso a Mongo queda pendiente de ops.
+- Si el muestreo descubre colecciones no inventariadas, actualizar `docs/uki-nft-data-inventory.md` antes de implementar.
+

--- a/docs/uki-nft-inventory-service.md
+++ b/docs/uki-nft-inventory-service.md
@@ -1,0 +1,388 @@
+# UKI NftInventoryService specification
+
+Estado: especificacion inicial.
+Issue: #22 `UKI-002.3`.
+Fecha: 2026-05-12.
+
+## Objetivo
+
+`NftInventoryService` es la capa estable entre las bases existentes de Cukies/marketplace y la nueva economia UKI. Su responsabilidad es devolver NFTs normalizados, validar ownership, resolver estado canonico y proteger acciones economicas contra doble uso.
+
+No debe duplicar el marketplace ni custodiar NFTs. Debe leer fuentes existentes, normalizarlas y aplicar reglas de consistencia/locks.
+
+## Fuentes
+
+La implementacion debe usar como base:
+
+- `docs/uki-nft-data-inventory.md`
+- `docs/uki-nft-data-quality-report.md`
+- `docs/adr-uki-economic-operations.md`
+- `docs/adr-uki-canonical-asset-states.md`
+- `docs/adr-uki-consistency-policy.md`
+
+## Responsabilidades
+
+El servicio debe:
+
+- normalizar NFTs BSC/TRON,
+- exponer owner, rareza, generacion, metadata minima y estado canonico,
+- validar ownership antes de locks o acciones economicas,
+- detectar listing/bridge/locks incompatibles,
+- crear y liberar locks atomicos,
+- proteger pool, Cukie Master y game sessions frente a doble uso,
+- exponer timestamps/freshness para UI y jobs,
+- producir logs auditables para cambios de estado y locks.
+
+El servicio no debe:
+
+- calcular rewards,
+- calcular ranking,
+- mover UKI,
+- ejecutar compras/claims,
+- decidir tokenomics,
+- confiar en datos enviados por cliente.
+
+## Tipos normalizados
+
+```ts
+type ChainNetwork = 'bsc' | 'tron' | 'unknown';
+
+type CukieAssetState =
+  | 'available'
+  | 'listed'
+  | 'bridging'
+  | 'soft_staked'
+  | 'in_pool'
+  | 'assigned_to_game'
+  | 'invalidated'
+  | 'unknown';
+
+type CukieGeneration = 'original' | 'second_generation' | 'unknown';
+
+type CukieRarity =
+  | 'common'
+  | 'uncommon'
+  | 'rare'
+  | 'epic'
+  | 'legendary'
+  | 'goat'
+  | 'unknown';
+
+type CukieAsset = {
+  assetId: string;
+  network: ChainNetwork;
+  contractAddress: string | null;
+  tokenId: string | null;
+  ownerWallet: string | null;
+  rarity: CukieRarity;
+  generation: CukieGeneration;
+  canonicalState: CukieAssetState;
+  stateReason: string | null;
+  imageUrl: string | null;
+  name: string | null;
+  metadata: Record<string, unknown> | null;
+  listingStatus: string | null;
+  bridgeStatus: string | null;
+  sourceRefs: SourceRef[];
+  freshness: DataFreshness;
+};
+
+type SourceRef = {
+  source: 'cukies' | 'originals' | 'wallets' | 'tx_nfts' | 'txMarketplace' | 'indexer' | 'manual';
+  collection?: string;
+  documentId?: string;
+  observedAt: string;
+};
+
+type DataFreshness = {
+  lastSyncedAt: string | null;
+  ownerCheckedAt: string | null;
+  marketplaceCheckedAt: string | null;
+  bridgeCheckedAt: string | null;
+  isStale: boolean;
+  staleReasons: string[];
+};
+```
+
+## API propuesta
+
+### `getWalletNfts(wallet)`
+
+Devuelve todos los NFTs conocidos para una wallet, sin filtrar por uso.
+
+```ts
+type GetWalletNftsInput = {
+  wallet: string;
+  includeStale?: boolean;
+  includeInvalidated?: boolean;
+};
+
+type GetWalletNftsResult = {
+  wallet: string;
+  normalizedWallet: string;
+  assets: CukieAsset[];
+  warnings: InventoryWarning[];
+};
+```
+
+Reglas:
+
+- Normalizar wallet: BSC lowercase, Tron uppercase.
+- Incluir assets `listed`, `bridging`, `unknown` e `invalidated` salvo que se filtren explicitamente.
+- No habilitar acciones solo por aparecer en esta respuesta.
+- Incluir warnings si la fuente esta stale o incompleta.
+
+### `getPlayableCukies(wallet)`
+
+Devuelve NFTs que pueden usarse en flujo de juego propio.
+
+```ts
+type GetPlayableCukiesInput = {
+  wallet: string;
+  gameId?: string;
+  requireFreshOwnership?: boolean;
+};
+
+type GetPlayableCukiesResult = {
+  wallet: string;
+  assets: CukieAsset[];
+  rejected: RejectedAsset[];
+};
+```
+
+Reglas:
+
+- Permitidos inicialmente: `available`.
+- Excluir `listed`, `bridging`, `in_pool`, `assigned_to_game`, `invalidated`, `unknown`.
+- Revalidar owner/listing/bridge si `requireFreshOwnership` es true.
+- No asignar locks; solo lectura filtrada.
+
+### `getPoolEligibleCukies(wallet)`
+
+Devuelve NFTs que pueden aportarse al pool de Cukies.
+
+```ts
+type GetPoolEligibleCukiesInput = {
+  wallet: string;
+  poolId?: string;
+  requireFreshOwnership?: boolean;
+};
+
+type GetPoolEligibleCukiesResult = {
+  wallet: string;
+  assets: CukieAsset[];
+  rejected: RejectedAsset[];
+};
+```
+
+Reglas:
+
+- Permitidos: `available`.
+- Requerir `ownerWallet`, `network`, `tokenId`, `rarity` y `generation` resueltos.
+- Excluir cualquier asset con listing/bridge/lock activo.
+- Si `generation` o `rarity` es `unknown`, rechazar con motivo recuperable.
+
+### `lockCukie(assetId, reason)`
+
+Crea un lock atomico para uso economico.
+
+```ts
+type CukieLockReason =
+  | 'pool_deposit'
+  | 'game_assignment'
+  | 'soft_stake'
+  | 'ops_hold'
+  | 'reconciliation';
+
+type LockCukieInput = {
+  assetId: string;
+  reason: CukieLockReason;
+  wallet?: string;
+  sessionId?: string;
+  poolId?: string;
+  ttlSeconds?: number;
+  idempotencyKey: string;
+};
+
+type LockCukieResult = {
+  lockId: string;
+  asset: CukieAsset;
+  previousState: CukieAssetState;
+  nextState: CukieAssetState;
+  expiresAt: string | null;
+};
+```
+
+Reglas:
+
+- Debe ser atomico por `assetId`.
+- Debe revalidar estado antes de crear lock.
+- Debe rechazar si existe lock incompatible activo.
+- Debe guardar `previousState` para desbloqueos temporales.
+- Debe ser idempotente por `idempotencyKey`.
+
+Mapeo de estado:
+
+| Reason | Estado resultante |
+| --- | --- |
+| `pool_deposit` | `in_pool` |
+| `game_assignment` | `assigned_to_game` |
+| `soft_stake` | `soft_staked` |
+| `ops_hold` | `invalidated` o `unknown` segun causa |
+| `reconciliation` | `unknown` |
+
+### `unlockCukie(assetId, reason)`
+
+Libera un lock activo.
+
+```ts
+type UnlockCukieInput = {
+  assetId: string;
+  lockId?: string;
+  reason: 'pool_withdraw' | 'game_finished' | 'game_expired' | 'ops_release' | 'reconciliation_resolved';
+  idempotencyKey: string;
+};
+
+type UnlockCukieResult = {
+  asset: CukieAsset;
+  releasedLockIds: string[];
+  previousState: CukieAssetState;
+  nextState: CukieAssetState;
+};
+```
+
+Reglas:
+
+- Debe liberar solo locks compatibles con el motivo.
+- Debe recalcular estado canonico tras liberar.
+- Si hay listing/bridge/owner conflict al liberar, no volver a `available`; usar precedencia canonica.
+- Debe ser idempotente.
+
+### `validateOwnership(assetId, wallet)`
+
+Comprueba si una wallet puede actuar sobre un asset.
+
+```ts
+type ValidateOwnershipInput = {
+  assetId: string;
+  wallet: string;
+  requireFresh?: boolean;
+  action?: 'play' | 'pool_deposit' | 'pool_withdraw' | 'soft_stake' | 'list' | 'admin_review';
+};
+
+type ValidateOwnershipResult = {
+  isOwner: boolean;
+  normalizedWallet: string;
+  ownerWallet: string | null;
+  asset: CukieAsset;
+  freshness: DataFreshness;
+  blockers: InventoryBlocker[];
+};
+```
+
+Reglas:
+
+- Debe comparar wallets normalizadas por red.
+- Si `requireFresh` y la fuente esta stale, devolver blocker `stale_ownership`.
+- Si `canonicalState` bloquea la accion, devolver blocker de estado.
+- No debe crear locks.
+
+## Errores y blockers
+
+```ts
+type InventoryBlocker =
+  | 'asset_not_found'
+  | 'owner_mismatch'
+  | 'unknown_owner'
+  | 'unknown_network'
+  | 'missing_token_id'
+  | 'missing_rarity'
+  | 'missing_generation'
+  | 'listed'
+  | 'bridging'
+  | 'already_locked'
+  | 'assigned_to_game'
+  | 'invalidated'
+  | 'unknown_state'
+  | 'stale_ownership'
+  | 'stale_marketplace'
+  | 'stale_bridge'
+  | 'ops_blocked';
+```
+
+Los blockers deben ser legibles por UI y jobs. No devolver solo `false` sin motivo.
+
+## Locks y auditoria
+
+Cada lock debe guardar:
+
+- `lockId`
+- `assetId`
+- `reason`
+- `wallet`
+- `sessionId`
+- `poolId`
+- `previousState`
+- `nextState`
+- `idempotencyKey`
+- `createdAt`
+- `expiresAt`
+- `releasedAt`
+- `releasedReason`
+- `createdBy`
+
+Cada cambio de estado debe registrar:
+
+- `assetId`
+- `previousState`
+- `nextState`
+- `reason`
+- `source`
+- `evidenceRefs`
+- `jobRunId`
+- `createdAt`
+
+## Resolucion de fuentes
+
+Orden inicial de resolucion:
+
+1. Asset candidates desde `cukies` y `originals`.
+2. Identity fields: `network`, `contractAddress`, `tokenId`.
+3. Owner desde campo directo si existe; si no, `wallets` o ultimo movimiento valido `tx_nfts`.
+4. Rarity/generation desde campos directos; si no, metadata/attributes o mapping de coleccion.
+5. Listing desde `txMarketplace` o fuente activa de marketplace si se detecta.
+6. Bridge desde campo/fuente de bridge si se detecta.
+7. Locks internos de la nueva dapp.
+8. Resolucion de `canonicalState`.
+
+Si una fuente necesaria no existe, el servicio debe devolver blocker y no inventar elegibilidad.
+
+## Semantica de consistencia
+
+Antes de acciones economicas:
+
+- `lockCukie`: requiere datos frescos de owner/listing/bridge segun `docs/adr-uki-consistency-policy.md`.
+- `validateOwnership(requireFresh: true)`: debe bloquear si no puede revalidar.
+- `getWalletNfts`: puede devolver datos stale con warnings.
+- `getPlayableCukies` y `getPoolEligibleCukies`: por defecto no deben incluir stale/unknown.
+
+## Uso por modulo
+
+| Consumidor | Metodos |
+| --- | --- |
+| Dashboard wallet | `getWalletNfts` |
+| Cukie Master ruta NFT | `getWalletNfts`, `validateOwnership` |
+| Pool de Cukies | `getPoolEligibleCukies`, `lockCukie`, `unlockCukie` |
+| Game economy session | `getPlayableCukies`, `lockCukie`, `unlockCukie` |
+| Reconciliacion | `validateOwnership`, `unlockCukie`, locks `reconciliation` |
+| Admin/Ops | `getWalletNfts`, audit logs, blockers |
+
+## Criterios para implementacion posterior
+
+- No crear una dependencia directa desde UI a colecciones historicas.
+- No devolver documentos Mongo originales al cliente.
+- No permitir acciones economicas con `unknown`, `invalidated`, `bridging` o `listed`.
+- No permitir dos locks activos incompatibles sobre el mismo asset.
+- No hardcodear Treasure Hunt dentro del servicio.
+- Exponer errores recuperables para UI y jobs.
+


### PR DESCRIPTION
Closes #22\n\nDepends on #153.\n\n## Summary\n- Add a specification for the internal `NftInventoryService` adapter.\n- Define normalized asset types, canonical states, freshness, source refs, blockers, locks and audit requirements.\n- Specify required methods: `getWalletNfts`, `getPlayableCukies`, `getPoolEligibleCukies`, `lockCukie`, `unlockCukie`, `validateOwnership`.\n- Link the specification from the technical backlog.\n\n## Validation\n- `rg -n 'getWalletNfts|getPlayableCukies|getPoolEligibleCukies|lockCukie|unlockCukie|validateOwnership|CukieAsset|canonicalState|InventoryBlocker|idempotencyKey|pool|game_assignment|owner|rarity|generation' docs/uki-nft-inventory-service.md` OK\n- `git diff --check` OK\n\n## Risks / Follow-ups\n- Documentation/specification only; no runtime implementation yet.\n- This branch is stacked on #153 because it depends on the NFT data inventory and quality-audit docs.\n- Implementation should avoid returning raw Mongo documents or hardcoding Treasure Hunt inside the service.