### PR TITLE
docs: add release candidate template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_candidate.yml
+++ b/.github/ISSUE_TEMPLATE/release_candidate.yml
@@ -1,0 +1,187 @@
+name: Release candidate
+description: Agrupa issues, validacion, responsables y decision go/no-go para una release UKI.
+title: "[RC] UKI <fase> <YYYY-MM-DD>"
+labels: ["area:ops", "area:security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Usa esta plantilla para congelar una release candidate antes de promover cambios entre entornos.
+        Produccion requiere aprobacion explicita de tech, producto/QA y ops.
+
+  - type: input
+    id: release_name
+    attributes:
+      label: Release candidate
+      description: Nombre corto de la RC.
+      placeholder: "UKI Phase 1 presale 2026-05-13"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: target_environment
+    attributes:
+      label: Entorno objetivo
+      description: Donde se quiere validar o publicar esta RC.
+      options:
+        - Staging
+        - Production
+        - Staging y despues production
+    validations:
+      required: true
+
+  - type: input
+    id: source_ref
+    attributes:
+      label: Ref origen
+      description: Rama, tag o commit que contiene los cambios.
+      placeholder: "main, release/staging-2026-05-13 o <sha>"
+    validations:
+      required: true
+
+  - type: input
+    id: target_ref
+    attributes:
+      label: Ref destino
+      description: Rama, tag o deploy target esperado.
+      placeholder: "main, production, staging-20260513.1 o prod-20260513.1"
+    validations:
+      required: true
+
+  - type: textarea
+    id: included_scope
+    attributes:
+      label: Issues incluidas
+      description: Lista cerrada de issues que entran en esta RC.
+      placeholder: |
+        - #123 Motivo
+        - #124 Motivo
+    validations:
+      required: true
+
+  - type: textarea
+    id: excluded_scope
+    attributes:
+      label: Issues excluidas o aplazadas
+      description: Trabajo cercano que queda fuera para evitar confusion de alcance.
+      placeholder: |
+        - #130 queda para la siguiente RC porque ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: prs_commits
+    attributes:
+      label: PRs, commits y tags
+      description: PRs fusionados, commits exactos y tags que forman la RC.
+      placeholder: |
+        - PR #...
+        - Commit ...
+        - Tag ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validacion requerida
+      description: Comandos, smoke tests, testnet checks, QA funcional y checks manuales.
+      placeholder: |
+        - `pnpm dapp lint`
+        - `pnpm dapp typecheck`
+        - Smoke staging: ...
+        - Contratos/testnet: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidencias
+      description: URLs de staging, capturas, tx hashes, logs, checks, deploy ids o notas de QA.
+      placeholder: |
+        - Staging URL:
+        - Deploy:
+        - Tx/BscScan:
+        - Capturas:
+    validations:
+      required: true
+
+  - type: textarea
+    id: owners
+    attributes:
+      label: Responsables
+      description: Go/no-go requiere al menos tech, producto/QA y ops.
+      value: |
+        - Tech lead:
+        - Producto/QA:
+        - Ops:
+        - Contract owner/multisig, si aplica:
+        - Comms/legal, si aplica:
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Riesgos, blockers y decisiones pendientes
+      description: Riesgos aceptados, P0 abiertos, dependencias y decisiones necesarias antes de go.
+      placeholder: |
+        - Riesgo:
+        - Mitigacion:
+        - Decision pendiente:
+    validations:
+      required: true
+
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback
+      description: Plan concreto de rollback para app/env/API/contratos/datos/comunicacion.
+      placeholder: |
+        - App/ref estable anterior:
+        - Env/config:
+        - Contratos:
+        - Datos:
+        - Comunicacion:
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue_closure
+    attributes:
+      label: Regla de cierre de issues
+      description: Define que issues se cierran al merge, al validar staging o solo tras produccion.
+      placeholder: |
+        - Se cierran al merge:
+        - Se cierran tras staging validado:
+        - Se cierran tras production validado:
+        - Permanecen abiertas/bloqueadas:
+    validations:
+      required: true
+
+  - type: textarea
+    id: go_no_go
+    attributes:
+      label: Decision go/no-go
+      description: Completar o actualizar antes de publicar production.
+      value: |
+        | Rol | Responsable | Decision | Fecha/hora | Nota |
+        | --- | --- | --- | --- | --- |
+        | Tech lead |  | Pending |  |  |
+        | Producto/QA |  | Pending |  |  |
+        | Ops |  | Pending |  |  |
+        | Contract owner/multisig, si aplica |  | N/A |  |  |
+        | Comms/legal, si aplica |  | N/A |  |  |
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Confirmaciones
+      options:
+        - label: La RC tiene alcance cerrado y no mezcla trabajo fuera de la lista incluida.
+          required: true
+        - label: Entiendo que production no se publica sin go explicito de tech, producto/QA y ops.
+          required: true

--- a/docs/release-candidate-template.md
+++ b/docs/release-candidate-template.md
@@ -1,0 +1,214 @@
+# UKI release candidate template
+
+Estado: plantilla operativa.
+Issue: #167 `UKI-090.5`.
+Fecha: 2026-05-13.
+
+## Objetivo
+
+Una release candidate (RC) agrupa un conjunto cerrado de issues, PRs y commits para validarlos en staging y decidir si pueden pasar a produccion.
+
+La RC no sustituye las issues. La RC coordina el paso entre entornos y deja evidencia de validacion, responsables, riesgos aceptados, rollback y cierre correcto de issues.
+
+## Cuando abrir una RC
+
+Abre una RC cuando se cumpla al menos una de estas condiciones:
+
+- hay varias issues ya mergeadas en `main` que deben validarse juntas en staging,
+- se quiere fijar un punto de release mientras `main` sigue recibiendo cambios,
+- se va a promover algo hacia `production`,
+- hay contratos, env vars, datos o comunicacion publica que requieren go/no-go explicito.
+
+No abras una RC para una tarea docs interna que se pueda cerrar al merge sin deploy ni validacion de entorno.
+
+## Plantilla
+
+```markdown
+# Release candidate: UKI <fase> <YYYY-MM-DD>
+
+## Metadata
+
+| Campo | Valor |
+| --- | --- |
+| Entorno objetivo | Staging / Production / Staging y despues production |
+| Source ref | `main` / `release/staging-YYYY-MM-DD` / commit SHA |
+| Target ref | `main` / `production` / tag `staging-*` / tag `prod-*` |
+| Ventana propuesta | YYYY-MM-DD HH:mm UTC |
+| Release owner | @... |
+| Issue de coordinacion | #... |
+
+## Alcance incluido
+
+- #... Motivo de inclusion.
+- #... Motivo de inclusion.
+
+## Alcance excluido o aplazado
+
+- #... Motivo de exclusion.
+- #... Motivo de exclusion.
+
+## PRs, commits y tags
+
+- PR #...
+- Commit `<sha>`
+- Tag `staging-YYYYMMDD.N` o `prod-YYYYMMDD.N`, si aplica.
+
+## Entorno
+
+| Area | Staging | Production | Nota |
+| --- | --- | --- | --- |
+| App/ref |  |  |  |
+| Coolify app |  |  |  |
+| Dominio |  |  |  |
+| DB hub |  |  | No escribir production desde staging. |
+| DB legacy Cukies |  |  | Usar replica sanitizada en staging. |
+| Chain | BSC testnet / N/A | BSC mainnet / N/A |  |
+| Contratos |  |  | Direcciones y BscScan si aplica. |
+
+## Validacion requerida
+
+### Automatizada
+
+- [ ] `pnpm dapp lint`
+- [ ] `pnpm dapp typecheck`
+- [ ] `pnpm dapp test`
+- [ ] `pnpm --filter @cukies/contracts test`, si aplica.
+- [ ] `pnpm --filter @cukies/contracts freeze:manifest`, si aplica.
+- [ ] Otros:
+
+### Staging smoke
+
+- [ ] Landing y rutas publicas criticas cargan.
+- [ ] Auth/wallet no rompe el shell.
+- [ ] Flujo afectado por la RC probado en staging.
+- [ ] APIs afectadas responden sin usar datos production por error.
+- [ ] Juegos afectados cargan o quedan explicitamente fuera.
+- [ ] Logs revisados tras smoke.
+
+### Contratos, si aplica
+
+- [ ] Deploy testnet registrado.
+- [ ] BscScan testnet verificado.
+- [ ] Roles/multisig revisados.
+- [ ] Freeze checklist actualizado.
+- [ ] Rollback/pausa on-chain definida.
+
+### Datos, si aplica
+
+- [ ] Staging DB refrescada o decision de no refrescar documentada.
+- [ ] Sanitizacion confirmada.
+- [ ] Conteos o queries de control adjuntas.
+
+## Evidencias
+
+- Staging URL:
+- Deploy id / Coolify event:
+- Commit desplegado:
+- Capturas:
+- Tx hashes / BscScan:
+- Logs relevantes:
+- QA notes:
+
+## Riesgos y blockers
+
+| Riesgo/blocker | Impacto | Mitigacion | Decision |
+| --- | --- | --- | --- |
+|  |  |  |  |
+
+## Rollback
+
+| Area | Accion | Responsable | Evidencia esperada |
+| --- | --- | --- | --- |
+| App | Redeploy de ref estable anterior o revert PR. | Tech/Ops | URL + commit. |
+| Env/config | Restaurar valor anterior en proveedor, sin publicar secretos. | Ops | Nota de cambio logico. |
+| API/backend | Revert deploy o feature flag off. | Tech/Ops | Smoke OK. |
+| Contratos | Pause/revoke/env lock; no asumir rollback on-chain. | Contract owner/multisig | Tx hash. |
+| Datos | Restaurar backup o ejecutar reconciliacion. | Tech/Ops | Conteos post-restore. |
+| Comunicacion | Revert copy o publicar aclaracion. | Producto/comms | URL/captura. |
+
+Ref estable anterior:
+
+- App:
+- Tag:
+- Commit:
+- Env snapshot logico:
+
+## Go/no-go
+
+Production no avanza si falta alguna de las tres decisiones obligatorias: tech, producto/QA y ops.
+
+| Rol | Responsable | Decision | Fecha/hora | Nota |
+| --- | --- | --- | --- | --- |
+| Tech lead |  | Pending / Go / No-go |  |  |
+| Producto/QA |  | Pending / Go / No-go |  |  |
+| Ops |  | Pending / Go / No-go |  |  |
+| Contract owner/multisig, si aplica |  | N/A / Pending / Go / No-go |  |  |
+| Comms/legal, si aplica |  | N/A / Pending / Go / No-go |  |  |
+
+Decision final:
+
+- [ ] Go staging.
+- [ ] No-go staging.
+- [ ] Go production.
+- [ ] No-go production.
+
+## Regla de cierre de issues
+
+| Tipo de issue | Cuando se cierra |
+| --- | --- |
+| Docs interna / tooling sin deploy | Al merge del PR si acceptance criteria esta cumplido. |
+| Cambio validado solo en staging | Tras evidencia de staging si la issue no requiere production. |
+| Cambio de producto/publico | Tras deploy production y smoke post-deploy registrados. |
+| Contratos | Tras deploy/verificacion del entorno requerido y roles/freeze documentados. |
+| Issue parcialmente cubierta | Permanece abierta con comentario de alcance pendiente. |
+| No-go o blocker | Permanece abierta con decision exacta requerida. |
+
+Issues que se cierran al merge:
+
+- #...
+
+Issues que se cierran tras staging validado:
+
+- #...
+
+Issues que se cierran tras production validado:
+
+- #...
+
+Issues que permanecen abiertas:
+
+- #... Motivo.
+
+## Log de ejecucion
+
+| Hora UTC | Accion | Responsable | Resultado |
+| --- | --- | --- | --- |
+|  |  |  |  |
+
+## Validacion post-deploy
+
+- [ ] Dominio correcto responde.
+- [ ] Commit/ref desplegado coincide con la RC.
+- [ ] Smoke critico OK.
+- [ ] Logs sin errores nuevos relevantes.
+- [ ] Monitorizacion revisada.
+- [ ] Issues actualizadas segun regla de cierre.
+- [ ] Incidentes o desviaciones registrados.
+```
+
+## Issue form
+
+Tambien existe la issue form `.github/ISSUE_TEMPLATE/release_candidate.yml` para abrir una RC desde GitHub con los campos obligatorios.
+
+Si la RC se gestiona desde una issue normal, copia la plantilla markdown anterior en la descripcion o en el primer comentario.
+
+## Reglas operativas
+
+- La RC debe listar explicitamente lo incluido y lo excluido.
+- La RC debe usar refs concretas: rama, tag o SHA.
+- No se publica `production` sin go de tech, producto/QA y ops.
+- Si la release toca contratos, el contract owner/multisig debe figurar como responsable adicional.
+- Si la release toca copy publico, claims legales o disclaimers, comms/legal debe figurar como responsable adicional.
+- Los secretos nunca se pegan en la RC; solo se documenta el nombre logico de la variable y el proveedor.
+- Cualquier no-go mantiene la RC abierta o cerrada como no planificada, pero no promueve cambios.
+- Las issues se cierran por la regla de entorno validado, no automaticamente por aparecer listadas en la RC.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -104,7 +104,12 @@ Debe tener una issue o PR de coordinacion con:
 - responsable tecnico,
 - responsable de validacion producto/ops.
 
-Formato sugerido:
+Plantilla operativa:
+
+- Markdown: `docs/release-candidate-template.md`.
+- GitHub issue form: `.github/ISSUE_TEMPLATE/release_candidate.yml`.
+
+Formato minimo:
 
 ```text
 Release candidate: UKI <fase> <fecha>
@@ -126,6 +131,16 @@ Go/no-go:
 Rollback:
 - ...
 ```
+
+Para publicar produccion, el go/no-go debe tener al menos tres responsables con decision explicita: tech lead, producto/QA y ops. Si la release toca contratos, tambien debe figurar contract owner/multisig. Si toca copy publico sensible, tambien debe figurar comms/legal.
+
+Regla de cierre:
+
+- docs internas o tooling sin deploy se pueden cerrar al merge si cumplen acceptance criteria;
+- cambios validados solo en staging se cierran tras evidencia de staging si la issue no exige produccion;
+- cambios publicos o de producto se cierran tras deploy production y smoke post-deploy;
+- issues parcialmente cubiertas permanecen abiertas con comentario del alcance pendiente;
+- cualquier no-go o blocker mantiene la issue abierta con la decision exacta requerida.
 
 ## Staging
 


### PR DESCRIPTION
Closes #167

## Summary
- Adds a GitHub issue form for UKI release candidates.
- Adds `docs/release-candidate-template.md` with required scope, refs, validation, evidence, owners, risk, rollback, go/no-go and issue-closure sections.
- Links the template from `docs/release-workflow.md` and documents closure rules by environment validation.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/release_candidate.yml")'` OK
- `git diff --cached --check` OK

## Risks / follow-ups
- This is documentation/tooling only; no runtime deploy required.
- #168 can use this template for the rollback dry-run release candidate.