### PR TITLE
feat: expose deployment health metadata

### DIFF
--- a/dapp/src/app/api/health/route.ts
+++ b/dapp/src/app/api/health/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+function envValue(...names: string[]) {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value && value.trim() !== '') {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+export async function GET() {
+  const gitSha = envValue(
+    'SOURCE_COMMIT',
+    'GIT_COMMIT_SHA',
+    'VERCEL_GIT_COMMIT_SHA',
+    'NEXT_PUBLIC_BUILD_SHA',
+  );
+  const gitRef = envValue('COOLIFY_BRANCH', 'GIT_BRANCH', 'VERCEL_GIT_COMMIT_REF');
+
+  return NextResponse.json({
+    status: 'ok',
+    app: 'cukies-hub',
+    environment: envValue('APP_ENV', 'COOLIFY_ENVIRONMENT_NAME', 'NODE_ENV') ?? 'unknown',
+    gitSha,
+    gitRef,
+    buildTime: envValue('BUILD_TIME', 'NEXT_PUBLIC_BUILD_TIME'),
+    coolify: {
+      resourceUuid: envValue('COOLIFY_RESOURCE_UUID'),
+      fqdn: envValue('COOLIFY_FQDN'),
+    },
+  });
+}

--- a/docs/release-candidate-template.md
+++ b/docs/release-candidate-template.md
@@ -102,6 +102,7 @@ No abras una RC para una tarea docs interna que se pueda cerrar al merge sin dep
 ## Evidencias
 
 - Staging URL:
+- Health/version:
 - Deploy id / Coolify event:
 - Commit desplegado:
 - Capturas:
@@ -188,6 +189,7 @@ Issues que permanecen abiertas:
 ## Validacion post-deploy
 
 - [ ] Dominio correcto responde.
+- [ ] `/api/health` responde y expone el commit/ref esperado sin secretos.
 - [ ] Commit/ref desplegado coincide con la RC.
 - [ ] Smoke critico OK.
 - [ ] Logs sin errores nuevos relevantes.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -153,6 +153,7 @@ Gates minimos para staging:
 - BSC testnet para compras/vesting/claims on-chain.
 - Datos de prueba que no afecten usuarios reales.
 - `pnpm dapp lint`, `pnpm dapp typecheck` y tests relevantes, o fallos documentados si son preexistentes.
+- `/api/health` expone el commit/ref esperado sin secretos, cuando el endpoint este disponible.
 - Smoke test de rutas criticas.
 
 Para contratos:
@@ -182,6 +183,7 @@ El deploy de produccion debe registrar:
 
 - fecha/hora,
 - commit/tag/branch desplegado,
+- evidencia de `/api/health` si esta disponible,
 - issue/PR de release,
 - persona que ejecuta,
 - validacion post-deploy,


### PR DESCRIPTION
Closes #173

## Summary
- Adds `GET /api/health` for safe deployment metadata: status, app, environment, git SHA/ref, optional build time and Coolify resource/FQDN.
- Forces the route to be dynamic so runtime deploy env is read at request time.
- Updates release docs so RCs use `/api/health` as deploy evidence.

## Validation
- `pnpm --filter dapp exec next lint --file src/app/api/health/route.ts` OK
- `cd dapp && pnpm exec tsc --noEmit --pretty false --target ES2017 --lib dom,dom.iterable,esnext --module esnext --moduleResolution bundler --jsx preserve --strict --skipLibCheck --esModuleInterop --isolatedModules src/app/api/health/route.ts` OK
- `git diff --cached --check` OK

## Known existing validation failures
- `pnpm dapp typecheck` fails on pre-existing generated route param typing, old `stats-cards` test typing/duplicate keys, and existing script `unknown` error handling.
- `pnpm dapp lint` fails on pre-existing `react/no-unescaped-entities` errors and hook warnings in unrelated pages.

## Risks
- Endpoint exposes only non-secret deploy metadata. It intentionally does not return env var values, tokens or database URLs.