### PR TITLE
feat: add vesting management flow

### DIFF
--- a/dapp/src/app/vesting/page.tsx
+++ b/dapp/src/app/vesting/page.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { formatUnits, isAddress, keccak256, parseUnits, toBytes } from 'viem';
+import { useAccount, useReadContract, useWriteContract } from 'wagmi';
+import { CalendarClock, CheckCircle2, LockKeyhole, Plus, ShieldCheck, Wallet } from 'lucide-react';
+
+import AppLayout from '@/components/layout/app-layout';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ukiSaleContracts, vestingVaultAbi } from '@/lib/contracts/uki-sale';
+
+type Schedule = readonly [bigint, bigint, bigint, bigint, bigint];
+
+const scheduleRows = [
+  { id: 'PRESALE', label: 'Presale', allocation: 'Buyer allocations', status: 'Live claim flow' },
+  { id: 'TEAM', label: 'Team', allocation: 'Core contributors', status: 'Cliff required' },
+  { id: 'ADVISORS', label: 'Advisors', allocation: 'Advisory grants', status: 'Cliff required' },
+  { id: 'ECOSYSTEM', label: 'Ecosystem', allocation: 'Rewards and growth', status: 'Managed' },
+];
+
+function formatToken(value?: bigint) {
+  if (value === undefined) return '0';
+  return Number(formatUnits(value, 18)).toLocaleString('en-US', {
+    maximumFractionDigits: 2,
+  });
+}
+
+function formatDate(timestamp?: bigint) {
+  if (!timestamp || timestamp === BigInt(0)) return '-';
+  return new Date(Number(timestamp) * 1000).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function daysFromNow(days: number) {
+  return Math.floor(Date.now() / 1000) + days * 24 * 60 * 60;
+}
+
+export default function VestingPage() {
+  const { address, isConnected } = useAccount();
+  const { writeContract, isPending } = useWriteContract();
+  const vaultAddress = ukiSaleContracts.vestingVaultAddress;
+  const isConfigured = Boolean(vaultAddress && isAddress(vaultAddress));
+  const contractAddress = isConfigured ? vaultAddress as `0x${string}` : undefined;
+  const accountAddress = address as `0x${string}` | undefined;
+  const [beneficiary, setBeneficiary] = useState('');
+  const [amount, setAmount] = useState('100000');
+  const [scheduleId, setScheduleId] = useState('TEAM');
+  const [startDays, setStartDays] = useState('365');
+  const [cliffDays, setCliffDays] = useState('365');
+  const [durationDays, setDurationDays] = useState('730');
+
+  const { data: totalAllocated } = useReadContract({
+    address: contractAddress,
+    abi: vestingVaultAbi,
+    functionName: 'totalAllocated',
+    query: { enabled: isConfigured },
+  });
+  const { data: totalReleased } = useReadContract({
+    address: contractAddress,
+    abi: vestingVaultAbi,
+    functionName: 'totalReleased',
+    query: { enabled: isConfigured },
+  });
+  const { data: unallocated } = useReadContract({
+    address: contractAddress,
+    abi: vestingVaultAbi,
+    functionName: 'unallocatedBalance',
+    query: { enabled: isConfigured },
+  });
+  const { data: userSchedule } = useReadContract({
+    address: contractAddress,
+    abi: vestingVaultAbi,
+    functionName: 'scheduleOf',
+    args: accountAddress ? [accountAddress] : undefined,
+    query: { enabled: isConfigured && Boolean(accountAddress) },
+  });
+  const { data: claimable } = useReadContract({
+    address: contractAddress,
+    abi: vestingVaultAbi,
+    functionName: 'releasable',
+    args: accountAddress ? [accountAddress] : undefined,
+    query: { enabled: isConfigured && Boolean(accountAddress) },
+  });
+
+  const schedule = userSchedule as Schedule | undefined;
+  const totalAmount = schedule?.[0] ?? BigInt(0);
+  const releasedAmount = schedule?.[1] ?? BigInt(0);
+  const lockedAmount = totalAmount > releasedAmount ? totalAmount - releasedAmount : BigInt(0);
+  const progress = totalAmount > BigInt(0) ? Number((releasedAmount * BigInt(10000)) / totalAmount) / 100 : 0;
+
+  const metrics = useMemo(() => [
+    { label: 'Total allocated', value: `${formatToken(totalAllocated)} UKI`, icon: ShieldCheck },
+    { label: 'Claimable now', value: `${formatToken(claimable)} UKI`, icon: Wallet },
+    { label: 'Released', value: `${formatToken(totalReleased)} UKI`, icon: CheckCircle2 },
+    { label: 'Unallocated', value: `${formatToken(unallocated)} UKI`, icon: LockKeyhole },
+  ], [claimable, totalAllocated, totalReleased, unallocated]);
+
+  function claimAll() {
+    if (!contractAddress) return;
+    writeContract({
+      address: contractAddress,
+      abi: vestingVaultAbi,
+      functionName: 'releaseAll',
+    });
+  }
+
+  function createVesting() {
+    if (!contractAddress || !isAddress(beneficiary)) return;
+    const start = BigInt(daysFromNow(Number(startDays)));
+    const cliff = BigInt(daysFromNow(Number(cliffDays)));
+    const duration = BigInt(Number(durationDays) * 24 * 60 * 60);
+
+    writeContract({
+      address: contractAddress,
+      abi: vestingVaultAbi,
+      functionName: 'createVestingWithCliff',
+      args: [
+        beneficiary,
+        keccak256(toBytes(scheduleId)),
+        parseUnits(amount || '0', 18),
+        start,
+        cliff,
+        duration,
+      ],
+    });
+  }
+
+  return (
+    <AppLayout>
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-teal-300/25 bg-teal-300/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-teal-200">
+              <LockKeyhole className="h-3.5 w-3.5" />
+              UKI token operations
+            </div>
+            <h1 className="font-headline text-4xl font-bold text-white md:text-5xl">UKI Vesting</h1>
+            <p className="mt-2 max-w-2xl text-sm text-slate-300">
+              Claim vested UKI, monitor locked allocations and create cliff-based schedules for team, advisors and ecosystem buckets.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs font-semibold">
+            <span className="rounded-full border border-teal-300/25 bg-teal-300/10 px-3 py-2 text-teal-100">
+              Chain {ukiSaleContracts.chainId}
+            </span>
+            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-slate-200">
+              Vault {isConfigured ? 'configured' : 'pending'}
+            </span>
+            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-slate-200">
+              Presale {ukiSaleContracts.presaleAddress ? 'linked' : 'pending'}
+            </span>
+          </div>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          {metrics.map((metric) => (
+            <div key={metric.label} className="rounded-lg border border-white/10 bg-[#172522]/85 p-4 shadow-lg shadow-black/20">
+              <div className="flex items-center justify-between">
+                <span className="text-xs uppercase tracking-[0.14em] text-slate-400">{metric.label}</span>
+                <metric.icon className="h-4 w-4 text-[#44edd6]" />
+              </div>
+              <div className="mt-3 text-2xl font-bold text-white">{metric.value}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[1.4fr_0.9fr]">
+          <section className="rounded-lg border border-white/10 bg-[#101b19]/90 p-5 shadow-xl shadow-black/25">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <h2 className="font-headline text-2xl font-semibold text-white">My vesting position</h2>
+                <p className="mt-1 text-sm text-slate-400">
+                  {isConnected ? address : 'Connect a wallet to read your live schedule.'}
+                </p>
+              </div>
+              <Button
+                onClick={claimAll}
+                disabled={!isConfigured || !isConnected || isPending || !claimable || claimable === BigInt(0)}
+                className="bg-[#008080] text-white hover:bg-[#009999]"
+              >
+                Claim UKI
+              </Button>
+            </div>
+
+            <div className="mt-6 grid gap-5 lg:grid-cols-[220px_1fr]">
+              <div className="flex aspect-square items-center justify-center rounded-lg border border-teal-300/20 bg-teal-300/5">
+                <div className="text-center">
+                  <div className="text-5xl font-bold text-[#44edd6]">{progress}%</div>
+                  <div className="mt-2 text-xs uppercase tracking-[0.16em] text-slate-400">released</div>
+                </div>
+              </div>
+              <div className="flex flex-col justify-center gap-5">
+                <div className="h-3 overflow-hidden rounded-full bg-white/10">
+                  <div className="h-full rounded-full bg-[#44edd6]" style={{ width: `${Math.min(progress, 100)}%` }} />
+                </div>
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <div>
+                    <div className="text-xs text-slate-400">Allocated</div>
+                    <div className="mt-1 text-lg font-semibold text-white">{formatToken(totalAmount)} UKI</div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-slate-400">Locked</div>
+                    <div className="mt-1 text-lg font-semibold text-white">{formatToken(lockedAmount)} UKI</div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-slate-400">Cliff</div>
+                    <div className="mt-1 text-lg font-semibold text-white">{formatDate(schedule?.[3])}</div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 rounded-lg border border-amber-300/20 bg-amber-300/10 px-3 py-2 text-sm text-amber-100">
+                  <CalendarClock className="h-4 w-4" />
+                  Next vesting end: {formatDate(schedule ? schedule[2] + schedule[4] : undefined)}
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <aside className="rounded-lg border border-white/10 bg-[#172522]/90 p-5 shadow-xl shadow-black/25">
+            <h2 className="font-headline text-xl font-semibold text-white">Allocation tools</h2>
+            <div className="mt-4 grid gap-3">
+              <Input placeholder="Beneficiary 0x..." value={beneficiary} onChange={(event) => setBeneficiary(event.target.value)} />
+              <div className="grid grid-cols-2 gap-3">
+                <Input placeholder="Schedule" value={scheduleId} onChange={(event) => setScheduleId(event.target.value.toUpperCase())} />
+                <Input placeholder="Amount UKI" value={amount} onChange={(event) => setAmount(event.target.value)} />
+              </div>
+              <div className="grid grid-cols-3 gap-3">
+                <Input placeholder="Start days" value={startDays} onChange={(event) => setStartDays(event.target.value)} />
+                <Input placeholder="Cliff days" value={cliffDays} onChange={(event) => setCliffDays(event.target.value)} />
+                <Input placeholder="Duration days" value={durationDays} onChange={(event) => setDurationDays(event.target.value)} />
+              </div>
+              <Button onClick={createVesting} disabled={!isConfigured || !isAddress(beneficiary) || isPending} className="mt-1 bg-white text-[#172522] hover:bg-slate-200">
+                <Plus className="mr-2 h-4 w-4" />
+                Create vesting
+              </Button>
+            </div>
+          </aside>
+        </div>
+
+        <section className="overflow-hidden rounded-lg border border-white/10 bg-[#101b19]/90 shadow-xl shadow-black/25">
+          <div className="flex items-center justify-between border-b border-white/10 px-5 py-4">
+            <h2 className="font-headline text-xl font-semibold text-white">Vesting schedules</h2>
+            <span className="text-xs uppercase tracking-[0.16em] text-slate-400">operational buckets</span>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[760px] text-left text-sm">
+              <thead className="bg-white/[0.03] text-xs uppercase tracking-[0.14em] text-slate-400">
+                <tr>
+                  <th className="px-5 py-3">Schedule</th>
+                  <th className="px-5 py-3">Allocation</th>
+                  <th className="px-5 py-3">Released</th>
+                  <th className="px-5 py-3">Claimable</th>
+                  <th className="px-5 py-3">Start</th>
+                  <th className="px-5 py-3">Cliff</th>
+                  <th className="px-5 py-3">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10 text-slate-200">
+                {scheduleRows.map((row, index) => (
+                  <tr key={row.id} className="hover:bg-white/[0.03]">
+                    <td className="px-5 py-4 font-semibold text-white">{row.label}</td>
+                    <td className="px-5 py-4">{index === 0 ? formatToken(totalAmount) : row.allocation}</td>
+                    <td className="px-5 py-4">{index === 0 ? `${formatToken(releasedAmount)} UKI` : '-'}</td>
+                    <td className="px-5 py-4">{index === 0 ? `${formatToken(claimable)} UKI` : '-'}</td>
+                    <td className="px-5 py-4">{index === 0 ? formatDate(schedule?.[2]) : 'Configured by admin'}</td>
+                    <td className="px-5 py-4">{index === 0 ? formatDate(schedule?.[3]) : 'Required'}</td>
+                    <td className="px-5 py-4">
+                      <span className="rounded-full border border-teal-300/20 bg-teal-300/10 px-2.5 py-1 text-xs font-semibold text-teal-100">
+                        {row.status}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </AppLayout>
+  );
+}

--- a/dapp/src/components/layout/app-layout.tsx
+++ b/dapp/src/components/layout/app-layout.tsx
@@ -21,6 +21,7 @@ import {
   Users,
   Coins,
   Send,
+  LockKeyhole,
 } from 'lucide-react';
 import Logo from '@/components/icons/logo';
 import Header from './header';
@@ -153,6 +154,22 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
                         <Coins className="h-4 w-4 text-amber-400 group-hover:text-yellow-400 transition-colors" />
                       </div>
                       <span className="group-data-[collapsible=icon]:hidden font-medium">Points</span>
+                    </div>
+                  </SidebarMenuButton>
+                </Link>
+              </SidebarMenuItem>
+
+              <SidebarMenuItem>
+                <Link href="/vesting" passHref>
+                  <SidebarMenuButton
+                    isActive={pathname.startsWith('/vesting')}
+                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-pink-600/10 hover:to-pink-600/10 hover:border-pink-500/30 hover:shadow-md hover:shadow-pink-600/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-pink-600/20 data-[active=true]:to-pink-600/20 data-[active=true]:border-pink-500/50"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-teal-400/20 to-cyan-500/20 group-hover:from-teal-400/30 group-hover:to-cyan-500/30 transition-all">
+                        <LockKeyhole className="h-4 w-4 text-teal-300 group-hover:text-cyan-300 transition-colors" />
+                      </div>
+                      <span className="group-data-[collapsible=icon]:hidden font-medium">Vesting</span>
                     </div>
                   </SidebarMenuButton>
                 </Link>

--- a/dapp/src/lib/contracts/abis/VestingVault.json
+++ b/dapp/src/lib/contracts/abis/VestingVault.json
@@ -58,6 +58,11 @@
   },
   {
     "inputs": [],
+    "name": "InvalidRecipient",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "InvalidSchedule",
     "type": "error"
   },
@@ -167,6 +172,12 @@
         "type": "address"
       },
       {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "scheduleId",
+        "type": "bytes32"
+      },
+      {
         "indexed": false,
         "internalType": "uint256",
         "name": "amount",
@@ -182,8 +193,33 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnallocatedWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "beneficiary",
         "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "scheduleId",
+        "type": "bytes32"
       },
       {
         "indexed": false,
@@ -200,6 +236,12 @@
       {
         "indexed": false,
         "internalType": "uint64",
+        "name": "cliff",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
         "name": "duration",
         "type": "uint64"
       }
@@ -210,6 +252,19 @@
   {
     "inputs": [],
     "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PRESALE_SCHEDULE_ID",
     "outputs": [
       {
         "internalType": "bytes32",
@@ -257,6 +312,44 @@
       }
     ],
     "name": "createVesting",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "beneficiary",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "scheduleId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "start",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "cliff",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "duration",
+        "type": "uint64"
+      }
+    ],
+    "name": "createVestingWithCliff",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -342,12 +435,68 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "beneficiary",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "scheduleId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "releasable",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "scheduleId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "release",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "release",
     "outputs": [
       {
         "internalType": "uint256",
         "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "releaseAll",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "totalAmount",
         "type": "uint256"
       }
     ],
@@ -398,6 +547,25 @@
         "type": "address"
       }
     ],
+    "name": "scheduleIdsOf",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "beneficiary",
+        "type": "address"
+      }
+    ],
     "name": "scheduleOf",
     "outputs": [
       {
@@ -415,6 +583,62 @@
           {
             "internalType": "uint64",
             "name": "start",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "cliff",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "duration",
+            "type": "uint64"
+          }
+        ],
+        "internalType": "struct VestingVault.VestingSchedule",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "beneficiary",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "scheduleId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "scheduleOf",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint128",
+            "name": "totalAmount",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "releasedAmount",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint64",
+            "name": "start",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "cliff",
             "type": "uint64"
           },
           {
@@ -490,6 +714,48 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "unallocatedBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "beneficiary",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "scheduleId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "timestamp",
+        "type": "uint64"
+      }
+    ],
+    "name": "vestedAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -511,6 +777,24 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawUnallocated",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   }
 ]

--- a/dapp/src/lib/contracts/uki-sale.ts
+++ b/dapp/src/lib/contracts/uki-sale.ts
@@ -177,6 +177,91 @@ export const erc20Abi = [
   },
 ] as const;
 
+export const vestingVaultAbi = [
+  {
+    type: 'function',
+    name: 'PRESALE_SCHEDULE_ID',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'bytes32' }],
+  },
+  {
+    type: 'function',
+    name: 'totalAllocated',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'totalReleased',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'unallocatedBalance',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'scheduleOf',
+    stateMutability: 'view',
+    inputs: [{ name: 'beneficiary', type: 'address' }],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        components: [
+          { name: 'totalAmount', type: 'uint128' },
+          { name: 'releasedAmount', type: 'uint128' },
+          { name: 'start', type: 'uint64' },
+          { name: 'cliff', type: 'uint64' },
+          { name: 'duration', type: 'uint64' },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'function',
+    name: 'releasable',
+    stateMutability: 'view',
+    inputs: [{ name: 'beneficiary', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'release',
+    stateMutability: 'nonpayable',
+    inputs: [],
+    outputs: [{ name: 'amount', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'releaseAll',
+    stateMutability: 'nonpayable',
+    inputs: [],
+    outputs: [{ name: 'totalAmount', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'createVestingWithCliff',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'beneficiary', type: 'address' },
+      { name: 'scheduleId', type: 'bytes32' },
+      { name: 'amount', type: 'uint256' },
+      { name: 'start', type: 'uint64' },
+      { name: 'cliff', type: 'uint64' },
+      { name: 'duration', type: 'uint64' },
+    ],
+    outputs: [],
+  },
+] as const;
+
 const envSchema = z.object({
   NEXT_PUBLIC_UKI_CHAIN_ID: z.coerce.number().default(56),
   NEXT_PUBLIC_ASM_TOKEN_ADDRESS: z.string().optional(),

--- a/packages/contracts/contracts/VestingVault.sol
+++ b/packages/contracts/contracts/VestingVault.sol
@@ -11,6 +11,7 @@ contract VestingVault is AccessControl {
     using SafeERC20 for IERC20;
 
     bytes32 public constant VESTING_MANAGER_ROLE = keccak256("VESTING_MANAGER_ROLE");
+    bytes32 public constant PRESALE_SCHEDULE_ID = keccak256("PRESALE");
 
     IERC20 public immutable ukiToken;
 
@@ -18,20 +19,31 @@ contract VestingVault is AccessControl {
         uint128 totalAmount;
         uint128 releasedAmount;
         uint64 start;
+        uint64 cliff;
         uint64 duration;
     }
 
-    mapping(address beneficiary => VestingSchedule) private _schedules;
+    mapping(address beneficiary => mapping(bytes32 scheduleId => VestingSchedule)) private _schedules;
+    mapping(address beneficiary => bytes32[] scheduleIds) private _scheduleIds;
     uint256 public totalAllocated;
     uint256 public totalReleased;
 
-    event VestingCreated(address indexed beneficiary, uint256 amount, uint64 start, uint64 duration);
-    event TokensReleased(address indexed beneficiary, uint256 amount);
+    event VestingCreated(
+        address indexed beneficiary,
+        bytes32 indexed scheduleId,
+        uint256 amount,
+        uint64 start,
+        uint64 cliff,
+        uint64 duration
+    );
+    event TokensReleased(address indexed beneficiary, bytes32 indexed scheduleId, uint256 amount);
+    event UnallocatedWithdrawn(address indexed to, uint256 amount);
 
     error InvalidToken();
     error InvalidBeneficiary();
     error InvalidAmount();
     error InvalidSchedule();
+    error InvalidRecipient();
     error ConflictingSchedule();
     error NothingToRelease();
     error InsufficientUnallocatedBalance();
@@ -48,50 +60,69 @@ contract VestingVault is AccessControl {
         external
         onlyRole(VESTING_MANAGER_ROLE)
     {
-        if (beneficiary == address(0)) revert InvalidBeneficiary();
-        if (amount == 0 || amount > type(uint128).max) revert InvalidAmount();
-        if (duration == 0) revert InvalidSchedule();
-        VestingSchedule storage schedule = _schedules[beneficiary];
-        if (
-            schedule.totalAmount != 0
-                && (schedule.start != start || schedule.duration != duration)
-        ) {
-            revert ConflictingSchedule();
-        }
+        _createVesting(beneficiary, PRESALE_SCHEDULE_ID, amount, start, start, duration);
+    }
 
-        uint256 available = ukiToken.balanceOf(address(this)) + totalReleased - totalAllocated;
-        if (amount > available) revert InsufficientUnallocatedBalance();
-
-        if (schedule.totalAmount == 0) {
-            schedule.start = start;
-            schedule.duration = duration;
-        }
-        schedule.totalAmount += uint128(amount);
-        totalAllocated += amount;
-
-        emit VestingCreated(beneficiary, amount, start, duration);
+    function createVestingWithCliff(
+        address beneficiary,
+        bytes32 scheduleId,
+        uint256 amount,
+        uint64 start,
+        uint64 cliff,
+        uint64 duration
+    ) external onlyRole(VESTING_MANAGER_ROLE) {
+        _createVesting(beneficiary, scheduleId, amount, start, cliff, duration);
     }
 
     function releasable(address beneficiary) public view returns (uint256) {
-        VestingSchedule memory schedule = _schedules[beneficiary];
-        return vestedAmount(beneficiary, uint64(block.timestamp)) - schedule.releasedAmount;
+        return releasable(beneficiary, PRESALE_SCHEDULE_ID);
+    }
+
+    function releasable(address beneficiary, bytes32 scheduleId) public view returns (uint256) {
+        VestingSchedule memory schedule = _schedules[beneficiary][scheduleId];
+        return vestedAmount(beneficiary, scheduleId, uint64(block.timestamp)) - schedule.releasedAmount;
     }
 
     function release() external returns (uint256 amount) {
-        amount = releasable(msg.sender);
+        return release(PRESALE_SCHEDULE_ID);
+    }
+
+    function release(bytes32 scheduleId) public returns (uint256 amount) {
+        amount = releasable(msg.sender, scheduleId);
         if (amount == 0) revert NothingToRelease();
 
-        VestingSchedule storage schedule = _schedules[msg.sender];
+        VestingSchedule storage schedule = _schedules[msg.sender][scheduleId];
         schedule.releasedAmount += uint128(amount);
         totalReleased += amount;
 
         ukiToken.safeTransfer(msg.sender, amount);
-        emit TokensReleased(msg.sender, amount);
+        emit TokensReleased(msg.sender, scheduleId, amount);
+    }
+
+    function releaseAll() external returns (uint256 totalAmount) {
+        bytes32[] memory ids = _scheduleIds[msg.sender];
+        for (uint256 index = 0; index < ids.length; index++) {
+            uint256 amount = releasable(msg.sender, ids[index]);
+            if (amount == 0) continue;
+
+            VestingSchedule storage schedule = _schedules[msg.sender][ids[index]];
+            schedule.releasedAmount += uint128(amount);
+            totalReleased += amount;
+            totalAmount += amount;
+            emit TokensReleased(msg.sender, ids[index], amount);
+        }
+
+        if (totalAmount == 0) revert NothingToRelease();
+        ukiToken.safeTransfer(msg.sender, totalAmount);
     }
 
     function vestedAmount(address beneficiary, uint64 timestamp) public view returns (uint256) {
-        VestingSchedule memory schedule = _schedules[beneficiary];
-        if (schedule.totalAmount == 0 || timestamp < schedule.start) {
+        return vestedAmount(beneficiary, PRESALE_SCHEDULE_ID, timestamp);
+    }
+
+    function vestedAmount(address beneficiary, bytes32 scheduleId, uint64 timestamp) public view returns (uint256) {
+        VestingSchedule memory schedule = _schedules[beneficiary][scheduleId];
+        if (schedule.totalAmount == 0 || timestamp < schedule.start || timestamp < schedule.cliff) {
             return 0;
         }
 
@@ -104,6 +135,61 @@ contract VestingVault is AccessControl {
     }
 
     function scheduleOf(address beneficiary) external view returns (VestingSchedule memory) {
-        return _schedules[beneficiary];
+        return _schedules[beneficiary][PRESALE_SCHEDULE_ID];
+    }
+
+    function scheduleOf(address beneficiary, bytes32 scheduleId) external view returns (VestingSchedule memory) {
+        return _schedules[beneficiary][scheduleId];
+    }
+
+    function scheduleIdsOf(address beneficiary) external view returns (bytes32[] memory) {
+        return _scheduleIds[beneficiary];
+    }
+
+    function unallocatedBalance() public view returns (uint256) {
+        return ukiToken.balanceOf(address(this)) + totalReleased - totalAllocated;
+    }
+
+    function withdrawUnallocated(address to, uint256 amount) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (to == address(0)) revert InvalidRecipient();
+        if (amount == 0) revert InvalidAmount();
+        if (amount > unallocatedBalance()) revert InsufficientUnallocatedBalance();
+
+        ukiToken.safeTransfer(to, amount);
+        emit UnallocatedWithdrawn(to, amount);
+    }
+
+    function _createVesting(
+        address beneficiary,
+        bytes32 scheduleId,
+        uint256 amount,
+        uint64 start,
+        uint64 cliff,
+        uint64 duration
+    ) private {
+        if (beneficiary == address(0)) revert InvalidBeneficiary();
+        if (scheduleId == bytes32(0)) revert InvalidSchedule();
+        if (amount == 0 || amount > type(uint128).max) revert InvalidAmount();
+        if (start == 0 || cliff < start || duration == 0 || cliff > start + duration) revert InvalidSchedule();
+        VestingSchedule storage schedule = _schedules[beneficiary][scheduleId];
+        if (
+            schedule.totalAmount != 0
+                && (schedule.start != start || schedule.cliff != cliff || schedule.duration != duration)
+        ) {
+            revert ConflictingSchedule();
+        }
+
+        if (amount > unallocatedBalance()) revert InsufficientUnallocatedBalance();
+
+        if (schedule.totalAmount == 0) {
+            schedule.start = start;
+            schedule.cliff = cliff;
+            schedule.duration = duration;
+            _scheduleIds[beneficiary].push(scheduleId);
+        }
+        schedule.totalAmount += uint128(amount);
+        totalAllocated += amount;
+
+        emit VestingCreated(beneficiary, scheduleId, amount, start, cliff, duration);
     }
 }

--- a/packages/contracts/docs/DEPLOYMENT.md
+++ b/packages/contracts/docs/DEPLOYMENT.md
@@ -12,6 +12,7 @@
 pnpm --filter @cukies/contracts compile
 pnpm --filter @cukies/contracts test
 pnpm --filter @cukies/contracts coverage
+pnpm --filter @cukies/contracts simulate:deploy
 pnpm --filter @cukies/contracts deploy:testnet
 pnpm --filter @cukies/contracts export:abi
 ```
@@ -41,8 +42,9 @@ Optional:
 3. Deploy `Presale`.
 4. Fund `VestingVault` with the UKI amount reserved for sale.
 5. Grant `VESTING_MANAGER_ROLE` on `VestingVault` to `Presale`.
-6. Verify contracts on BscScan.
-7. Export ABIs and set dapp env addresses.
+6. Create team/advisors/ecosystem schedules with `createVestingWithCliff`.
+7. Verify contracts on BscScan.
+8. Export ABIs and set dapp env addresses.
 
 Before mainnet, complete `packages/contracts/docs/SECURITY.md`.
 

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -9,6 +9,7 @@
     "clean": "hardhat clean",
     "deploy:testnet": "hardhat run scripts/deploy-presale.cjs --network bscTestnet",
     "deploy:mainnet": "hardhat run scripts/deploy-presale.cjs --network bsc",
+    "simulate:deploy": "hardhat run scripts/simulate-full-deploy.cjs --network hardhat",
     "export:abi": "node scripts/export-abi.cjs"
   },
   "dependencies": {

--- a/packages/contracts/scripts/simulate-full-deploy.cjs
+++ b/packages/contracts/scripts/simulate-full-deploy.cjs
@@ -1,0 +1,107 @@
+const hre = require('hardhat');
+
+async function deploy(name, args = []) {
+  const Factory = await hre.ethers.getContractFactory(name);
+  const contract = await Factory.deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+async function main() {
+  const [deployer, treasury, buyer, team, advisor, ecosystem] = await hre.ethers.getSigners();
+  const now = Math.floor(Date.now() / 1000);
+  const saleStart = BigInt(now + 60);
+  const saleEnd = saleStart + 30n * 24n * 60n * 60n;
+  const presaleVestingStart = saleEnd;
+  const nineMonths = 9n * 30n * 24n * 60n * 60n;
+  const oneYear = 365n * 24n * 60n * 60n;
+  const twoYears = 2n * oneYear;
+
+  const asm = await deploy('MockERC20', ['ApeSwap', 'ASM']);
+  const uki = await deploy('UKIToken', [
+    deployer.address,
+    deployer.address,
+    hre.ethers.parseEther('1000000000'),
+  ]);
+  const vault = await deploy('VestingVault', [await uki.getAddress(), deployer.address]);
+  const presale = await deploy('Presale', [{
+    owner: deployer.address,
+    asmToken: await asm.getAddress(),
+    vestingVault: await vault.getAddress(),
+    treasury: treasury.address,
+    saleStart,
+    saleEnd,
+    ukiPerAsm: hre.ethers.parseEther('100'),
+    minAsmPerPurchase: hre.ethers.parseEther('1'),
+    maxAsmPerPurchase: hre.ethers.parseEther('10000'),
+    walletAsmCap: hre.ethers.parseEther('25000'),
+    totalUkiForSale: hre.ethers.parseEther('10000000'),
+    vestingStart: presaleVestingStart,
+    vestingDuration: nineMonths,
+  }]);
+
+  await uki.transfer(await vault.getAddress(), hre.ethers.parseEther('150000000'));
+  await vault.grantRole(await vault.VESTING_MANAGER_ROLE(), await presale.getAddress());
+  await vault.grantRole(await vault.VESTING_MANAGER_ROLE(), deployer.address);
+
+  await vault.createVestingWithCliff(
+    team.address,
+    hre.ethers.id('TEAM'),
+    hre.ethers.parseEther('80000000'),
+    BigInt(now) + oneYear,
+    BigInt(now) + oneYear,
+    twoYears
+  );
+  await vault.createVestingWithCliff(
+    advisor.address,
+    hre.ethers.id('ADVISORS'),
+    hre.ethers.parseEther('20000000'),
+    BigInt(now) + 180n * 24n * 60n * 60n,
+    BigInt(now) + 180n * 24n * 60n * 60n,
+    oneYear
+  );
+  await vault.createVestingWithCliff(
+    ecosystem.address,
+    hre.ethers.id('ECOSYSTEM'),
+    hre.ethers.parseEther('40000000'),
+    BigInt(now) + 30n * 24n * 60n * 60n,
+    BigInt(now) + 30n * 24n * 60n * 60n,
+    twoYears
+  );
+
+  await asm.mint(buyer.address, hre.ethers.parseEther('5000'));
+  await asm.connect(buyer).approve(await presale.getAddress(), hre.ethers.MaxUint256);
+  await hre.network.provider.send('evm_setNextBlockTimestamp', [Number(saleStart)]);
+  await presale.connect(buyer).buy(hre.ethers.parseEther('1000'));
+
+  const buyerSchedule = await vault['scheduleOf(address)'](buyer.address);
+  const teamSchedule = await vault['scheduleOf(address,bytes32)'](team.address, hre.ethers.id('TEAM'));
+
+  console.log(JSON.stringify({
+    network: hre.network.name,
+    deployer: deployer.address,
+    contracts: {
+      asm: await asm.getAddress(),
+      uki: await uki.getAddress(),
+      vestingVault: await vault.getAddress(),
+      presale: await presale.getAddress(),
+    },
+    sale: {
+      treasury: treasury.address,
+      buyerAsmPaid: hre.ethers.formatEther(await presale.asmPurchased(buyer.address)),
+      buyerUkiAllocated: hre.ethers.formatEther(buyerSchedule.totalAmount),
+    },
+    vesting: {
+      vaultUkiBalance: hre.ethers.formatEther(await uki.balanceOf(await vault.getAddress())),
+      totalAllocated: hre.ethers.formatEther(await vault.totalAllocated()),
+      unallocated: hre.ethers.formatEther(await vault.unallocatedBalance()),
+      buyerScheduleIds: await vault.scheduleIdsOf(buyer.address),
+      teamUkiAllocated: hre.ethers.formatEther(teamSchedule.totalAmount),
+    },
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/contracts/test/presale.test.cjs
+++ b/packages/contracts/test/presale.test.cjs
@@ -62,7 +62,9 @@ describe('Presale', function () {
     const schedule = await vault.scheduleOf(buyer.address);
     expect(schedule.totalAmount).to.equal(ukiAmount);
     expect(schedule.start).to.equal(vestingStart);
+    expect(schedule.cliff).to.equal(vestingStart);
     expect(schedule.duration).to.equal(vestingDuration);
+    expect(await vault.scheduleIdsOf(buyer.address)).to.deep.equal([await vault.PRESALE_SCHEDULE_ID()]);
   });
 
   it('allows multiple purchases in the same vesting schedule', async function () {

--- a/packages/contracts/test/vesting-vault.test.cjs
+++ b/packages/contracts/test/vesting-vault.test.cjs
@@ -24,12 +24,12 @@ describe('VestingVault', function () {
 
     await expect(vault.connect(manager).createVesting(beneficiary.address, amount, start, duration))
       .to.emit(vault, 'VestingCreated')
-      .withArgs(beneficiary.address, amount, start, duration);
+      .withArgs(beneficiary.address, await vault.PRESALE_SCHEDULE_ID(), amount, start, start, duration);
 
     await time.setNextBlockTimestamp(start + 450n);
     await expect(vault.connect(beneficiary).release())
       .to.emit(vault, 'TokensReleased')
-      .withArgs(beneficiary.address, ethers.parseEther('450'));
+      .withArgs(beneficiary.address, await vault.PRESALE_SCHEDULE_ID(), ethers.parseEther('450'));
     expect(await uki.balanceOf(beneficiary.address)).to.equal(ethers.parseEther('450'));
 
     await time.setNextBlockTimestamp(start + duration);
@@ -47,6 +47,55 @@ describe('VestingVault', function () {
 
     const schedule = await vault.scheduleOf(beneficiary.address);
     expect(schedule.totalAmount).to.equal(ethers.parseEther('150'));
+  });
+
+  it('supports multiple schedule ids with cliff and releaseAll', async function () {
+    const { manager, beneficiary, uki, vault } = await deployVaultFixture();
+    const now = BigInt(await time.latest());
+    const presaleId = await vault.PRESALE_SCHEDULE_ID();
+    const teamId = ethers.id('TEAM');
+    const advisorsId = ethers.id('ADVISORS');
+
+    await vault.connect(manager).createVesting(beneficiary.address, ethers.parseEther('100'), now + 100n, 1_000n);
+    await vault.connect(manager).createVestingWithCliff(
+      beneficiary.address,
+      teamId,
+      ethers.parseEther('300'),
+      now + 100n,
+      now + 400n,
+      1_000n
+    );
+    await vault.connect(manager).createVestingWithCliff(
+      beneficiary.address,
+      advisorsId,
+      ethers.parseEther('200'),
+      now + 100n,
+      now + 100n,
+      1_000n
+    );
+
+    expect(await vault.scheduleIdsOf(beneficiary.address)).to.deep.equal([presaleId, teamId, advisorsId]);
+
+    await time.increaseTo(now + 300n);
+    expect(await vault['releasable(address,bytes32)'](beneficiary.address, teamId)).to.equal(0);
+    expect(await vault['releasable(address,bytes32)'](beneficiary.address, advisorsId)).to.equal(ethers.parseEther('40'));
+
+    await vault.connect(beneficiary).releaseAll();
+    expect(await uki.balanceOf(beneficiary.address)).to.equal(ethers.parseEther('60.3'));
+  });
+
+  it('withdraws only unallocated UKI by admin', async function () {
+    const { admin, manager, beneficiary, other, uki, vault } = await deployVaultFixture();
+    const start = BigInt(await time.latest()) + 100n;
+
+    await vault.connect(manager).createVesting(beneficiary.address, ethers.parseEther('100'), start, 900);
+    await expect(vault.connect(other).withdrawUnallocated(other.address, ethers.parseEther('1')))
+      .to.be.revertedWithCustomError(vault, 'AccessControlUnauthorizedAccount');
+
+    await vault.connect(admin).withdrawUnallocated(other.address, ethers.parseEther('9900'));
+    expect(await uki.balanceOf(other.address)).to.equal(ethers.parseEther('9900'));
+    await expect(vault.connect(admin).withdrawUnallocated(other.address, 1))
+      .to.be.revertedWithCustomError(vault, 'InsufficientUnallocatedBalance');
   });
 
   it('rejects unauthorized or conflicting schedules', async function () {


### PR DESCRIPTION
## Summary
- Extends `VestingVault` to support multiple schedule ids per beneficiary, explicit cliffs, `release(bytes32)`, `releaseAll()`, `scheduleIdsOf()` and admin withdrawal of unallocated UKI.
- Keeps the existing presale path compatible through `PRESALE_SCHEDULE_ID` and the old `createVesting(...)`, `release()` and `scheduleOf(address)` helpers.
- Adds `pnpm --filter @cukies/contracts simulate:deploy` to deploy the full local flow: ASM mock, UKI token, VestingVault, Presale, vault funding, presale role grant, team/advisors/ecosystem vestings and a buyer purchase.
- Adds dapp `/vesting` page with user claim panel, schedule table, contract status chips and admin allocation form.
- Adds Vesting navigation entry and updates exported VestingVault ABI.

## Validation
- `pnpm --filter @cukies/contracts clean` OK
- `pnpm --filter @cukies/contracts compile` OK
- `pnpm --filter @cukies/contracts test` OK: 13 passing
- `pnpm --filter @cukies/contracts coverage` OK: statements 87.06%, lines 86.89%
- `pnpm --filter @cukies/contracts simulate:deploy` OK, local full deploy and purchase simulation completed
- `pnpm --filter @cukies/contracts export:abi` OK
- `pnpm dapp dev` OK on port 3001; `/vesting` returned HTTP 200

## Known existing dapp checks
- `pnpm dapp typecheck` still fails on pre-existing unrelated errors in `__tests__/components/stats-cards.test.tsx`, Telegram scripts and chat API routes. No `/vesting` errors remain in the output.
