### PR TITLE
test: expand UKI contract coverage

### DIFF
--- a/packages/contracts/test/presale.test.cjs
+++ b/packages/contracts/test/presale.test.cjs
@@ -125,5 +125,123 @@ describe('Presale', function () {
     await presale.connect(owner).pause();
     await expect(presale.connect(buyer).buy(ethers.parseEther('1')))
       .to.be.revertedWithCustomError(presale, 'EnforcedPause');
+
+    await presale.connect(owner).unpause();
+    await expect(presale.connect(buyer).buy(ethers.parseEther('1')))
+      .to.emit(presale, 'Purchased');
+  });
+
+  it('allows the owner to update sale administration settings', async function () {
+    const { owner, treasury, other, buyer, presale, saleStart, saleEnd, vestingStart } = await deployPresaleFixture();
+    const nextSaleStart = saleStart + 1_000n;
+    const nextSaleEnd = saleEnd + 1_000n;
+    const nextVestingStart = vestingStart + 2_000n;
+    const nextVestingDuration = 365n * 24n * 60n * 60n;
+    const nextMin = ethers.parseEther('2');
+    const nextMax = ethers.parseEther('5000');
+    const nextCap = ethers.parseEther('15000');
+
+    await expect(presale.connect(owner).setTreasury(other.address))
+      .to.emit(presale, 'TreasuryUpdated')
+      .withArgs(treasury.address, other.address);
+    expect(await presale.treasury()).to.equal(other.address);
+
+    await expect(presale.connect(owner).setSaleWindow(nextSaleStart, nextSaleEnd))
+      .to.emit(presale, 'SaleWindowUpdated')
+      .withArgs(nextSaleStart, nextSaleEnd);
+    expect(await presale.saleStart()).to.equal(nextSaleStart);
+    expect(await presale.saleEnd()).to.equal(nextSaleEnd);
+
+    await expect(presale.connect(owner).setPurchaseLimits(nextMin, nextMax, nextCap))
+      .to.emit(presale, 'PurchaseLimitsUpdated')
+      .withArgs(nextMin, nextMax, nextCap);
+    expect(await presale.minAsmPerPurchase()).to.equal(nextMin);
+    expect(await presale.maxAsmPerPurchase()).to.equal(nextMax);
+    expect(await presale.walletAsmCap()).to.equal(nextCap);
+
+    await expect(presale.connect(owner).setVestingConfig(nextVestingStart, nextVestingDuration))
+      .to.emit(presale, 'VestingConfigUpdated')
+      .withArgs(nextVestingStart, nextVestingDuration);
+    expect(await presale.vestingStart()).to.equal(nextVestingStart);
+    expect(await presale.vestingDuration()).to.equal(nextVestingDuration);
+
+    await expect(presale.connect(buyer).setTreasury(treasury.address))
+      .to.be.revertedWithCustomError(presale, 'OwnableUnauthorizedAccount')
+      .withArgs(buyer.address);
+  });
+
+  it('rejects invalid owner sale configuration updates', async function () {
+    const { presale, saleStart, saleEnd, vestingStart } = await deployPresaleFixture();
+
+    await expect(presale.setTreasury(ethers.ZeroAddress))
+      .to.be.revertedWithCustomError(presale, 'InvalidAddress');
+    await expect(presale.setSaleWindow(0, saleEnd))
+      .to.be.revertedWithCustomError(presale, 'InvalidSaleWindow');
+    await expect(presale.setSaleWindow(saleEnd, saleStart))
+      .to.be.revertedWithCustomError(presale, 'InvalidSaleWindow');
+    await expect(presale.setPurchaseLimits(0, ethers.parseEther('10'), ethers.parseEther('10')))
+      .to.be.revertedWithCustomError(presale, 'InvalidLimits');
+    await expect(presale.setPurchaseLimits(ethers.parseEther('20'), ethers.parseEther('10'), ethers.parseEther('30')))
+      .to.be.revertedWithCustomError(presale, 'InvalidLimits');
+    await expect(presale.setPurchaseLimits(ethers.parseEther('1'), ethers.parseEther('20'), ethers.parseEther('10')))
+      .to.be.revertedWithCustomError(presale, 'InvalidLimits');
+    await expect(presale.setVestingConfig(0, 1))
+      .to.be.revertedWithCustomError(presale, 'InvalidVesting');
+    await expect(presale.setVestingConfig(vestingStart, 0))
+      .to.be.revertedWithCustomError(presale, 'InvalidVesting');
+  });
+
+  it('rejects invalid constructor configuration', async function () {
+    const { owner, treasury, asm, vault, presale, saleStart, saleEnd, vestingStart, vestingDuration } = await deployPresaleFixture();
+    const Presale = await ethers.getContractFactory('Presale');
+    const baseConfig = {
+      owner: owner.address,
+      asmToken: await asm.getAddress(),
+      vestingVault: await vault.getAddress(),
+      treasury: treasury.address,
+      saleStart,
+      saleEnd,
+      ukiPerAsm: ethers.parseEther('100'),
+      minAsmPerPurchase: ethers.parseEther('1'),
+      maxAsmPerPurchase: ethers.parseEther('10000'),
+      walletAsmCap: ethers.parseEther('20000'),
+      totalUkiForSale: ethers.parseEther('10000000'),
+      vestingStart,
+      vestingDuration,
+    };
+
+    await expect(Presale.deploy({ ...baseConfig, owner: ethers.ZeroAddress }))
+      .to.be.revertedWithCustomError(presale, 'OwnableInvalidOwner')
+      .withArgs(ethers.ZeroAddress);
+    await expect(Presale.deploy({ ...baseConfig, asmToken: ethers.ZeroAddress }))
+      .to.be.revertedWithCustomError(presale, 'InvalidAddress');
+    await expect(Presale.deploy({ ...baseConfig, treasury: ethers.ZeroAddress }))
+      .to.be.revertedWithCustomError(presale, 'InvalidAddress');
+    await expect(Presale.deploy({ ...baseConfig, saleStart: 0 }))
+      .to.be.revertedWithCustomError(presale, 'InvalidSaleWindow');
+    await expect(Presale.deploy({ ...baseConfig, saleEnd: saleStart }))
+      .to.be.revertedWithCustomError(presale, 'InvalidSaleWindow');
+    await expect(Presale.deploy({ ...baseConfig, ukiPerAsm: 0 }))
+      .to.be.revertedWithCustomError(presale, 'InvalidRate');
+    await expect(Presale.deploy({ ...baseConfig, minAsmPerPurchase: 0 }))
+      .to.be.revertedWithCustomError(presale, 'InvalidLimits');
+    await expect(Presale.deploy({
+      ...baseConfig,
+      minAsmPerPurchase: ethers.parseEther('2'),
+      maxAsmPerPurchase: ethers.parseEther('1'),
+    }))
+      .to.be.revertedWithCustomError(presale, 'InvalidLimits');
+    await expect(Presale.deploy({
+      ...baseConfig,
+      maxAsmPerPurchase: ethers.parseEther('3'),
+      walletAsmCap: ethers.parseEther('2'),
+    }))
+      .to.be.revertedWithCustomError(presale, 'InvalidLimits');
+    await expect(Presale.deploy({ ...baseConfig, totalUkiForSale: 0 }))
+      .to.be.revertedWithCustomError(presale, 'SaleCapExceeded');
+    await expect(Presale.deploy({ ...baseConfig, vestingStart: 0 }))
+      .to.be.revertedWithCustomError(presale, 'InvalidVesting');
+    await expect(Presale.deploy({ ...baseConfig, vestingDuration: 0 }))
+      .to.be.revertedWithCustomError(presale, 'InvalidVesting');
   });
 });

--- a/packages/contracts/test/uki-token.test.cjs
+++ b/packages/contracts/test/uki-token.test.cjs
@@ -20,6 +20,17 @@ describe('UKIToken', function () {
     expect(await uki.balanceOf(treasury.address)).to.equal(initialSupply);
   });
 
+  it('rejects invalid constructor addresses', async function () {
+    const { owner, treasury, uki, initialSupply } = await deployTokenFixture();
+    const UKIToken = await ethers.getContractFactory('UKIToken');
+
+    await expect(UKIToken.deploy(ethers.ZeroAddress, treasury.address, initialSupply))
+      .to.be.revertedWithCustomError(uki, 'OwnableInvalidOwner')
+      .withArgs(ethers.ZeroAddress);
+    await expect(UKIToken.deploy(owner.address, ethers.ZeroAddress, initialSupply))
+      .to.be.revertedWithCustomError(uki, 'InvalidSupplyReceiver');
+  });
+
   it('supports transfers, allowance and burn', async function () {
     const { treasury, user, uki } = await deployTokenFixture();
 
@@ -41,6 +52,7 @@ describe('UKIToken', function () {
     await uki.connect(owner).pause();
     await expect(uki.connect(treasury).transfer(user.address, ethers.parseEther('1')))
       .to.be.revertedWithCustomError(uki, 'EnforcedPause');
+    await expect(uki.connect(user).unpause()).to.be.revertedWithCustomError(uki, 'OwnableUnauthorizedAccount');
 
     await uki.connect(owner).unpause();
     await expect(uki.connect(treasury).transfer(user.address, ethers.parseEther('1')))

--- a/packages/contracts/test/vesting-vault.test.cjs
+++ b/packages/contracts/test/vesting-vault.test.cjs
@@ -16,6 +16,18 @@ describe('VestingVault', function () {
     return { admin, manager, beneficiary, other, uki, vault };
   }
 
+  it('rejects invalid constructor arguments', async function () {
+    const { admin, vault } = await deployVaultFixture();
+    const VestingVault = await ethers.getContractFactory('VestingVault');
+    const UKIToken = await ethers.getContractFactory('UKIToken');
+    const uki = await UKIToken.deploy(admin.address, admin.address, ethers.parseEther('1000'));
+
+    await expect(VestingVault.deploy(ethers.ZeroAddress, admin.address))
+      .to.be.revertedWithCustomError(vault, 'InvalidToken');
+    await expect(VestingVault.deploy(await uki.getAddress(), ethers.ZeroAddress))
+      .to.be.revertedWithCustomError(vault, 'InvalidBeneficiary');
+  });
+
   it('creates and releases linear vesting schedules', async function () {
     const { manager, beneficiary, uki, vault } = await deployVaultFixture();
     const start = BigInt(await time.latest()) + 100n;
@@ -84,6 +96,40 @@ describe('VestingVault', function () {
     expect(await uki.balanceOf(beneficiary.address)).to.equal(ethers.parseEther('60.3'));
   });
 
+  it('exposes presale and named schedule views and releases by schedule id', async function () {
+    const { manager, beneficiary, uki, vault } = await deployVaultFixture();
+    const now = BigInt(await time.latest());
+    const start = now + 100n;
+    const duration = 1_000n;
+    const teamId = ethers.id('TEAM');
+
+    await vault.connect(manager).createVesting(beneficiary.address, ethers.parseEther('100'), start, duration);
+    await vault.connect(manager).createVestingWithCliff(
+      beneficiary.address,
+      teamId,
+      ethers.parseEther('500'),
+      start,
+      start + 200n,
+      duration
+    );
+
+    expect(await vault.releasable(beneficiary.address)).to.equal(0);
+    expect(await vault.vestedAmount(beneficiary.address, start - 1n)).to.equal(0);
+    expect(await vault['vestedAmount(address,bytes32,uint64)'](beneficiary.address, teamId, start + duration)).to.equal(
+      ethers.parseEther('500')
+    );
+
+    const teamSchedule = await vault['scheduleOf(address,bytes32)'](beneficiary.address, teamId);
+    expect(teamSchedule.totalAmount).to.equal(ethers.parseEther('500'));
+    expect(teamSchedule.cliff).to.equal(start + 200n);
+
+    await time.increaseTo(start + 600n);
+    await expect(vault.connect(beneficiary)['release(bytes32)'](teamId))
+      .to.emit(vault, 'TokensReleased')
+      .withArgs(beneficiary.address, teamId, ethers.parseEther('300.5'));
+    expect(await uki.balanceOf(beneficiary.address)).to.equal(ethers.parseEther('300.5'));
+  });
+
   it('withdraws only unallocated UKI by admin', async function () {
     const { admin, manager, beneficiary, other, uki, vault } = await deployVaultFixture();
     const start = BigInt(await time.latest()) + 100n;
@@ -98,11 +144,60 @@ describe('VestingVault', function () {
       .to.be.revertedWithCustomError(vault, 'InsufficientUnallocatedBalance');
   });
 
+  it('rejects invalid unallocated withdrawals', async function () {
+    const { admin, vault } = await deployVaultFixture();
+
+    await expect(vault.connect(admin).withdrawUnallocated(ethers.ZeroAddress, 1))
+      .to.be.revertedWithCustomError(vault, 'InvalidRecipient');
+    await expect(vault.connect(admin).withdrawUnallocated(admin.address, 0))
+      .to.be.revertedWithCustomError(vault, 'InvalidAmount');
+  });
+
   it('rejects unauthorized or conflicting schedules', async function () {
-    const { beneficiary, other, vault } = await deployVaultFixture();
+    const { manager, beneficiary, other, vault } = await deployVaultFixture();
+    const start = BigInt(await time.latest()) + 100n;
+    const amount = ethers.parseEther('100');
+    const teamId = ethers.id('TEAM');
+
+    await expect(vault.connect(other).createVesting(beneficiary.address, amount, start, 900))
+      .to.be.revertedWithCustomError(vault, 'AccessControlUnauthorizedAccount');
+    await expect(vault.connect(manager).createVesting(ethers.ZeroAddress, amount, start, 900))
+      .to.be.revertedWithCustomError(vault, 'InvalidBeneficiary');
+    await expect(
+      vault.connect(manager).createVestingWithCliff(beneficiary.address, ethers.ZeroHash, amount, start, start, 900)
+    )
+      .to.be.revertedWithCustomError(vault, 'InvalidSchedule');
+    await expect(vault.connect(manager).createVesting(beneficiary.address, 0, start, 900))
+      .to.be.revertedWithCustomError(vault, 'InvalidAmount');
+    await expect(vault.connect(manager).createVesting(beneficiary.address, amount, 0, 900))
+      .to.be.revertedWithCustomError(vault, 'InvalidSchedule');
+    await expect(vault.connect(manager).createVesting(beneficiary.address, amount, start, 0))
+      .to.be.revertedWithCustomError(vault, 'InvalidSchedule');
+    await expect(
+      vault.connect(manager).createVestingWithCliff(beneficiary.address, teamId, amount, start, start - 1n, 900)
+    )
+      .to.be.revertedWithCustomError(vault, 'InvalidSchedule');
+    await expect(
+      vault.connect(manager).createVestingWithCliff(beneficiary.address, teamId, amount, start, start + 901n, 900)
+    )
+      .to.be.revertedWithCustomError(vault, 'InvalidSchedule');
+
+    await vault.connect(manager).createVesting(beneficiary.address, amount, start, 900);
+    await expect(vault.connect(manager).createVesting(beneficiary.address, amount, start + 1n, 900))
+      .to.be.revertedWithCustomError(vault, 'ConflictingSchedule');
+    await expect(vault.connect(manager).createVesting(other.address, ethers.parseEther('20000'), start, 900))
+      .to.be.revertedWithCustomError(vault, 'InsufficientUnallocatedBalance');
+  });
+
+  it('rejects releases when nothing is vested', async function () {
+    const { manager, beneficiary, vault } = await deployVaultFixture();
     const start = BigInt(await time.latest()) + 100n;
 
-    await expect(vault.connect(other).createVesting(beneficiary.address, ethers.parseEther('100'), start, 900))
-      .to.be.revertedWithCustomError(vault, 'AccessControlUnauthorizedAccount');
+    await expect(vault.connect(beneficiary).release())
+      .to.be.revertedWithCustomError(vault, 'NothingToRelease');
+
+    await vault.connect(manager).createVesting(beneficiary.address, ethers.parseEther('100'), start, 900);
+    await expect(vault.connect(beneficiary).releaseAll())
+      .to.be.revertedWithCustomError(vault, 'NothingToRelease');
   });
 });


### PR DESCRIPTION
Refs #126

## Summary
- Expands `Presale` tests across pause/unpause, owner setters, invalid owner updates and constructor validation.
- Adds `UKIToken` constructor and unauthorized unpause coverage.
- Extends `VestingVault` tests for constructor guards, named schedule views/releases, invalid withdrawals, invalid schedules, conflicts and no-op release failures.

## Validation
- `pnpm --filter @cukies/contracts test` OK: 21 passing
- `pnpm --filter @cukies/contracts coverage` OK: 100% statements, 88.1% branches, 100% functions, 100% lines
- `pnpm --filter @cukies/contracts simulate:deploy` OK
- `git diff --check` OK

## Notes
- This covers the currently implemented contracts: `UKIToken`, `Presale` and `VestingVault`.
- `UKIStaking` and `RewardsDistributor` are still pending contracts, so #126 should remain open until their tests exist too.