### PR TITLE
style: normalize app shell colors

### DIFF
--- a/dapp/src/app/globals.css
+++ b/dapp/src/app/globals.css
@@ -14,68 +14,68 @@ body {
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
-    --primary: 330 81% 60%;
+    --primary: 178 79% 52%;
     --primary-foreground: 0 0% 98%;
     --secondary: 0 0% 96.1%;
     --secondary-foreground: 0 0% 9%;
     --muted: 0 0% 96.1%;
     --muted-foreground: 0 0% 45.1%;
-    --accent: 330 81% 60%;
+    --accent: 178 79% 52%;
     --accent-foreground: 0 0% 98%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 89.8%;
     --input: 0 0% 89.8%;
-    --ring: 330 81% 60%;
-    --chart-1: 330 81% 60%;
-    --chart-2: 340 82% 52%;
-    --chart-3: 300 65% 55%;
+    --ring: 178 79% 52%;
+    --chart-1: 178 79% 52%;
+    --chart-2: 181 100% 25%;
+    --chart-3: 176 82% 58%;
     --chart-4: 15 85% 65%;
     --chart-5: 260 70% 60%;
     --radius: 0.75rem;
     --sidebar-background: 0 0% 98%;
     --sidebar-foreground: 240 5.3% 26.1%;
-    --sidebar-primary: 330 81% 60%;
+    --sidebar-primary: 178 79% 52%;
     --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 330 30% 95%;
-    --sidebar-accent-foreground: 330 40% 15%;
-    --sidebar-border: 330 25% 88%;
-    --sidebar-ring: 330 81% 60%;
+    --sidebar-accent: 176 30% 95%;
+    --sidebar-accent-foreground: 176 40% 15%;
+    --sidebar-border: 176 25% 88%;
+    --sidebar-ring: 178 79% 52%;
   }
   .dark {
-    --background: 330 28% 10%;
+    --background: 190 65% 4%;
     --foreground: 0 0% 98%;
-    --card: 330 30% 14%;
+    --card: 176 34% 9%;
     --card-foreground: 0 0% 98%;
-    --popover: 330 32% 12%;
+    --popover: 176 37% 8%;
     --popover-foreground: 0 0% 98%;
-    --primary: 330 81% 60%;
+    --primary: 178 79% 52%;
     --primary-foreground: 0 0% 98%;
-    --secondary: 330 25% 20%;
+    --secondary: 176 29% 13%;
     --secondary-foreground: 0 0% 98%;
-    --muted: 330 25% 20%;
+    --muted: 176 29% 13%;
     --muted-foreground: 0 0% 70%;
-    --accent: 330 81% 60%;
+    --accent: 178 79% 52%;
     --accent-foreground: 0 0% 98%;
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 98%;
-    --border: 330 25% 24%;
-    --input: 330 25% 18%;
-    --ring: 330 81% 60%;
-    --chart-1: 330 81% 60%;
-    --chart-2: 340 82% 52%;
-    --chart-3: 300 65% 55%;
+    --border: 176 26% 18%;
+    --input: 176 31% 11%;
+    --ring: 178 79% 52%;
+    --chart-1: 178 79% 52%;
+    --chart-2: 181 100% 25%;
+    --chart-3: 176 82% 58%;
     --chart-4: 15 85% 65%;
     --chart-5: 260 70% 60%;
     --radius: 0.75rem;
-    --sidebar-background: 330 30% 14%;
-    --sidebar-foreground: 330 18% 80%;
-    --sidebar-primary: 330 81% 60%;
+    --sidebar-background: 176 34% 9%;
+    --sidebar-foreground: 176 18% 82%;
+    --sidebar-primary: 178 79% 52%;
     --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 330 32% 22%;
+    --sidebar-accent: 176 30% 16%;
     --sidebar-accent-foreground: 0 0% 98%;
-    --sidebar-border: 330 28% 26%;
-    --sidebar-ring: 330 81% 60%;
+    --sidebar-border: 176 26% 20%;
+    --sidebar-ring: 178 79% 52%;
   }
 }
 
@@ -122,7 +122,7 @@ body {
 
   /* Efectos adicionales para Cukies World */
   .glow-effect {
-    box-shadow: 0 0 20px rgba(236, 72, 153, 0.3);
+    box-shadow: 0 0 20px rgba(34, 231, 223, 0.3);
   }
 
   .glass-effect {
@@ -152,7 +152,7 @@ body {
   }
 
   .animated-gradient {
-    background: linear-gradient(-45deg, #ec4899, #be185d, #f472b6, #db2777);
+    background: linear-gradient(-45deg, #22e7df, #008080, #44edd6, #008080);
     background-size: 400% 400%;
     animation: gradient-shift 15s ease infinite;
   }
@@ -199,10 +199,10 @@ body {
   /* Efecto de resplandor pulsante */
   @keyframes glow-pulse {
     0%, 100% { 
-      box-shadow: 0 0 20px rgba(236, 72, 153, 0.3);
+      box-shadow: 0 0 20px rgba(34, 231, 223, 0.3);
     }
     50% { 
-      box-shadow: 0 0 40px rgba(236, 72, 153, 0.6);
+      box-shadow: 0 0 40px rgba(34, 231, 223, 0.6);
     }
   }
 
@@ -236,8 +236,8 @@ body {
     --uki-cyan-soft: rgba(34, 231, 223, 0.11);
     --uki-cyan-border: rgba(34, 231, 223, 0.22);
     --uki-gold: #f2c34b;
-    --uki-pink: #ef5f8f;
-    --uki-pink-border: rgba(239, 95, 143, 0.28);
+    --uki-cyan-strong: #22e7df;
+    --uki-cyan-border-strong: rgba(34, 231, 223, 0.28);
     --uki-ease: cubic-bezier(0.32, 0.72, 0, 1);
     position: relative;
     font-family: var(--font-space-grotesk), var(--font-inter), sans-serif;
@@ -377,10 +377,10 @@ body {
     display: inline-flex;
     width: fit-content;
     border-radius: 5px;
-    border: 1px solid rgba(239, 95, 143, 0.72);
-    background: rgba(42, 13, 26, 0.78);
+    border: 1px solid rgba(34, 231, 223, 0.72);
+    background: rgba(2, 24, 28, 0.78);
     padding: 0.55rem 0.75rem;
-    color: #ff75aa;
+    color: #44edd6;
     font-size: 0.72rem;
     font-weight: 900;
     letter-spacing: 0.14em;
@@ -703,10 +703,10 @@ body {
     align-items: center;
     gap: 0.45rem;
     border-radius: 6px;
-    border: 1px solid rgba(239, 95, 143, 0.38);
-    background: rgba(42, 13, 26, 0.56);
+    border: 1px solid rgba(34, 231, 223, 0.38);
+    background: rgba(2, 24, 28, 0.56);
     padding: 0.45rem 0.6rem;
-    color: #ff75aa;
+    color: #44edd6;
     font-size: 0.64rem;
     font-weight: 900;
     letter-spacing: 0.1em;
@@ -725,7 +725,7 @@ body {
     gap: 0.75rem;
     min-height: 3rem;
     border-radius: 7px;
-    border: 1px solid var(--uki-pink-border);
+    border: 1px solid var(--uki-cyan-border-strong);
     background: rgba(6, 28, 25, 0.58);
     padding: 0.55rem 0.7rem;
     transition: transform 420ms var(--uki-ease), border-color 420ms var(--uki-ease), background-color 420ms var(--uki-ease);
@@ -854,7 +854,7 @@ body {
 
   .uki-metric-tile:nth-child(3n + 1) svg { color: var(--uki-cyan); }
   .uki-metric-tile:nth-child(3n + 2) svg { color: var(--uki-gold); }
-  .uki-metric-tile:nth-child(3n) svg { color: #ff75aa; }
+  .uki-metric-tile:nth-child(3n) svg { color: #44edd6; }
 
   .uki-label {
     color: var(--uki-muted);
@@ -948,7 +948,7 @@ body {
     background: radial-gradient(circle at 32% 24%, #fff0a8, #f2c34b 46%, #8b5410 100%);
   }
 
-  .uki-token-purple {
+  .uki-token-cyan {
     background: radial-gradient(circle at 32% 24%, #ffd4ff, #b668d9 46%, #5b2675 100%);
   }
 
@@ -1219,10 +1219,10 @@ body {
   .uki-node-worlds { left: 21%; bottom: 9%; }
   .uki-node-rewards { right: 21%; bottom: 9%; }
 
-  .uki-node-purple { color: #dcb8ff; background: linear-gradient(135deg, rgba(48, 21, 74, 0.72), rgba(6, 16, 22, 0.68)); }
+  .uki-node-mint { color: #8ffefa; background: linear-gradient(135deg, rgba(3, 38, 44, 0.72), rgba(6, 16, 22, 0.68)); }
   .uki-node-gold { color: #ffd97a; background: linear-gradient(135deg, rgba(58, 42, 16, 0.76), rgba(6, 16, 22, 0.68)); }
   .uki-node-blue { color: #99ddff; background: linear-gradient(135deg, rgba(11, 45, 61, 0.74), rgba(6, 16, 22, 0.68)); }
-  .uki-node-pink { color: #ff9fbd; background: linear-gradient(135deg, rgba(61, 19, 38, 0.76), rgba(6, 16, 22, 0.68)); }
+  .uki-node-cyan { color: #44edd6; background: linear-gradient(135deg, rgba(2, 35, 38, 0.76), rgba(6, 16, 22, 0.68)); }
   .uki-node-green { color: #c9f79f; background: linear-gradient(135deg, rgba(23, 50, 29, 0.76), rgba(6, 16, 22, 0.68)); }
   .uki-node-red { color: #ffb0bf; background: linear-gradient(135deg, rgba(59, 20, 32, 0.76), rgba(6, 16, 22, 0.68)); }
 
@@ -1442,7 +1442,7 @@ body {
     background:
       linear-gradient(180deg, rgba(2, 9, 13, 0.72) 0%, rgba(2, 9, 13, 0.5) 100%),
       radial-gradient(circle at 4% 22%, rgba(34, 231, 223, 0.13), transparent 14rem),
-      radial-gradient(circle at 96% 16%, rgba(239, 95, 143, 0.1), transparent 16rem),
+      radial-gradient(circle at 96% 16%, rgba(34, 231, 223, 0.1), transparent 16rem),
       url("/brand/generated/uki-cukie-master-scene-v2.png") left bottom / 34rem auto no-repeat;
     opacity: 0.52;
     transition: transform 900ms var(--uki-ease), filter 900ms var(--uki-ease);
@@ -1675,7 +1675,7 @@ body {
   }
 
   .uki-future-cyan .uki-panel-core::after { background: linear-gradient(0deg, #17d8c8, transparent); }
-  .uki-future-pink .uki-panel-core::after { background: linear-gradient(0deg, #ef4f94, transparent); }
+  .uki-future-cyan .uki-panel-core::after { background: linear-gradient(0deg, #22e7df, transparent); }
   .uki-future-gold .uki-panel-core::after { background: linear-gradient(0deg, #f5c34d, transparent); }
   .uki-future-vault .uki-panel-core::after { background: linear-gradient(0deg, #ffbd4b, transparent); }
 

--- a/dapp/src/components/layout/app-layout.tsx
+++ b/dapp/src/components/layout/app-layout.tsx
@@ -11,7 +11,6 @@ import {
   SidebarMenuItem,
   SidebarMenuButton,
   SidebarFooter,
-  useSidebar,
 } from '@/components/ui/sidebar';
 import {
   Home,
@@ -23,7 +22,6 @@ import {
   Send,
   LockKeyhole,
 } from 'lucide-react';
-import Logo from '@/components/icons/logo';
 import Header from './header';
 import DiscordIcon from '../icons/discord';
 import XIcon from '../icons/x-icon';
@@ -51,14 +49,14 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="flex h-screen w-full bg-background relative">
       <SidebarProvider>
-        <Sidebar collapsible="icon" className="border-r border-pink-600/20 bg-black/10 backdrop-blur-md shadow-xl shadow-pink-600/10" style={{
+        <Sidebar collapsible="icon" className="border-r border-teal-400/20 bg-black/10 backdrop-blur-md shadow-xl shadow-teal-400/10" style={{
             // Override sidebar background variable for transparency
             // 25% opaque black provides dark overlay while showing content background
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             "--sidebar-background": "rgb(255, 255, 255)",
-            "--sidebar-border": "rgba(236, 72, 153, 0.3)"
+            "--sidebar-border": "rgba(34, 231, 223, 0.3)"
           } as React.CSSProperties}>
-          <SidebarHeader className="border-b border-pink-600/20 bg-black/15 backdrop-blur-sm h-16 flex items-center">
+          <SidebarHeader className="border-b border-teal-400/20 bg-black/15 backdrop-blur-sm h-16 flex items-center">
             <SidebarLogo />
           </SidebarHeader>
           <SidebarContent className="py-4 bg-black/10 backdrop-blur-sm">
@@ -67,11 +65,11 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
                 <Link href="/" passHref>
                   <SidebarMenuButton
                     isActive={pathname === '/'}
-                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-pink-600/10 hover:to-pink-600/10 hover:border-pink-500/30 hover:shadow-md hover:shadow-pink-600/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-pink-600/20 data-[active=true]:to-pink-600/20 data-[active=true]:border-pink-500/50"
+                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-teal-400/10 hover:to-teal-400/10 hover:border-cyan-300/30 hover:shadow-md hover:shadow-teal-400/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-teal-400/20 data-[active=true]:to-teal-400/20 data-[active=true]:border-cyan-300/50"
                   >
                     <div className="flex items-center gap-3">
-                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-blue-400/20 to-cyan-500/20 group-hover:from-blue-400/30 group-hover:to-cyan-500/30 transition-all">
-                        <Home className="h-4 w-4 text-blue-400 group-hover:text-cyan-400 transition-colors" />
+                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-teal-400/20 to-cyan-400/20 group-hover:from-teal-400/30 group-hover:to-cyan-400/30 transition-all">
+                        <Home className="h-4 w-4 text-cyan-300 group-hover:text-cyan-200 transition-colors" />
                       </div>
                       <span className="group-data-[collapsible=icon]:hidden font-medium">Home</span>
                     </div>
@@ -83,11 +81,11 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
                 <Link href="/games" passHref>
                   <SidebarMenuButton
                     isActive={pathname.startsWith('/games')}
-                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-pink-600/10 hover:to-pink-600/10 hover:border-pink-500/30 hover:shadow-md hover:shadow-pink-600/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-pink-600/20 data-[active=true]:to-pink-600/20 data-[active=true]:border-pink-500/50"
+                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-teal-400/10 hover:to-teal-400/10 hover:border-cyan-300/30 hover:shadow-md hover:shadow-teal-400/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-teal-400/20 data-[active=true]:to-teal-400/20 data-[active=true]:border-cyan-300/50"
                   >
                     <div className="flex items-center gap-3">
-                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-pink-500/20 to-pink-600/20 group-hover:from-pink-500/30 group-hover:to-pink-600/30 transition-all">
-                        <Gamepad2 className="h-4 w-4 text-pink-500 group-hover:text-pink-500 transition-colors" />
+                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-cyan-300/20 to-teal-400/20 group-hover:from-cyan-300/30 group-hover:to-teal-400/30 transition-all">
+                        <Gamepad2 className="h-4 w-4 text-cyan-300 group-hover:text-cyan-300 transition-colors" />
                       </div>
                       <span className="group-data-[collapsible=icon]:hidden font-medium">Games</span>
                     </div>
@@ -99,11 +97,11 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
                 <Link href="/leaderboard" passHref>
                   <SidebarMenuButton
                     isActive={pathname.startsWith('/leaderboard')}
-                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-pink-600/10 hover:to-pink-600/10 hover:border-pink-500/30 hover:shadow-md hover:shadow-pink-600/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-pink-600/20 data-[active=true]:to-pink-600/20 data-[active=true]:border-pink-500/50"
+                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-teal-400/10 hover:to-teal-400/10 hover:border-cyan-300/30 hover:shadow-md hover:shadow-teal-400/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-teal-400/20 data-[active=true]:to-teal-400/20 data-[active=true]:border-cyan-300/50"
                   >
                     <div className="flex items-center gap-3">
-                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-yellow-400/20 to-orange-500/20 group-hover:from-yellow-400/30 group-hover:to-orange-500/30 transition-all">
-                        <Trophy className="h-4 w-4 text-yellow-400 group-hover:text-orange-400 transition-colors" />
+                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-teal-400/20 to-cyan-400/20 group-hover:from-teal-400/30 group-hover:to-cyan-400/30 transition-all">
+                        <Trophy className="h-4 w-4 text-cyan-300 group-hover:text-cyan-200 transition-colors" />
                       </div>
                       <span className="group-data-[collapsible=icon]:hidden font-medium">Leaderboard</span>
                     </div>
@@ -115,11 +113,11 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
                 <Link href="/quests" passHref>
                   <SidebarMenuButton
                     isActive={pathname.startsWith('/quests')}
-                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-pink-600/10 hover:to-pink-600/10 hover:border-pink-500/30 hover:shadow-md hover:shadow-pink-600/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-pink-600/20 data-[active=true]:to-pink-600/20 data-[active=true]:border-pink-500/50"
+                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-teal-400/10 hover:to-teal-400/10 hover:border-cyan-300/30 hover:shadow-md hover:shadow-teal-400/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-teal-400/20 data-[active=true]:to-teal-400/20 data-[active=true]:border-cyan-300/50"
                   >
                     <div className="flex items-center gap-3">
-                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-purple-400/20 to-pink-500/20 group-hover:from-purple-400/30 group-hover:to-pink-500/30 transition-all">
-                        <Star className="h-4 w-4 text-purple-400 group-hover:text-pink-400 transition-colors" />
+                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-teal-400/20 to-cyan-400/20 group-hover:from-teal-400/30 group-hover:to-cyan-400/30 transition-all">
+                        <Star className="h-4 w-4 text-cyan-300 group-hover:text-cyan-200 transition-colors" />
                       </div>
                       <span className="group-data-[collapsible=icon]:hidden font-medium">Quests</span>
                     </div>
@@ -131,11 +129,11 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
                 <Link href="/referrals" passHref>
                   <SidebarMenuButton
                     isActive={pathname.startsWith('/referrals')}
-                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-pink-600/10 hover:to-pink-600/10 hover:border-pink-500/30 hover:shadow-md hover:shadow-pink-600/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-pink-600/20 data-[active=true]:to-pink-600/20 data-[active=true]:border-pink-500/50"
+                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-teal-400/10 hover:to-teal-400/10 hover:border-cyan-300/30 hover:shadow-md hover:shadow-teal-400/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-teal-400/20 data-[active=true]:to-teal-400/20 data-[active=true]:border-cyan-300/50"
                   >
                     <div className="flex items-center gap-3">
-                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-indigo-400/20 to-blue-500/20 group-hover:from-indigo-400/30 group-hover:to-blue-500/30 transition-all">
-                        <Users className="h-4 w-4 text-indigo-400 group-hover:text-blue-400 transition-colors" />
+                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-teal-400/20 to-cyan-400/20 group-hover:from-teal-400/30 group-hover:to-cyan-400/30 transition-all">
+                        <Users className="h-4 w-4 text-cyan-300 group-hover:text-cyan-300 transition-colors" />
                       </div>
                       <span className="group-data-[collapsible=icon]:hidden font-medium">Referrals</span>
                     </div>
@@ -147,11 +145,11 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
                 <Link href="/points" passHref>
                   <SidebarMenuButton
                     isActive={pathname.startsWith('/points')}
-                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-pink-600/10 hover:to-pink-600/10 hover:border-pink-500/30 hover:shadow-md hover:shadow-pink-600/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-pink-600/20 data-[active=true]:to-pink-600/20 data-[active=true]:border-pink-500/50"
+                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-teal-400/10 hover:to-teal-400/10 hover:border-cyan-300/30 hover:shadow-md hover:shadow-teal-400/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-teal-400/20 data-[active=true]:to-teal-400/20 data-[active=true]:border-cyan-300/50"
                   >
                     <div className="flex items-center gap-3">
-                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-amber-400/20 to-yellow-500/20 group-hover:from-amber-400/30 group-hover:to-yellow-500/30 transition-all">
-                        <Coins className="h-4 w-4 text-amber-400 group-hover:text-yellow-400 transition-colors" />
+                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-teal-400/20 to-cyan-400/20 group-hover:from-teal-400/30 group-hover:to-cyan-400/30 transition-all">
+                        <Coins className="h-4 w-4 text-cyan-300 group-hover:text-cyan-300 transition-colors" />
                       </div>
                       <span className="group-data-[collapsible=icon]:hidden font-medium">Points</span>
                     </div>
@@ -163,11 +161,11 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
                 <Link href="/vesting" passHref>
                   <SidebarMenuButton
                     isActive={pathname.startsWith('/vesting')}
-                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-pink-600/10 hover:to-pink-600/10 hover:border-pink-500/30 hover:shadow-md hover:shadow-pink-600/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-pink-600/20 data-[active=true]:to-pink-600/20 data-[active=true]:border-pink-500/50"
+                    className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-teal-400/10 hover:to-teal-400/10 hover:border-cyan-300/30 hover:shadow-md hover:shadow-teal-400/20 data-[active=true]:bg-gradient-to-r data-[active=true]:from-teal-400/20 data-[active=true]:to-teal-400/20 data-[active=true]:border-cyan-300/50"
                   >
                     <div className="flex items-center gap-3">
-                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-teal-400/20 to-cyan-500/20 group-hover:from-teal-400/30 group-hover:to-cyan-500/30 transition-all">
-                        <LockKeyhole className="h-4 w-4 text-teal-300 group-hover:text-cyan-300 transition-colors" />
+                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-teal-400/20 to-cyan-500/20 group-hover:from-teal-400/30 group-hover:to-cyan-400/30 transition-all">
+                        <LockKeyhole className="h-4 w-4 text-cyan-200 group-hover:text-cyan-300 transition-colors" />
                       </div>
                       <span className="group-data-[collapsible=icon]:hidden font-medium">Vesting</span>
                     </div>
@@ -178,12 +176,12 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
               <SidebarMenuItem>
                 <SidebarMenuButton
                   asChild
-                  className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-pink-600/10 hover:to-pink-600/10 hover:border-pink-500/30 hover:shadow-md hover:shadow-pink-600/20"
+                  className="group relative rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-teal-400/10 hover:to-teal-400/10 hover:border-cyan-300/30 hover:shadow-md hover:shadow-teal-400/20"
                 >
                   <a href="https://marketplace.cukies.world/" target="_blank" rel="noopener noreferrer">
                     <div className="flex items-center gap-3">
-                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-emerald-400/20 to-teal-500/20 group-hover:from-emerald-400/30 group-hover:to-teal-500/30 transition-all">
-                        <Coins className="h-4 w-4 text-emerald-400 group-hover:text-teal-300 transition-colors" />
+                      <div className="p-1.5 rounded-lg bg-gradient-to-br from-teal-400/20 to-cyan-400/20 group-hover:from-teal-400/30 group-hover:to-cyan-400/30 transition-all">
+                        <Coins className="h-4 w-4 text-cyan-300 group-hover:text-cyan-200 transition-colors" />
                       </div>
                       <span className="group-data-[collapsible=icon]:hidden font-medium">Marketplace</span>
                     </div>
@@ -194,16 +192,16 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
             
 
           </SidebarContent>
-          <SidebarFooter className="border-t border-pink-600/20 bg-black/15 backdrop-blur-sm">
+          <SidebarFooter className="border-t border-teal-400/20 bg-black/15 backdrop-blur-sm">
             <div className="p-3 flex flex-col gap-3 group-data-[collapsible=icon]:items-center">
 
                 <SidebarMenu className="group-data-[collapsible=icon]:items-center space-y-1">
                     <SidebarMenuItem>
-                      <SidebarMenuButton asChild className="group rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-blue-500/10 hover:to-cyan-500/10 hover:shadow-md hover:shadow-blue-500/20">
+                      <SidebarMenuButton asChild className="group rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-teal-400/10 hover:to-cyan-400/10 hover:shadow-md hover:shadow-teal-400/20">
                         <a href="https://x.com/cukiesworld" target="_blank" rel="noopener noreferrer">
                           <div className="flex items-center gap-3">
-                            <div className="p-1.5 rounded-lg bg-gradient-to-br from-blue-400/20 to-cyan-500/20 group-hover:from-blue-400/30 group-hover:to-cyan-500/30 transition-all">
-                              <XIcon className="h-3 w-3 text-blue-400 group-hover:text-cyan-400 transition-colors" />
+                            <div className="p-1.5 rounded-lg bg-gradient-to-br from-teal-400/20 to-cyan-400/20 group-hover:from-teal-400/30 group-hover:to-cyan-400/30 transition-all">
+                              <XIcon className="h-3 w-3 text-cyan-300 group-hover:text-cyan-200 transition-colors" />
                             </div>
                             <span className="group-data-[collapsible=icon]:hidden font-medium text-sm">Twitter</span>
                           </div>
@@ -211,11 +209,11 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
                       </SidebarMenuButton>
                     </SidebarMenuItem>
                     <SidebarMenuItem>
-                      <SidebarMenuButton asChild className="group rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-blue-500/10 hover:to-indigo-500/10 hover:shadow-md hover:shadow-blue-500/20">
+                      <SidebarMenuButton asChild className="group rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-teal-400/10 hover:to-cyan-400/10 hover:shadow-md hover:shadow-teal-400/20">
                         <a href="https://t.me/Cukies World" target="_blank" rel="noopener noreferrer">
                           <div className="flex items-center gap-3">
-                            <div className="p-1.5 rounded-lg bg-gradient-to-br from-blue-400/20 to-indigo-500/20 group-hover:from-blue-400/30 group-hover:to-indigo-500/30 transition-all">
-                              <Send className="h-3 w-3 text-blue-400 group-hover:text-indigo-400 transition-colors" />
+                            <div className="p-1.5 rounded-lg bg-gradient-to-br from-teal-400/20 to-cyan-400/20 group-hover:from-teal-400/30 group-hover:to-cyan-400/30 transition-all">
+                              <Send className="h-3 w-3 text-cyan-300 group-hover:text-cyan-300 transition-colors" />
                             </div>
                             <span className="group-data-[collapsible=icon]:hidden font-medium text-sm">Telegram</span>
                           </div>
@@ -223,11 +221,11 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
                       </SidebarMenuButton>
                     </SidebarMenuItem>
                     <SidebarMenuItem>
-                      <SidebarMenuButton asChild className="group rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-purple-500/10 hover:to-indigo-500/10 hover:shadow-md hover:shadow-purple-500/20">
+                      <SidebarMenuButton asChild className="group rounded-xl transition-all duration-300 hover:bg-gradient-to-r hover:from-teal-400/10 hover:to-cyan-400/10 hover:shadow-md hover:shadow-teal-400/20">
                         <a href="https://discord.gg/BxFxZZeAAj" target="_blank" rel="noopener noreferrer">
                           <div className="flex items-center gap-3">
-                            <div className="p-1.5 rounded-lg bg-gradient-to-br from-purple-400/20 to-indigo-500/20 group-hover:from-purple-400/30 group-hover:to-indigo-500/30 transition-all">
-                              <DiscordIcon className="h-3 w-3 text-purple-400 group-hover:text-indigo-400 transition-colors" />
+                            <div className="p-1.5 rounded-lg bg-gradient-to-br from-teal-400/20 to-cyan-400/20 group-hover:from-teal-400/30 group-hover:to-cyan-400/30 transition-all">
+                              <DiscordIcon className="h-3 w-3 text-cyan-300 group-hover:text-cyan-300 transition-colors" />
                             </div>
                             <span className="group-data-[collapsible=icon]:hidden font-medium text-sm">Discord</span>
                           </div>
@@ -240,50 +238,50 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
         </Sidebar>
         <div className="flex flex-1 flex-col overflow-hidden relative z-10">
           {/* Main background with gradients and textures */}
-          <div className="absolute inset-0 bg-gradient-to-br from-background via-pink-950/20 to-pink-900/30"></div>
+          <div className="absolute inset-0 bg-gradient-to-br from-background via-cyan-950/20 to-cyan-950/30"></div>
           
           {/* Subtle grid pattern */}
           <div className="absolute inset-0 opacity-[0.03]" style={{
-            backgroundImage: `radial-gradient(circle at 1px 1px, rgba(236, 72, 153, 0.4) 1px, transparent 0)`,
+            backgroundImage: `radial-gradient(circle at 1px 1px, rgba(34, 231, 223, 0.4) 1px, transparent 0)`,
             backgroundSize: '50px 50px'
           }}></div>
           
           {/* Gaming hexagonal pattern */}
           <div className="absolute inset-0 opacity-[0.02]" style={{
-            backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ec4899' fill-opacity='0.6'%3E%3Cpath d='M30 3l25.98 15v30L30 63 4.02 48V18z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
+            backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%2322e7df' fill-opacity='0.6'%3E%3Cpath d='M30 3l25.98 15v30L30 63 4.02 48V18z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
             backgroundSize: '120px 120px'
           }}></div>
           
           {/* Ambient light effects */}
-          <div className="absolute top-0 left-1/4 w-96 h-96 bg-pink-600/10 rounded-full blur-3xl animate-pulse"></div>
-          <div className="absolute bottom-0 right-1/4 w-80 h-80 bg-pink-600/8 rounded-full blur-3xl animate-pulse delay-1000"></div>
+          <div className="absolute top-0 left-1/4 w-96 h-96 bg-teal-400/10 rounded-full blur-3xl animate-pulse"></div>
+          <div className="absolute bottom-0 right-1/4 w-80 h-80 bg-teal-400/8 rounded-full blur-3xl animate-pulse delay-1000"></div>
           <div className="absolute top-1/2 left-1/2 w-72 h-72 bg-cyan-500/5 rounded-full blur-3xl animate-pulse delay-2000"></div>
           
           {/* Floating gradients */}
           <div className="absolute inset-0 overflow-hidden pointer-events-none">
-            <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-radial from-pink-500/20 via-pink-600/10 to-transparent rounded-full blur-xl floating"></div>
-            <div className="absolute -bottom-32 -left-32 w-64 h-64 bg-gradient-radial from-pink-500/15 via-pink-600/8 to-transparent rounded-full blur-xl floating delay-3000"></div>
+            <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-radial from-cyan-300/20 via-teal-400/10 to-transparent rounded-full blur-xl floating"></div>
+            <div className="absolute -bottom-32 -left-32 w-64 h-64 bg-gradient-radial from-cyan-300/15 via-teal-400/8 to-transparent rounded-full blur-xl floating delay-3000"></div>
           </div>
           
           {/* Animated decorative lines */}
           <div className="absolute inset-0 overflow-hidden pointer-events-none">
-            <div className="absolute top-1/4 left-0 w-full h-px bg-gradient-to-r from-transparent via-pink-600/30 to-transparent transform -rotate-12 animate-pulse"></div>
-            <div className="absolute bottom-1/3 right-0 w-full h-px bg-gradient-to-l from-transparent via-pink-600/20 to-transparent transform rotate-12 animate-pulse delay-1500"></div>
+            <div className="absolute top-1/4 left-0 w-full h-px bg-gradient-to-r from-transparent via-teal-400/30 to-transparent transform -rotate-12 animate-pulse"></div>
+            <div className="absolute bottom-1/3 right-0 w-full h-px bg-gradient-to-l from-transparent via-teal-400/20 to-transparent transform rotate-12 animate-pulse delay-1500"></div>
           </div>
           
           {/* Decorative floating particles */}
           <div className="absolute inset-0 overflow-hidden pointer-events-none">
-            <div className="absolute top-20 left-20 w-2 h-2 bg-pink-500/60 rounded-full floating-slow"></div>
-            <div className="absolute top-40 right-32 w-1 h-1 bg-pink-500/40 rounded-full floating-slow delay-2000"></div>
+            <div className="absolute top-20 left-20 w-2 h-2 bg-cyan-300/60 rounded-full floating-slow"></div>
+            <div className="absolute top-40 right-32 w-1 h-1 bg-cyan-300/40 rounded-full floating-slow delay-2000"></div>
             <div className="absolute bottom-32 left-1/3 w-3 h-3 bg-cyan-400/30 rounded-full floating-slow delay-4000"></div>
-            <div className="absolute top-1/2 right-20 w-1.5 h-1.5 bg-pink-400/50 rounded-full floating-slow delay-6000"></div>
-            <div className="absolute bottom-20 right-1/4 w-2 h-2 bg-pink-400/40 rounded-full floating-slow delay-8000"></div>
+            <div className="absolute top-1/2 right-20 w-1.5 h-1.5 bg-cyan-200/50 rounded-full floating-slow delay-6000"></div>
+            <div className="absolute bottom-20 right-1/4 w-2 h-2 bg-cyan-200/40 rounded-full floating-slow delay-8000"></div>
           </div>
           
           {/* Energy waves */}
           <div className="absolute inset-0 overflow-hidden pointer-events-none opacity-20">
-            <div className="absolute top-0 left-0 w-full h-2 bg-gradient-to-r from-pink-600/0 via-pink-600/30 to-pink-600/0 wave-animation"></div>
-            <div className="absolute bottom-0 right-0 w-full h-1 bg-gradient-to-l from-pink-600/0 via-pink-600/20 to-pink-600/0 wave-animation delay-4000"></div>
+            <div className="absolute top-0 left-0 w-full h-2 bg-gradient-to-r from-teal-400/0 via-teal-400/30 to-teal-400/0 wave-animation"></div>
+            <div className="absolute bottom-0 right-0 w-full h-1 bg-gradient-to-l from-teal-400/0 via-teal-400/20 to-teal-400/0 wave-animation delay-4000"></div>
           </div>
           
           <Header />

--- a/dapp/src/components/layout/header.tsx
+++ b/dapp/src/components/layout/header.tsx
@@ -87,12 +87,12 @@ export default function Header() {
   }
 
   return (
-    <header className="sticky top-0 z-50 flex h-16 shrink-0 items-center gap-4 border-b border-pink-600/20 bg-black/25 backdrop-blur-md shadow-lg shadow-pink-600/10 px-4 sm:px-6">
+    <header className="sticky top-0 z-50 flex h-16 shrink-0 items-center gap-4 border-b border-teal-400/20 bg-black/25 backdrop-blur-md shadow-lg shadow-teal-400/10 px-4 sm:px-6">
       <Button
         variant="ghost"
         size="icon"
         onClick={toggleSidebar}
-        className="hover:bg-pink-600/10 hover:text-pink-500 transition-all duration-300"
+        className="hover:bg-teal-400/10 hover:text-cyan-300 transition-all duration-300"
       >
         <PanelLeft />
         <span className="sr-only">Toggle Sidebar</span>
@@ -110,24 +110,24 @@ export default function Header() {
         {user && (
           <Popover>
             <PopoverTrigger asChild>
-              <Button variant="ghost" size="icon" className="relative rounded-full group hover:bg-pink-600/10 transition-all duration-300">
-                <Bell className="group-hover:text-pink-500 transition-colors" />
+              <Button variant="ghost" size="icon" className="relative rounded-full group hover:bg-teal-400/10 transition-all duration-300">
+                <Bell className="group-hover:text-cyan-300 transition-colors" />
                 <span className="absolute top-1 right-1 flex h-2 w-2">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-pink-500 opacity-75"></span>
-                  <span className="relative inline-flex rounded-full h-2 w-2 bg-pink-500"></span>
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-cyan-300 opacity-75"></span>
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-cyan-300"></span>
                 </span>
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-80 border-2 border-pink-600/20 bg-gradient-to-br from-card to-card/50 backdrop-blur-sm shadow-xl shadow-pink-600/10" align="end">
+            <PopoverContent className="w-80 border-2 border-teal-400/20 bg-gradient-to-br from-card to-card/50 backdrop-blur-sm shadow-xl shadow-teal-400/10" align="end">
                 <CardHeader className="pb-4">
                   <CardTitle className="text-foreground">🔔 Notifications</CardTitle>
                   <CardDescription>You have 1 unread message.</CardDescription>
                 </CardHeader>
                 <CardContent className="grid gap-4">
-                  <div className="flex items-start gap-4 p-3 rounded-lg bg-pink-600/5 border border-pink-600/10">
-                      <Avatar className="h-10 w-10 border-2 border-pink-500/30">
+                  <div className="flex items-start gap-4 p-3 rounded-lg bg-teal-400/5 border border-teal-400/10">
+                      <Avatar className="h-10 w-10 border-2 border-cyan-300/30">
                           <AvatarImage src="https://placehold.co/100x100.png" alt="Avatar" data-ai-hint="logo icon"/>
-                          <AvatarFallback className="bg-gradient-to-br from-pink-500 to-pink-600 text-white font-bold">HL</AvatarFallback>
+                          <AvatarFallback className="bg-gradient-to-br from-cyan-300 to-teal-400 text-white font-bold">HL</AvatarFallback>
                       </Avatar>
                       <div className="grid gap-1">
                           <p className="text-sm font-medium text-foreground">Welcome to Cukies World! 🎉</p>
@@ -136,7 +136,7 @@ export default function Header() {
                   </div>
                   <Button 
                     variant="outline" 
-                    className="w-full border-pink-600/30 bg-pink-600/10 hover:bg-pink-600/20 hover:border-pink-500/50 transition-all duration-300" 
+                    className="w-full border-teal-400/30 bg-teal-400/10 hover:bg-teal-400/20 hover:border-cyan-300/50 transition-all duration-300" 
                     asChild
                   >
                     <Link href="/quests">✨ View All</Link>
@@ -149,16 +149,16 @@ export default function Header() {
         {user ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="relative h-10 w-10 rounded-full group hover:bg-pink-600/10 transition-all duration-300">
-                <Avatar className="h-10 w-10 border-2 border-pink-500/30 group-hover:border-pink-500/60 transition-all duration-300">
+              <Button variant="ghost" className="relative h-10 w-10 rounded-full group hover:bg-teal-400/10 transition-all duration-300">
+                <Avatar className="h-10 w-10 border-2 border-cyan-300/30 group-hover:border-cyan-300/60 transition-all duration-300">
                   <AvatarImage src={user.profilePictureUrl ?? "https://placehold.co/100x100.png"} alt={user.username ?? "user"} data-ai-hint="profile avatar" />
-                  <AvatarFallback className="bg-gradient-to-br from-pink-500 to-pink-600 text-white font-bold">
+                  <AvatarFallback className="bg-gradient-to-br from-cyan-300 to-teal-400 text-white font-bold">
                     {user.username?.slice(0,1).toUpperCase() ?? "U"}
                   </AvatarFallback>
                 </Avatar>
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-64 border-2 border-pink-600/20 bg-gradient-to-br from-card to-card/50 backdrop-blur-sm shadow-xl shadow-pink-600/10">
+            <DropdownMenuContent align="end" className="w-64 border-2 border-teal-400/20 bg-gradient-to-br from-card to-card/50 backdrop-blur-sm shadow-xl shadow-teal-400/10">
               <DropdownMenuLabel className="text-base font-bold text-foreground">
                 {user.username 
                   ? user.username.length > 15 
@@ -167,27 +167,27 @@ export default function Header() {
                   : "My Account"}
               </DropdownMenuLabel>
               <div className="px-3 pt-2 pb-3 space-y-3">
-                <div className="p-3 rounded-lg bg-gradient-to-r from-pink-600/10 to-pink-600/10 border border-pink-500/20">
+                <div className="p-3 rounded-lg bg-gradient-to-r from-teal-400/10 to-teal-400/10 border border-cyan-300/20">
                   <p className="text-xs text-muted-foreground uppercase tracking-wide">Rank</p>
-                  <p className="font-bold text-pink-500 text-sm">{userRank}</p>
+                  <p className="font-bold text-cyan-300 text-sm">{userRank}</p>
                 </div>
-                <div className="p-3 rounded-lg bg-gradient-to-r from-blue-500/10 to-cyan-500/10 border border-blue-400/20">
+                <div className="p-3 rounded-lg bg-gradient-to-r from-teal-400/10 to-cyan-400/10 border border-cyan-300/20">
                   <p className="text-xs text-muted-foreground uppercase tracking-wide">XP</p>
-                  <p className="font-bold font-mono text-blue-400 text-lg">{userXP.toLocaleString()}</p>
+                  <p className="font-bold font-mono text-cyan-300 text-lg">{userXP.toLocaleString()}</p>
                 </div>
               </div>
-              <DropdownMenuSeparator className="bg-pink-600/20" />
+              <DropdownMenuSeparator className="bg-teal-400/20" />
               <DropdownMenuItem disabled className="opacity-50">
                 <Wallet className="mr-3 h-4 w-4 text-gray-400" />
                 <span>My Wallet</span>
               </DropdownMenuItem>
-              <DropdownMenuItem asChild className="hover:bg-pink-600/10 transition-colors">
+              <DropdownMenuItem asChild className="hover:bg-teal-400/10 transition-colors">
                 <Link href="/settings">
-                  <Settings className="mr-3 h-4 w-4 text-pink-500" />
+                  <Settings className="mr-3 h-4 w-4 text-cyan-300" />
                   <span>Settings</span>
                 </Link>
               </DropdownMenuItem>
-              <DropdownMenuSeparator className="bg-pink-600/20" />
+              <DropdownMenuSeparator className="bg-teal-400/20" />
               <DropdownMenuItem 
                 onClick={() => disconnect()} 
                 className="hover:bg-red-500/10 text-red-400 hover:text-red-300 transition-colors"
@@ -205,9 +205,9 @@ export default function Header() {
               className={`${
                 isWaitingForApproval 
                   ? "bg-gradient-to-r from-amber-500 to-orange-600 cursor-not-allowed" 
-                  : "bg-gradient-to-r from-pink-600 to-pink-700 hover:from-pink-700 hover:to-pink-800 hover:scale-105 hover:shadow-xl hover:shadow-pink-600/40"
+                  : "bg-gradient-to-r from-teal-400 to-teal-500 hover:from-teal-500 hover:to-teal-600 hover:scale-105 hover:shadow-xl hover:shadow-teal-400/40"
               } text-white font-bold px-6 py-2 rounded-xl shadow-lg transition-all duration-300 ${
-                isWaitingForApproval ? "shadow-amber-500/30 animate-pulse" : "shadow-pink-600/30"
+                isWaitingForApproval ? "shadow-amber-500/30 animate-pulse" : "shadow-teal-400/30"
               }`}
             >
               {isWaitingForApproval ? (
@@ -224,7 +224,7 @@ export default function Header() {
             </Button>
 
             <Dialog open={isWalletDialogOpen} onOpenChange={setIsWalletDialogOpen}>
-              <DialogContent className="sm:max-w-md border-2 border-pink-600/20 bg-gradient-to-br from-card to-card/50 backdrop-blur-sm shadow-xl shadow-pink-600/10">
+              <DialogContent className="sm:max-w-md border-2 border-teal-400/20 bg-gradient-to-br from-card to-card/50 backdrop-blur-sm shadow-xl shadow-teal-400/10">
                 <DialogHeader>
                   <DialogTitle className="text-2xl font-bold text-foreground">
                     Choose Wallet Type
@@ -236,10 +236,10 @@ export default function Header() {
                 <div className="grid gap-4 py-4">
                   <Button
                     onClick={handleConnectEVM}
-                    className="w-full h-auto p-6 flex flex-col items-start gap-3 bg-gradient-to-r from-blue-600/10 to-purple-600/10 hover:from-blue-600/20 hover:to-purple-600/20 border-2 border-blue-500/30 hover:border-blue-500/50 transition-all duration-300"
+                    className="w-full h-auto p-6 flex flex-col items-start gap-3 bg-gradient-to-r from-teal-400/10 to-cyan-400/10 hover:from-teal-400/20 hover:to-cyan-400/20 border-2 border-cyan-300/30 hover:border-cyan-300/50 transition-all duration-300"
                   >
                     <div className="flex items-center gap-3 w-full">
-                      <div className="p-2 rounded-lg bg-gradient-to-br from-blue-500 to-purple-600">
+                      <div className="p-2 rounded-lg bg-gradient-to-br from-teal-500 to-cyan-400">
                         <Wallet className="h-6 w-6 text-white" />
                       </div>
                       <div className="flex-1 text-left">
@@ -252,10 +252,10 @@ export default function Header() {
                   <Button
                     onClick={handleConnectTron}
                     disabled={!isTronInstalled}
-                    className="w-full h-auto p-6 flex flex-col items-start gap-3 bg-gradient-to-r from-yellow-600/10 to-orange-600/10 hover:from-yellow-600/20 hover:to-orange-600/20 border-2 border-yellow-500/30 hover:border-yellow-500/50 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="w-full h-auto p-6 flex flex-col items-start gap-3 bg-gradient-to-r from-teal-400/10 to-cyan-400/10 hover:from-teal-400/20 hover:to-cyan-400/20 border-2 border-cyan-300/30 hover:border-cyan-300/50 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <div className="flex items-center gap-3 w-full">
-                      <div className="p-2 rounded-lg bg-gradient-to-br from-yellow-500 to-orange-600">
+                      <div className="p-2 rounded-lg bg-gradient-to-br from-teal-500 to-cyan-400">
                         <Zap className="h-6 w-6 text-white" />
                       </div>
                       <div className="flex-1 text-left">


### PR DESCRIPTION
## Summary
- Normalizes the dapp shell, header and sidebar to the UKI home palette: dark base, teal and cyan accents.
- Removes the pink/purple visual treatment from active nav states, shadows, wallet button, modal borders and app background effects.
- Updates global design tokens so shared UI components use cyan/teal by default.

## Validation
- `pnpm dapp dev` OK on port 3001
- `/vesting` returned HTTP 200
- `pnpm dapp typecheck` still fails only on pre-existing unrelated issues in stats-card tests and Telegram/chat scripts.
