### PR TITLE
feat/docs: sync UKI rules and presale UX states

### DIFF
--- a/dapp/src/app/globals.css
+++ b/dapp/src/app/globals.css
@@ -719,6 +719,73 @@ body {
     color: rgba(255, 242, 220, 0.68);
   }
 
+  .uki-status-inline {
+    display: inline-flex;
+    min-height: 1rem;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .uki-state-callout {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    min-height: 3.2rem;
+    align-items: start;
+    gap: 0.65rem;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 242, 220, 0.1);
+    background: rgba(255, 242, 220, 0.045);
+    padding: 0.72rem 0.8rem;
+    color: var(--uki-cream);
+  }
+
+  .uki-state-callout p {
+    font-size: 0.68rem;
+    font-weight: 900;
+    line-height: 1.1;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .uki-state-callout span {
+    display: block;
+    margin-top: 0.25rem;
+    color: var(--uki-muted);
+    font-size: 0.72rem;
+    font-weight: 650;
+    line-height: 1.25;
+  }
+
+  .uki-state-callout-loading {
+    border-color: rgba(255, 242, 220, 0.14);
+    background: rgba(255, 242, 220, 0.055);
+  }
+
+  .uki-state-callout-locked {
+    border-color: rgba(34, 231, 223, 0.25);
+    background: rgba(2, 24, 28, 0.56);
+  }
+
+  .uki-state-callout-warning {
+    border-color: rgba(242, 195, 75, 0.3);
+    background: rgba(83, 55, 8, 0.18);
+  }
+
+  .uki-state-callout-ready {
+    border-color: rgba(34, 231, 223, 0.34);
+    background: rgba(34, 231, 223, 0.08);
+  }
+
+  .uki-state-callout-loading svg,
+  .uki-state-callout-locked svg,
+  .uki-state-callout-ready svg {
+    color: var(--uki-cyan);
+  }
+
+  .uki-state-callout-warning svg {
+    color: var(--uki-gold);
+  }
+
   .uki-trust-signal {
     display: flex;
     align-items: center;

--- a/dapp/src/components/landing/data.tsx
+++ b/dapp/src/components/landing/data.tsx
@@ -100,28 +100,28 @@ export const vestingTracks = [
 export const utilityNodes = [
   {
     title: 'Games',
-    text: 'Play, compete and earn.',
+    text: 'Play and compete.',
     icon: Gamepad2,
     className: 'uki-node-purple',
     positionClassName: 'uki-node-games',
   },
   {
     title: 'Credits',
-    text: 'Earn, spend and upgrade.',
+    text: 'Use internal game resources.',
     icon: Coins,
     className: 'uki-node-gold',
     positionClassName: 'uki-node-credits',
   },
   {
     title: 'Pools',
-    text: 'Powerful pools with real utility.',
+    text: 'Share resources under clear rules.',
     icon: Database,
     className: 'uki-node-blue',
     positionClassName: 'uki-node-pools',
   },
   {
     title: 'Cukie Master',
-    text: 'Boost yield and unlock perks.',
+    text: 'Unlock slots and daily credit access.',
     icon: Crown,
     className: 'uki-node-pink',
     positionClassName: 'uki-node-master',
@@ -135,7 +135,7 @@ export const utilityNodes = [
   },
   {
     title: 'Rewards',
-    text: 'Compete, rank, get rewarded.',
+    text: 'Track period-based allocations.',
     icon: Gift,
     className: 'uki-node-red',
     positionClassName: 'uki-node-rewards',
@@ -171,7 +171,7 @@ export const timeline = [
   {
     year: 'Next',
     title: 'Game economy',
-    text: 'Play, earn, own, together.',
+    text: 'Play, compete and build utility.',
     image: '/brand/generated/uki-timeline-economy.svg',
   },
 ];
@@ -179,7 +179,7 @@ export const timeline = [
 export const futureUtility = [
   {
     title: 'Stake UKI',
-    text: 'Stake your UKI to boost power and multipliers.',
+    text: 'Stake UKI to unlock Cukie Master slots.',
     icon: Sparkles,
     className: 'uki-future-cyan',
     image: '/brand/generated/cukie-master-stake-landing.png',
@@ -193,14 +193,14 @@ export const futureUtility = [
   },
   {
     title: 'Receive credits',
-    text: 'Earn credits from activity, games and pools.',
+    text: 'Receive internal credits from active slots.',
     icon: Coins,
     className: 'uki-future-gold',
     image: '/brand/generated/cukie-master-credits-landing.png',
   },
   {
     title: 'Enter pools',
-    text: 'Join exclusive pools for greater rewards.',
+    text: 'Join pools when the post-presale phase opens.',
     icon: Crown,
     className: 'uki-future-vault',
     image: '/brand/generated/cukie-master-pools-landing.png',

--- a/dapp/src/components/landing/presale-countdown.tsx
+++ b/dapp/src/components/landing/presale-countdown.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { ArrowRight, Lock, Timer } from 'lucide-react';
-import { UKI_PRESALE_START_ISO, UKI_PRESALE_START_LABEL } from './sale-config';
+import {
+  UKI_PRESALE_HAS_EXACT_START,
+  UKI_PRESALE_START_ISO,
+  UKI_PRESALE_START_LABEL,
+  UKI_PRESALE_START_SHORT_LABEL,
+} from './sale-config';
 
 type RemainingTime = {
   total: number;
@@ -14,6 +19,10 @@ type RemainingTime = {
 };
 
 function getRemainingTime(): RemainingTime {
+  if (!UKI_PRESALE_HAS_EXACT_START) {
+    return { total: Number.POSITIVE_INFINITY, days: 0, hours: 0, minutes: 0, seconds: 0 };
+  }
+
   const total = Math.max(0, new Date(UKI_PRESALE_START_ISO).getTime() - Date.now());
   const seconds = Math.floor((total / 1000) % 60);
   const minutes = Math.floor((total / (1000 * 60)) % 60);
@@ -40,6 +49,7 @@ export function usePresaleLock() {
 
   return useMemo(
     () => ({
+      hasExactStart: UKI_PRESALE_HAS_EXACT_START,
       isLocked: remaining.total > 0,
       remaining,
     }),
@@ -61,7 +71,7 @@ export function PresaleCountdown() {
       {boxes.map((box) => (
         <div key={box.label} className="uki-countdown-box">
           <span className="block font-headline text-xl font-black leading-none text-[var(--uki-cyan)]" suppressHydrationWarning>
-            {isLocked ? formatCountdownValue(box.value) : '00'}
+            {!UKI_PRESALE_HAS_EXACT_START ? '--' : isLocked ? formatCountdownValue(box.value) : '00'}
           </span>
           <span className="mt-1.5 block text-[0.55rem] font-bold uppercase tracking-[0.1em] text-[var(--uki-muted)]">
             {box.label}
@@ -99,7 +109,7 @@ export function PresaleGateAction({
       {isLocked ? (
         <span className="inline-flex items-center justify-center gap-2">
           <Lock className="h-3.5 w-3.5" strokeWidth={1.8} />
-          Opens Jun 10
+          Opens {UKI_PRESALE_START_SHORT_LABEL}
         </span>
       ) : (
         openLabel ?? children
@@ -131,7 +141,7 @@ export function PresaleGateLink({
       <span aria-disabled="true" className={`uki-button ${variantClass} uki-button-locked ${className}`}>
         <span className="inline-flex items-center gap-2">
           <Lock className="h-3.5 w-3.5" strokeWidth={1.8} />
-          Opens Jun 10
+          Opens {UKI_PRESALE_START_SHORT_LABEL}
         </span>
         <span className="uki-button-icon" aria-hidden="true">
           <Timer className="h-4 w-4" />

--- a/dapp/src/components/landing/presale-status.tsx
+++ b/dapp/src/components/landing/presale-status.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { AlertTriangle, CheckCircle2, Loader2, Lock, RadioTower } from 'lucide-react';
+import { UKI_PRESALE_START_LABEL } from './sale-config';
+import { usePresaleLock } from './presale-countdown';
+
+type PresaleStatusResponse = {
+  source: 'static' | 'contract';
+  isConfigured: boolean;
+  isOpen?: boolean;
+  message?: string;
+  startsAtLabel: string;
+  chainLabel: string;
+  price?: {
+    ukiPerAsmFormatted: string;
+  };
+};
+
+type PresaleStatusState =
+  | { status: 'loading'; data: null; error: null }
+  | { status: 'ready'; data: PresaleStatusResponse; error: null }
+  | { status: 'error'; data: null; error: string };
+
+const PresaleStatusContext = createContext<PresaleStatusState | null>(null);
+
+function usePresaleStatus(): PresaleStatusState {
+  const [state, setState] = useState<PresaleStatusState>({ status: 'loading', data: null, error: null });
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function loadStatus() {
+      try {
+        const response = await fetch('/api/presale/status', {
+          cache: 'no-store',
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Status request failed with ${response.status}`);
+        }
+
+        const data = (await response.json()) as PresaleStatusResponse;
+        setState({ status: 'ready', data, error: null });
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        setState({
+          status: 'error',
+          data: null,
+          error: error instanceof Error ? error.message : 'Status unavailable',
+        });
+      }
+    }
+
+    loadStatus();
+
+    return () => controller.abort();
+  }, []);
+
+  return state;
+}
+
+function usePresaleStatusValue() {
+  const state = useContext(PresaleStatusContext);
+
+  if (!state) {
+    throw new Error('Presale status components must be rendered inside PresaleStatusProvider.');
+  }
+
+  return state;
+}
+
+export function PresaleStatusProvider({ children }: { children: ReactNode }) {
+  const state = usePresaleStatus();
+
+  return <PresaleStatusContext.Provider value={state}>{children}</PresaleStatusContext.Provider>;
+}
+
+function formatRate(value?: string) {
+  if (!value) return 'Fixed at launch';
+
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) return 'Fixed at launch';
+
+  return `1 ASM = ${numeric.toLocaleString('en-US', { maximumFractionDigits: 4 })} UKI`;
+}
+
+export function PresaleRateLabel() {
+  const state = usePresaleStatusValue();
+
+  if (state.status === 'loading') {
+    return <span className="uki-status-inline">Loading sale status</span>;
+  }
+
+  if (state.status === 'error' || !state.data.isConfigured) {
+    return <span className="uki-status-inline">ASM rate fixed at launch</span>;
+  }
+
+  return <span className="uki-status-inline">{formatRate(state.data.price?.ukiPerAsmFormatted)}</span>;
+}
+
+export function PresaleRuntimeStatus() {
+  const state = usePresaleStatusValue();
+  const { isLocked } = usePresaleLock();
+
+  const runtime = useMemo(() => {
+    if (state.status === 'loading') {
+      return {
+        icon: Loader2,
+        tone: 'loading',
+        title: 'Loading sale status',
+        text: 'Checking presale configuration.',
+      } as const;
+    }
+
+    if (state.status === 'error') {
+      return {
+        icon: AlertTriangle,
+        tone: 'warning',
+        title: 'Status unavailable',
+        text: 'The landing remains readable; buying stays locked until status is confirmed.',
+      } as const;
+    }
+
+    if (!state.data.isConfigured) {
+      return {
+        icon: RadioTower,
+        tone: 'warning',
+        title: 'Contract pending',
+        text: state.data.message ?? 'Presale contract is not configured yet.',
+      } as const;
+    }
+
+    if (state.data.isOpen) {
+      return {
+        icon: CheckCircle2,
+        tone: 'ready',
+        title: 'Presale open',
+        text: `${state.data.chainLabel} contract is active.`,
+      } as const;
+    }
+
+    return {
+      icon: Lock,
+      tone: isLocked ? 'locked' : 'warning',
+      title: isLocked ? `Locked until ${UKI_PRESALE_START_LABEL}` : 'Not open yet',
+      text: 'Connect wallet to review details; approve and buy stay blocked until the sale opens.',
+    } as const;
+  }, [isLocked, state]);
+
+  const Icon = runtime.icon;
+
+  return (
+    <div className={`uki-state-callout uki-state-callout-${runtime.tone}`} aria-live="polite">
+      <Icon className={runtime.tone === 'loading' ? 'h-4 w-4 animate-spin' : 'h-4 w-4'} strokeWidth={1.8} />
+      <div>
+        <p>{runtime.title}</p>
+        <span>{runtime.text}</span>
+      </div>
+    </div>
+  );
+}

--- a/dapp/src/components/landing/sale-config.ts
+++ b/dapp/src/components/landing/sale-config.ts
@@ -1,5 +1,6 @@
-export const UKI_PRESALE_START_ISO = '2026-06-10T00:00:00+02:00';
-export const UKI_PRESALE_START_LABEL = 'June 10, 2026';
-export const UKI_PRESALE_START_SHORT_LABEL = 'Jun 10';
+export const UKI_PRESALE_START_ISO = process.env.NEXT_PUBLIC_UKI_PRESALE_START_ISO || '';
+export const UKI_PRESALE_HAS_EXACT_START = Boolean(UKI_PRESALE_START_ISO);
+export const UKI_PRESALE_START_LABEL = process.env.NEXT_PUBLIC_UKI_PRESALE_START_LABEL || 'first week of June 2026';
+export const UKI_PRESALE_START_SHORT_LABEL = process.env.NEXT_PUBLIC_UKI_PRESALE_START_SHORT_LABEL || 'early June';
 export const UKI_PRESALE_CHAIN_ID = Number(process.env.NEXT_PUBLIC_UKI_CHAIN_ID || 56);
 export const UKI_PRESALE_CHAIN_LABEL = UKI_PRESALE_CHAIN_ID === 97 ? 'BNB Smart Chain Testnet' : 'BNB Smart Chain';

--- a/dapp/src/components/landing/sale-console.tsx
+++ b/dapp/src/components/landing/sale-console.tsx
@@ -1,53 +1,63 @@
 import { Lock, Wallet, Zap, type LucideIcon } from 'lucide-react';
 import { PresaleCountdown, PresaleLockBadge } from './presale-countdown';
+import { PresaleRateLabel, PresaleRuntimeStatus, PresaleStatusProvider } from './presale-status';
 import { Panel, TokenCoin } from './primitives';
 import { UKI_PRESALE_START_LABEL } from './sale-config';
-import { LandingWalletConnectButton, LandingWalletStatusLabel } from './wallet-connect-dynamic';
+import { LandingWalletConnectButton, LandingWalletStateCallout, LandingWalletStatusLabel } from './wallet-connect-dynamic';
 
 export function SaleConsole() {
   return (
-    <Panel id="presale-console" className="uki-sale-console" innerClassName="p-3">
-      <div className="text-center">
-        <p className="font-headline text-xl font-black uppercase tracking-[0.12em] text-[var(--uki-cyan)]">
-          Buy UKI token
-        </p>
-        <p className="mt-1 text-xs font-black uppercase tracking-[0.16em] text-[var(--uki-muted)]">1 ASM = 100 UKI</p>
-      </div>
-
-      <div className="mt-2.5 rounded-[10px] border border-[var(--uki-pink-border)] bg-[#02090d]/74 p-2.5">
-        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
-          <TokenBox label="ASM" tone="purple" />
-          <span className="font-headline text-2xl font-black text-[var(--uki-cyan)]">-&gt;</span>
-          <TokenBox label="UKI" tone="gold" />
+    <PresaleStatusProvider>
+      <Panel id="presale-console" className="uki-sale-console" innerClassName="p-3">
+        <div className="text-center">
+          <p className="font-headline text-xl font-black uppercase tracking-[0.12em] text-[var(--uki-cyan)]">
+            UKI presale
+          </p>
+          <p className="mt-1 text-xs font-black uppercase tracking-[0.16em] text-[var(--uki-muted)]">
+            <PresaleRateLabel />
+          </p>
         </div>
-      </div>
 
-      <div className="mt-2.5 divide-y divide-white/10 border-y border-white/10">
-        <ConsoleRow label="Sale price" value="$0.01" helper="Per UKI" />
-        <ConsoleRow label="Network" value="BNB Smart Chain" icon={Zap} />
-        <ConsoleRow label="Vesting" value="9 months" helper="Linear release" icon={Lock} />
-      </div>
-
-      <div className="mt-2.5 rounded-[10px] border border-[var(--uki-pink-border)] bg-[#02090d]/70 p-2.5">
-        <p className="text-center text-[0.65rem] font-black uppercase tracking-[0.18em] text-[var(--uki-muted)]">
-          Presale starts {UKI_PRESALE_START_LABEL}
-        </p>
-        <PresaleCountdown />
-      </div>
-
-      <div className="mt-2.5 rounded-[8px] border border-[#ef5f8f]/45 bg-[#2a0d1a]/58 p-2.5">
-        <div className="flex items-center justify-between gap-4 text-xs font-black uppercase tracking-[0.12em]">
-          <span className="inline-flex items-center gap-2 text-[var(--uki-cyan)]">
-            <Wallet className="h-4 w-4" strokeWidth={1.8} />
-            Wallet
-          </span>
-          <LandingWalletStatusLabel />
+        <div className="mt-2.5 rounded-[10px] border border-[var(--uki-pink-border)] bg-[#02090d]/74 p-2.5">
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
+            <TokenBox label="ASM" tone="purple" />
+            <span className="font-headline text-2xl font-black text-[var(--uki-cyan)]">-&gt;</span>
+            <TokenBox label="UKI" tone="gold" />
+          </div>
         </div>
-        <PresaleLockBadge className="mt-2 w-full justify-center" />
-      </div>
 
-      <LandingWalletConnectButton className="mt-2.5 w-full justify-center" showCompactText={false} />
-    </Panel>
+        <div className="mt-2.5 divide-y divide-white/10 border-y border-white/10">
+          <ConsoleRow label="Sale price" value="$0.01" helper="Per UKI" />
+          <ConsoleRow label="Network" value="BNB Smart Chain" icon={Zap} />
+          <ConsoleRow label="Vesting" value="9 months" helper="Linear release" icon={Lock} />
+        </div>
+
+        <div className="mt-2.5 space-y-2">
+          <PresaleRuntimeStatus />
+          <LandingWalletStateCallout />
+        </div>
+
+        <div className="mt-2.5 rounded-[10px] border border-[var(--uki-pink-border)] bg-[#02090d]/70 p-2.5">
+          <p className="text-center text-[0.65rem] font-black uppercase tracking-[0.18em] text-[var(--uki-muted)]">
+            Presale starts {UKI_PRESALE_START_LABEL}
+          </p>
+          <PresaleCountdown />
+        </div>
+
+        <div className="mt-2.5 rounded-[8px] border border-[#ef5f8f]/45 bg-[#2a0d1a]/58 p-2.5">
+          <div className="flex items-center justify-between gap-4 text-xs font-black uppercase tracking-[0.12em]">
+            <span className="inline-flex items-center gap-2 text-[var(--uki-cyan)]">
+              <Wallet className="h-4 w-4" strokeWidth={1.8} />
+              Wallet
+            </span>
+            <LandingWalletStatusLabel />
+          </div>
+          <PresaleLockBadge className="mt-2 w-full justify-center" />
+        </div>
+
+        <LandingWalletConnectButton className="mt-2.5 w-full justify-center" showCompactText={false} />
+      </Panel>
+    </PresaleStatusProvider>
   );
 }
 

--- a/dapp/src/components/landing/sections.tsx
+++ b/dapp/src/components/landing/sections.tsx
@@ -17,7 +17,7 @@ import { PresaleGateAction, PresaleGateLink, PresaleLockBadge } from './presale-
 import { HeroBackgroundVideo } from './hero-background-video';
 import { LandingButton, MetricTile, Panel, ProgressTrack, SectionHeading, TokenCoin } from './primitives';
 import { SaleConsole } from './sale-console';
-import { UKI_PRESALE_START_LABEL } from './sale-config';
+import { UKI_PRESALE_START_LABEL, UKI_PRESALE_START_SHORT_LABEL } from './sale-config';
 import { LandingWalletConnectButton } from './wallet-connect-dynamic';
 
 export function CukiesLanding() {
@@ -85,7 +85,7 @@ function HeroSection() {
           <h1 className="uki-hero-title">
             <span className="uki-hero-title-line">UKI presale</span>
             {' '}
-            <span className="uki-hero-title-line text-[var(--uki-cyan)]">opens Jun 10</span>
+            <span className="uki-hero-title-line text-[var(--uki-cyan)]">opens {UKI_PRESALE_START_SHORT_LABEL}</span>
           </h1>
           <p className="mt-4 max-w-[28rem] text-lg leading-snug text-[var(--uki-text)] sm:text-xl">
             The token powering the next Cukies game economy on{' '}
@@ -180,7 +180,7 @@ function StepCard({ step }: { step: (typeof purchaseSteps)[number] }) {
             </div>
             <div>
               <p className="uki-label">Spend limit</p>
-              <p className="mt-1 font-headline text-lg font-black text-[var(--uki-cream)]">10,000 ASM</p>
+              <p className="mt-1 font-headline text-lg font-black text-[var(--uki-cream)]">Set amount</p>
             </div>
             <PresaleGateAction className="h-9 w-full rounded-[5px] bg-[var(--uki-cyan)] text-[0.68rem] font-black uppercase tracking-[0.1em] text-[#02090d]">
               Approve
@@ -189,11 +189,14 @@ function StepCard({ step }: { step: (typeof purchaseSteps)[number] }) {
         ) : null}
         {step.number === '3' ? (
           <div className="space-y-2">
-            <Amount label="You pay (ASM)" value="10,000" token="ASM" />
+            <Amount label="You pay" value="ASM amount" token="ASM" />
             <div className="flex justify-center">
               <ArrowRight className="h-4 w-4 rotate-90 rounded-full border border-[var(--uki-cyan-border)] p-0.5 text-[var(--uki-cyan)]" />
             </div>
-            <Amount label="You receive (UKI)" value="1,000,000" token="UKI" />
+            <Amount label="You receive" value="Quoted UKI" token="UKI" />
+            <p className="text-center text-[0.62rem] font-bold uppercase tracking-[0.1em] text-[var(--uki-muted)]">
+              ASM rate is fixed when presale opens
+            </p>
             <PresaleLockBadge className="mt-2 w-full justify-center" />
           </div>
         ) : null}
@@ -392,7 +395,7 @@ function AfterPresale() {
                     After presale: <span className="text-[var(--uki-cyan)]">Cukie Master coming next</span>
                   </>
                 }
-                subtitle="More utility. More rewards. More ways to grow."
+                subtitle="Slots, credits and pools open after presale."
               />
               <span className="w-fit rounded-[4px] border border-[#ef5f8f]/55 bg-[#2a0d1a]/75 px-3 py-1 text-xs font-black uppercase tracking-[0.12em] text-[#ff75aa]">
                 Phase 02
@@ -468,7 +471,7 @@ function Games() {
           <div className="uki-game-overview rounded-[10px] border border-white/10 bg-[#02090d]/62 p-5">
             <h3 className="font-headline text-xl font-black uppercase tracking-[0.08em] text-[var(--uki-cyan)]">Game overview</h3>
             <ul className="mt-5 space-y-4 text-sm font-semibold text-[var(--uki-text)]">
-              {['Use credits to enter', 'Hunt treasures and earn rewards', 'Climb the weekly rankings'].map((item) => (
+              {['Use credits to enter', 'Hunt treasures and submit scores', 'Climb the weekly rankings'].map((item) => (
                 <li key={item} className="flex items-center gap-3">
                   <Check className="h-4 w-4 rounded-full bg-[var(--uki-cyan)] p-0.5 text-[#02090d]" strokeWidth={2} />
                   {item}
@@ -478,7 +481,7 @@ function Games() {
             <div className="mt-8 grid grid-cols-3 gap-3 border-t border-white/10 pt-5">
               <GameMetric label="Entry cost" value="10" helper="Credits" />
               <GameMetric label="Rankings" value="Weekly" helper="Resets" />
-              <GameMetric label="Top reward" value="UKI +" helper="Credits" />
+              <GameMetric label="Settlement" value="Rules" helper="Based" />
             </div>
           </div>
         </div>
@@ -541,7 +544,9 @@ function FaqAndCta() {
             <h2 className="font-headline text-3xl font-black uppercase leading-[0.98] text-[var(--uki-cream)] sm:text-4xl">
               Be part of the next Cukies chapter
             </h2>
-            <p className="mt-3 max-w-sm text-sm font-semibold leading-snug text-[var(--uki-text)]">UKI Presale opens on {UKI_PRESALE_START_LABEL}. Do not miss your chance.</p>
+            <p className="mt-3 max-w-sm text-sm font-semibold leading-snug text-[var(--uki-text)]">
+              UKI Presale opens on {UKI_PRESALE_START_LABEL}. Review the sale details before it opens.
+            </p>
             <div className="mt-5 flex flex-col gap-3 sm:flex-row">
               <PresaleGateLink href="#presale-console">Join UKI presale</PresaleGateLink>
               <LandingButton href="#token" variant="secondary">

--- a/dapp/src/components/landing/wallet-connect-button.tsx
+++ b/dapp/src/components/landing/wallet-connect-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Wallet } from 'lucide-react';
+import { CheckCircle2, ShieldAlert, Wallet } from 'lucide-react';
 import { useAccount, useConnect, useDisconnect, useSwitchChain } from 'wagmi';
 import { useToast } from '@/hooks/use-toast';
 import { UKI_PRESALE_CHAIN_ID, UKI_PRESALE_CHAIN_LABEL } from './sale-config';
@@ -110,4 +110,43 @@ export function WalletStatusLabel() {
   }
 
   return <span className="text-[var(--uki-cyan)]">{shortAddress(address)}</span>;
+}
+
+export function WalletStateCallout() {
+  const { address, chainId, isConnected } = useAccount();
+  const isWrongChain = isConnected && chainId !== UKI_PRESALE_CHAIN_ID;
+
+  if (!isConnected || !address) {
+    return (
+      <div className="uki-state-callout uki-state-callout-warning">
+        <Wallet className="h-4 w-4" strokeWidth={1.8} />
+        <div>
+          <p>Wallet disconnected</p>
+          <span>Connect an EVM wallet to review personal sale and vesting data.</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (isWrongChain) {
+    return (
+      <div className="uki-state-callout uki-state-callout-warning">
+        <ShieldAlert className="h-4 w-4" strokeWidth={1.8} />
+        <div>
+          <p>Wrong chain</p>
+          <span>Switch to {UKI_PRESALE_CHAIN_LABEL} before approve, buy or vesting actions.</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="uki-state-callout uki-state-callout-ready">
+      <CheckCircle2 className="h-4 w-4" strokeWidth={1.8} />
+      <div>
+        <p>Wallet ready</p>
+        <span>{shortAddress(address)} is connected on {UKI_PRESALE_CHAIN_LABEL}.</span>
+      </div>
+    </div>
+  );
 }

--- a/dapp/src/components/landing/wallet-connect-dynamic.tsx
+++ b/dapp/src/components/landing/wallet-connect-dynamic.tsx
@@ -23,10 +23,29 @@ const DynamicWalletStatusLabel = dynamic(
   },
 );
 
+const DynamicWalletStateCallout = dynamic(
+  () => import('./wallet-connect-island').then((mod) => mod.LandingWalletStateCallout),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="uki-state-callout uki-state-callout-loading">
+        <div>
+          <p>Loading wallet</p>
+          <span>Checking wallet state.</span>
+        </div>
+      </div>
+    ),
+  },
+);
+
 export function LandingWalletConnectButton(props: WalletConnectButtonProps) {
   return <DynamicWalletConnectButton {...props} />;
 }
 
 export function LandingWalletStatusLabel() {
   return <DynamicWalletStatusLabel />;
+}
+
+export function LandingWalletStateCallout() {
+  return <DynamicWalletStateCallout />;
 }

--- a/dapp/src/components/landing/wallet-connect-island.tsx
+++ b/dapp/src/components/landing/wallet-connect-island.tsx
@@ -3,6 +3,7 @@
 import { Web3Provider } from '@/providers/web3-provider';
 import {
   WalletConnectButton,
+  WalletStateCallout,
   WalletStatusLabel,
   type WalletConnectButtonProps,
 } from './wallet-connect-button';
@@ -19,6 +20,14 @@ export function LandingWalletStatusLabel() {
   return (
     <Web3Provider>
       <WalletStatusLabel />
+    </Web3Provider>
+  );
+}
+
+export function LandingWalletStateCallout() {
+  return (
+    <Web3Provider>
+      <WalletStateCallout />
     </Web3Provider>
   );
 }

--- a/docs/adr-uki-economic-operations.md
+++ b/docs/adr-uki-economic-operations.md
@@ -3,6 +3,7 @@
 Estado: aceptado para implementacion inicial.
 Issue: #16 `UKI-001.1`.
 Fecha: 2026-05-12.
+Fuente de reglas vigente: `docs/uki-current-operating-rules.md` sincronizado el 2026-05-17.
 
 ## Contexto
 
@@ -15,6 +16,7 @@ Reglas base heredadas del backlog tecnico:
 - BSC liquida valor, compras, vesting, staking de UKI y claims finales.
 - Treasure Hunt es el primer juego, pero las reglas deben soportar multiples juegos.
 - El bridge/marketplace existente no se reimplementa dentro de este lanzamiento.
+- Direccion actual de producto: las nuevas posiciones de staking Cukie Master y pool de Cukies operan solo en BSC; Tron se mantiene para lectura, reconciliacion y migracion salvo decision posterior.
 
 ## Decision
 
@@ -31,7 +33,7 @@ Usamos BSC como fuente de verdad para valor transferible y derechos on-chain. Us
 | Staking UKI para Cukie Master | Contrato `UKIStaking` | BSC: cantidad staked, lock si aplica y timestamps | Si. Eventos `Staked`, `Unstaked`, `StakeExtended` si hay duracion. Backend/indexer deriva cupos, pero no inventa stake. |
 | Cupos por ruta UKI | Backend `CukieMasterService` | Derivado de BSC indexado: UKI staked y regla vigente de cupos | Si. Audit log off-chain con version de regla, snapshot usado y cupos calculados. No necesita evento on-chain porque es una autorizacion de producto derivada. |
 | Cupos por ruta NFT | Backend `CukieMasterService` | Mongo/marketplace normalizado por `NftInventoryService` | Si. Audit log off-chain con wallet, NFTs considerados, rareza, puntos y version de regla. Debe poder recalcularse desde snapshot. |
-| Soft staking NFT / aportar Cukie a pool | Backend `NftInventoryService` + `CukiePoolService` | Mongo: lock/position operativa sobre NFT normalizado | Si. Event log off-chain append-only para `pool_entered`, `pool_exited`, `lock_created`, `lock_released`, owner verificado y snapshot de rareza. No mueve NFT en BSC/TRON. |
+| Soft staking NFT / aportar Cukie a pool | Backend `NftInventoryService` + `CukiePoolService` | Mongo: lock/position operativa sobre NFT normalizado y elegibilidad BSC para nuevas posiciones | Si. Event log off-chain append-only para `pool_entered`, `pool_exited`, `lock_created`, `lock_released`, owner verificado y snapshot de rareza. La direccion actual no mueve NFT en partida y limita nuevas posiciones a BSC, manteniendo Tron para migracion/reconciliacion. |
 | Estado de NFT usable | Backend `NftInventoryService` | Mongo normalizado + reconciliacion con owner/bridge/listing | Si. Cambios de estado deben dejar audit log cuando afecten uso economico: `available`, `listed`, `bridging`, `soft_staked`, `in_pool`, `assigned_to_game`, `invalidated`, `unknown`. |
 | Creditos diarios de Cukie Master | Job diario + `CompetitionCreditService` | Mongo ledger append-only de creditos | Si. Ledger off-chain obligatorio con `grant`, periodo, slot/cupo origen, idempotency key y job run id. |
 | Deposito de creditos a pool | Job diario + `CompetitionCreditService` | Mongo ledger append-only | Si. Ledger con `pool_deposit`, config aplicada, hora de corte, wallet, slot y periodo. |
@@ -151,4 +153,3 @@ La UI no debe calcular saldos finales, rewards finales, ranking final, elegibili
 - #18 debe fijar ventanas de consistencia, confirmaciones BSC minimas y politicas de recuperacion.
 - #27 debe elegir framework de contratos con esta separacion como requisito.
 - #47 debe decidir si `RewardsDistributor` usa Merkle root por periodo o firmas EIP-712.
-

--- a/docs/uki-brand-token-book.md
+++ b/docs/uki-brand-token-book.md
@@ -3,6 +3,7 @@
 Estado: borrador v0.1 para validacion.
 Uso: fuente de verdad para branding, design tokens, UX visual, copy base e imagenes generadas.
 Principio: los assets actuales inspiran el ADN Cukies, pero no obligan a copiar el estilo antiguo.
+Fuente de reglas vigente: `docs/uki-current-operating-rules.md` sincronizado el 2026-05-17.
 
 ## 1. Tesis de marca
 
@@ -532,8 +533,10 @@ Campos minimos:
 - red: BNB Smart Chain,
 - activo de compra: ASM,
 - precio: $0.01,
-- duracion,
-- vesting,
+- duracion: 1 mes,
+- listing minimo: $0.012,
+- vesting comprador: 9 meses lineal sin cliff,
+- liquidez: ASM recaudado a liquidez UKI con bloqueo/quema minimo 9 meses,
 - estado wallet,
 - CTA.
 
@@ -579,7 +582,8 @@ Contenido:
 - UKI Presale.
 - BNB Smart Chain.
 - compra con ASM.
-- precio/duracion/vesting.
+- precio $0.01, duracion 1 mes y vesting 9 meses.
+- listing minimo $0.012.
 - CTA principal.
 
 Visual:
@@ -609,6 +613,7 @@ Contenido:
 - liquidity lock/burn.
 - buyer vesting.
 - team vesting.
+- ecosistema: 30M UKI liberados 40 dias tras TGE; resto con cliff/vesting.
 - rewards program.
 
 ### 4. Why UKI Exists
@@ -637,9 +642,11 @@ Objetivo: explicar utilidad futura sin distraer del CTA principal.
 Contenido:
 
 - staking UKI,
-- Cukie points,
+- Cukies Originales por puntos de rareza,
 - creditos diarios,
 - cupos,
+- maximo 5 cupos por wallet,
+- UKI con vesting cuenta para cupos,
 - fase posterior.
 
 ### 7. First Game: Treasure Hunt
@@ -776,4 +783,3 @@ Antes de implementar home:
 4. Si la preventa se comunica en ingles, español o bilingue.
 5. Si el tono visual debe inclinarse mas a comunidad NFT o mas a producto financiero/juego.
 6. Si los screenshots de producto deben ser reales desde la app o conceptuales durante prelaunch.
-

--- a/docs/uki-current-operating-rules.md
+++ b/docs/uki-current-operating-rules.md
@@ -1,0 +1,292 @@
+# UKI current operating rules
+
+Estado: fuente operativa vigente para especificacion tecnica.
+Fecha de sincronizacion: 2026-05-17.
+Fuentes: `/Users/fgomezserna/Downloads/Funcionamiento.docx` y `/Users/fgomezserna/Downloads/UKI/Preventa UKI.docx`.
+
+Este documento sustituye como referencia de producto a los documentos antiguos de `Funcionamiento`, `dudas` y `para comentar`. Si una issue o documento anterior contradice estas reglas, estas reglas prevalecen hasta que producto apruebe una version nueva.
+
+## Preventa UKI
+
+- Inicio previsto: primera semana de junio de 2026.
+- Duracion prevista: 1 mes.
+- Precio preventa: 1 UKI = 0.01 USD.
+- Precio de listing: al menos 0.012 USD. Si ASM sube durante la preventa, se puede anunciar un listing mayor para incentivar compra.
+- Compra principal: ASM.
+- Ratio ASM -> UKI: se fija al inicio de la preventa con el valor de ASM en ese momento y permanece constante durante toda la preventa.
+- Ejemplo de ratio: si ASM vale 6 USD al inicio, 1 ASM = 600 UKI.
+- BNB/USDT: opcion pendiente. Si se permite, debe convertirse automaticamente a ASM o guardarse para conversion posterior a ASM.
+- ASM recaudado: debe usarse para aportar liquidez contra UKI.
+- Liquidez inicial: se quema o se bloquea durante al menos 9 meses.
+- Compradores de preventa: vesting lineal de 9 meses, sin cliff.
+- Incentivos Concilium/Ascensum: la cantidad vendida en preventa a esa comunidad se iguala con UKI para Marcel, destinada a incentivos de Concilium/Ascensum.
+- Vesting de incentivos Concilium/Ascensum: mismas condiciones que team, 9 meses de cliff y 24 meses de vesting.
+- Incentivo por compra y referral: pendiente de definir, posiblemente sorteo o regalo de Cukies.
+
+## Tokenomics
+
+Suministro total: 1,000,000,000 UKI.
+
+| Pool | Porcentaje | Uso |
+| --- | ---: | --- |
+| Programa de Recompensas Cukie Masters | 45% | Entrega durante 6 anos segun programa de recompensas. |
+| Ecosistema | 25% | Preventa, airdrops, reservas, marketing, eventos y oportunidades. |
+| Liquidez | 18% | Listing en Pancake, market making, liquidez posterior o exchange centralizado. |
+| Equipo | 12% | Team y asignaciones de incentivos Concilium/Ascensum. |
+
+Reglas de ecosistema:
+
+- Los tokens vendidos durante preventa salen del pool de ecosistema.
+- 3% del pool de ecosistema, 30,000,000 UKI, se libera 40 dias despues del TGE.
+- Ese 3% solo se usa si aparece una oportunidad concreta: partner, marketing, evento u otra accion aprobada.
+- El resto del ecosistema tiene 9 meses de cliff y 12 meses de vesting lineal.
+
+## Cukie Master
+
+Hay dos rutas independientes para obtener cupos de Cukie Master.
+
+### Ruta 1: staking de Cukies Originales
+
+- Cupos iniciales disponibles: 500.
+- Requisito inicial: 3 puntos en Cukies Originales.
+- Los Cukies stakeados se pueden usar para jugar.
+- Los Cukies stakeados para Cukie Master no quedan disponibles para ser prestados a otros jugadores.
+
+Puntos por rareza:
+
+| Rareza | Puntos |
+| --- | ---: |
+| Comun | 1 |
+| No Comun | 2 |
+| Raro | 4 |
+| Epico | 7 |
+| Legendario | 10 |
+| Goat | 15 |
+
+### Ruta 2: staking de UKI
+
+- Cupos iniciales disponibles: 500.
+- Requisito inicial: 20,000 UKI por cupo.
+- Los UKI comprados en preventa con vesting cuentan directamente para staking y asignan cupos a holders.
+- Para calcular cupos se suma UKI con vesting y UKI liberado/stakeado adicional.
+- Un usuario puede stakear mas UKI de los que necesita. El exceso no da beneficios adicionales, pero funciona como margen si sube el requisito.
+
+### Limites y requisito dinamico
+
+- Maximo por wallet: 5 cupos de Cukie Master sumando ruta NFT y ruta UKI.
+- Maximo global de cupos previsto: 5,000.
+- Si una ruta llena sus 500 cupos iniciales y se decide no abrir mas cupos en ese momento, el requisito sube.
+- Cuando el requisito sube, se abre una ventana de 48 horas para que los Cukie Masters ajusten staking y conserven posicion.
+- Si, al cierre de la ventana, un usuario no cumple el nuevo requisito, pierde los cupos que no pueda mantener.
+- El contador de 48 horas no se cancela aunque alguien haga unstake y el numero de cupos ocupados baje por debajo de 500.
+- Cualquier usuario que quiera tomar un hueco libre durante esa ventana debe hacerlo cumpliendo el nuevo requisito.
+
+La UI debe avisar con impacto concreto:
+
+- Requisito anterior y nuevo.
+- Cupos actuales y cupos que conservara si no actua.
+- Cantidad adicional de puntos NFT o UKI necesaria para conservar cupos.
+- Fecha/hora limite.
+
+## Creditos de competicion
+
+- Cada cupo de Cukie Master recibe 100 creditos diarios.
+- La entrega se hace siempre a la misma hora.
+- Un usuario debe ser Cukie Master durante al menos 24 horas antes de recibir la primera asignacion.
+- Si deja de cumplir el requisito, conserva los creditos ya asignados, pero no recibe futuras entregas.
+- Si vuelve a hacer staking para ser Cukie Master, el periodo de 24 horas empieza de nuevo.
+- Los creditos no usados durante el dia se pierden.
+- Los creditos se pueden usar para jugar o aportar al pool de creditos.
+
+## Pool de creditos
+
+- Los Cukie Masters pueden indicar cuantos creditos diarios quieren enviar al pool.
+- La configuracion debe ser en multiplos de 10.
+- La configuracion debe hacerse antes de la hora diaria de entrega.
+- Si no se configura antes del corte, aplica al dia siguiente.
+- Los UKI del pool se asignan diariamente a quienes aportaron creditos ese dia, de forma proporcional a su aportacion.
+- Si un usuario aporto creditos al pool, recibira la recompensa de ese dia aunque deje de ser Cukie Master antes de la entrega de recompensas.
+- Los jugadores sin creditos propios reciben creditos del pool mientras haya disponibilidad.
+
+Retorno minimo inicial:
+
+- El retorno inicial garantizado equivale a convertir el 20% de los creditos del pool.
+- En el calculo diario, si la cantidad por cada 10 creditos aportados queda por debajo de 0.75 UKI, se asignan 0.75 UKI por cada 10 creditos.
+
+Pool semanal:
+
+- Cada semana, los mejores jugadores se reparten el bote semanal.
+- Si las partidas ganadoras usaron creditos del pool y/o Cukies del pool, un porcentaje del premio se asigna al pool correspondiente.
+- Ese importe no se reparte el mismo dia; se asigna a los participantes del pool de la semana siguiente.
+- La distribucion se hace diariamente, repartiendo 1/7 cada dia.
+- Estos UKI son adicionales al minimo diario del pool de creditos.
+
+## Pool de Cukies
+
+- Los usuarios pueden aportar Cukies para que otros jugadores los usen.
+- Hay dos pools separados: Cukies Originales y Cukies de segunda generacion.
+- Primero se prestan Cukies Originales.
+- Si se agotan los Originales, se prestan Cukies de segunda generacion.
+- Si no hay ningun Cukie disponible, se asigna un Seiku ficticio.
+- El reparto con Seiku se trata de forma similar a jugar con un Cukie Comun Original.
+- Los UKI generados para propietarios se reparten en el pool correspondiente segun si el jugador uso Original o segunda generacion.
+- El usuario debe tener el Cukie en staking al menos 24 horas antes de recibir la primera recompensa.
+- Si hace unstake, al volver a stakear empieza de nuevo la espera minima de 24 horas.
+
+Reparto por rareza:
+
+| Tramo de rareza | Porcentaje |
+| --- | ---: |
+| Todos | 16.66% |
+| No Comun o superior | 16.66% |
+| Raro o superior | 16.66% |
+| Epico o superior | 16.66% |
+| Legendario o superior | 16.66% |
+| Goat | 16.66% |
+
+Partidas disponibles por Cukie:
+
+| Rareza | Original | Segunda generacion o superior |
+| --- | ---: | ---: |
+| Comun | 2 | 1 |
+| No Comun | 4 | 2 |
+| Raro | 6 | 3 |
+| Epico | 8 | 4 |
+| Legendario | 10 | 5 |
+| Goat | 12 | 6 |
+
+## Arena ranking
+
+- Solo se rankean los jugadores que usan creditos del pool.
+- Los jugadores empiezan en ranking #5.
+- El ranking se actualiza semanalmente.
+- El movimiento maximo semanal es de 2 categorias hacia arriba o hacia abajo.
+- Para poder subir hay que jugar al menos 20 partidas durante la semana.
+- Para poder bajar hay que jugar al menos 10 partidas durante la semana.
+- Para calcular el porcentaje de creditos convertidos no se cuentan los 2.5 creditos que se convierten al iniciar una partida y van al pool semanal.
+- Para actualizar ranking no se cuentan los UKI ganados por estar entre los mejores jugadores de la semana.
+
+Tabla de ranking:
+
+| Ranking | Recompensa | Ascenso | Descenso |
+| --- | ---: | ---: | ---: |
+| #1 | 100% | No aplica | <70% |
+| #2 | 90% | >80% | <60% |
+| #3 | 80% | >70% | <50% |
+| #4 | 70% | >60% | <40% |
+| #5 | 60% | >50% | <30% |
+| #6 | 50% | >40% | <20% |
+| #7 | 40% | >30% | <10% |
+| #8 | 30% | >20% | <5% |
+| #9 | 20% | >10% | No aplica |
+
+La recompensa por ranking aplica sobre los tokens que quedan despues de asignar 50% al pool de creditos y, si corresponde, 25% al pool de Cukies.
+
+## Treasure Hunt
+
+- Una partida requiere 10 creditos de competicion y un Cukie con partidas disponibles.
+- 2.5 creditos se convierten inmediatamente a UKI y van al pool semanal de premios.
+- Los 7.5 creditos restantes estan en juego.
+- Conversion de score: lineal entre 0 y 3,000 puntos.
+- 3,000 puntos o mas convierten el 100% de los 7.5 creditos.
+- 1,000 puntos convierten 33.33%.
+
+Uso de creditos:
+
+- Si el jugador tiene creditos propios, se usan sus creditos.
+- Las partidas con creditos propios no computan para ranking.
+- En partidas con creditos propios no se mira el ranking para calcular UKI del jugador.
+- Si el jugador no tiene creditos propios, se asignan 10 creditos del pool.
+- Las partidas con creditos del pool computan para ranking.
+- En partidas con creditos del pool se usa el ranking del jugador para calcular su parte.
+
+Uso de Cukies:
+
+- Si el jugador tiene Cukies con partidas disponibles, la propuesta actual es que seleccione cual usar.
+- Si no tiene Cukies con partidas disponibles, se asigna un Cukie del pool.
+- Decision pendiente: confirmar si la seleccion manual del Cukie propio es necesaria o si conviene automatizarla.
+
+Settlement si se convierten 7.5 UKI:
+
+| Caso | Pool creditos | Pool Cukies | Jugador |
+| --- | ---: | ---: | --- |
+| Creditos prestados + Cukie prestado | 3.75 UKI | 1.875 UKI | Porcentaje de ranking sobre 1.875 UKI |
+| Creditos prestados + Cukie propio | 3.75 UKI | 0 | Porcentaje de ranking sobre 3.75 UKI |
+| Creditos propios + Cukie prestado | 0 | 3.75 UKI | 3.75 UKI |
+| Creditos propios + Cukie propio | 0 | 0 | 7.5 UKI |
+
+## UKI no distribuidos
+
+Reserva diaria prevista para recompensas a usuarios: 500,000 UKI.
+
+Puede quedar UKI sin distribuir si:
+
+- Hay menos de 5,000 Cukie Masters.
+- Hay creditos que no se usan.
+- Hay creditos que se usan pero no se convierten a UKI.
+- Un jugador no tiene ranking #1 y por tanto no recibe el 100% de la parte restante.
+
+Distribucion propuesta:
+
+| Destino | Porcentaje |
+| --- | ---: |
+| Tesoreria | 80% |
+| Marketing | 5% |
+| Desarrollo | 5% |
+| Reducir supply | 10% |
+
+Usos previstos de tesoreria:
+
+- Ampliar duracion del programa de recompensas.
+- Aportar liquidez al token.
+- Reserva.
+- Crecimiento del ecosistema.
+- Eventos, promociones e incentivos.
+
+## BSC, Tron y migracion
+
+- Direccion actual de producto: staking para Cukie Master y staking de Cukies para prestar solo en BSC.
+- Esto implica empujar a los usuarios a migrar de Tron a BSC para participar.
+- Pendiente: revisar si se cobra TRX para cubrir fee posterior en BSC.
+- Direccion actual: no priorizar bridge de vuelta de BSC a Tron si no cambian las condiciones.
+
+## Cukie Points y crias
+
+Necesidades:
+
+- Saber cuantos Cukie Points existen en mercado.
+- Saber cuantos Cukie Points tiene cada usuario, incluyendo pendientes de reclamar.
+- Definir una fecha a partir de la cual los Cukies en staking dejan de generar Cukie Points.
+- Parar la opcion de generar crias a partir de una fecha.
+
+Usos propuestos para Cukie Points:
+
+1. Conversion a creditos.
+   - Definir ratio Cukie Points -> creditos.
+   - Limite diario global, ejemplo: 10,000 creditos al dia.
+   - Limite diario por wallet, ejemplo: 500 creditos al dia.
+   - Conversion solo en multiplos de 70.
+   - Los creditos convertidos se asignan durante 7 dias.
+   - Ejemplo: convertir 70 da 10 creditos diarios durante 7 dias.
+   - La primera asignacion se hace a la misma hora diaria que Cukie Master.
+   - Estos creditos tambien pueden configurarse para entrar en el pool.
+
+2. Torneos.
+   - Si en el futuro se permite jugar torneos pagando con UKI, permitir usar Cukie Points en lugar de UKI.
+   - El objetivo seria calificar entre mejores de la semana.
+
+3. Sorteo de NFTs.
+   - Vender tickets en Cukie Points.
+   - Ejecutar sorteo cuando se alcance una cantidad total definida.
+
+## Decisiones pendientes
+
+- Fecha exacta de inicio de preventa.
+- Si BNB/USDT se aceptan en preventa y bajo que flujo.
+- Incentivo concreto por compra.
+- Incentivo concreto por invitar usuarios.
+- Si el usuario elige manualmente Cukie propio en Treasure Hunt o se automatiza.
+- Fecha de corte para Cukie Points generados por Cukies en staking.
+- Fecha de cierre para generar crias.
+- Ratios y limites finales de conversion Cukie Points -> creditos.
+- Detalle operativo de migracion Tron -> BSC y posible cobro de TRX para fee.

--- a/docs/uki-dapp-sitemap.md
+++ b/docs/uki-dapp-sitemap.md
@@ -3,6 +3,7 @@
 Estado: propuesta inicial.
 Issue: #110 `UKI-070.1`.
 Fecha: 2026-05-12.
+Fuente de reglas vigente: `docs/uki-current-operating-rules.md` sincronizado el 2026-05-17.
 
 ## Objetivo
 
@@ -86,11 +87,13 @@ Responsabilidad:
 Contenido minimo:
 
 - Estado de venta.
-- Precio/ratio.
+- Precio 0.01 USD, duracion prevista 1 mes y ratio ASM/UKI fijado al inicio.
+- Listing minimo previsto 0.012 USD.
 - Caps si aplican.
 - Allowance ASM.
 - Compra UKI.
 - Vesting personal.
+- Resumen de liquidez ASM -> UKI y bloqueo/quema minimo 9 meses.
 - Links a BscScan.
 
 No debe:
@@ -130,9 +133,11 @@ Contenido minimo:
 
 - Ruta UKI staking.
 - Ruta NFT points.
-- Maximo de cupos.
+- Maximo de 5 cupos por wallet.
+- Cupos iniciales: 500 por ruta UKI y 500 por ruta Cukies Originales.
 - Requisito dinamico si aplica.
 - Estado de cada cupo.
+- Aviso de 48h cuando sube requisito.
 
 No debe:
 
@@ -150,6 +155,7 @@ Contenido minimo:
 - Balance de creditos.
 - Configuracion diaria en multiplos permitidos.
 - Hora de corte.
+- Retorno minimo vigente si el calculo diario queda por debajo de 0.75 UKI por cada 10 creditos aportados.
 - Ledger de grants/spend/deposit/expire.
 - Pool availability.
 
@@ -169,6 +175,8 @@ Contenido minimo:
 - Cukies elegibles.
 - Estado canonico de cada NFT.
 - Rarity/generation.
+- Direccion actual BSC-only para nuevas posiciones, con Tron como lectura/migracion.
+- Separacion entre pool de Originales y pool de segunda generacion.
 - Locks activos.
 - Solicitud de retirada.
 - Recompensas/allocations si existen.
@@ -187,10 +195,12 @@ Responsabilidad:
 Contenido minimo:
 
 - Coste de entrada.
+- Coste exacto: 10 creditos, con 2.5 destinados al pool semanal y 7.5 en juego.
 - Credit source: propios o pool.
 - Cukie propio o asignado.
 - Session economy status.
 - Reglas de score/reward del juego.
+- Decision pendiente: seleccion manual o automatica de Cukie propio.
 
 No debe:
 
@@ -210,6 +220,8 @@ Contenido minimo:
 - Periodo semanal.
 - Partidas validas.
 - Reglas +2/-2.
+- Minimos: 20 partidas para subir, 10 para bajar.
+- Tabla de recompensa #1-#9 segun `docs/uki-current-operating-rules.md`.
 - Historial por periodo.
 
 No debe:
@@ -277,6 +289,5 @@ No debe:
 - La navegacion publica debe priorizar `/`, `/presale`, `/wallet`, `/games/treasure-hunt` y `/rewards`.
 - Pools, Cukie Master y Arena pueden aparecer bloqueados/coming next hasta que contratos/backend esten listos.
 - Cada pantalla debe consumir APIs de dominio, no leer colecciones Mongo directamente.
-- Los estados UX detallados quedan para `#111`.
-- Las imagenes o referencias visuales por pantalla quedan para `#112`.
-
+- Los estados UX detallados quedan definidos en `docs/uki-ux-state-matrix.md` para `#111`.
+- Las imagenes o referencias visuales por pantalla quedan preparadas en `docs/uki-ux-image-validation-plan.md` para `#112` y `#145`; no se generan sin aprobacion explicita.

--- a/docs/uki-launch-technical-backlog.md
+++ b/docs/uki-launch-technical-backlog.md
@@ -4,6 +4,7 @@ Estado: borrador tecnico para convertir en GitHub Issues.
 Cadena objetivo: BNB Smart Chain.
 Fuente operativa de NFTs: Mongo Proxmox / marketplace.cukies.world.
 Regla base: Mongo opera producto y juegos; BSC liquida valor, staking de UKI, vesting y claims.
+Fuente de reglas vigente: `docs/uki-current-operating-rules.md` sincronizado el 2026-05-17.
 
 ## Convenciones
 
@@ -42,6 +43,8 @@ Regla base: Mongo opera producto y juegos; BSC liquida valor, staking de UKI, ve
 5. Las compras, vesting, staking de UKI y claim final de UKI se resuelven on-chain en BSC.
 6. Treasure Hunt es el primer juego, pero la arquitectura debe soportar multiples juegos.
 7. Toda pantalla que tenga especificacion UX necesita imagen generada validada antes de implementacion visual final.
+8. Las reglas de preventa, Cukie Master, creditos, pools, ranking, Treasure Hunt y UKI no distribuido se toman de `docs/uki-current-operating-rules.md`.
+9. La direccion actual para staking Cukie Master y pool de Cukies es BSC-only; Tron queda como inventario/estado legacy y flujo de migracion salvo decision posterior.
 
 ## Milestone M0 - Decisiones de arquitectura y alcance
 
@@ -184,6 +187,7 @@ Issues hijas:
     - Componentes criticos identificados para reutilizacion.
 
 - UKI-004.4 Task - Validar imagenes generadas de landing, preventa y app shell
+  - Documento de preparacion: `docs/uki-ux-image-validation-plan.md`.
   - Acceptance criteria:
     - Prompt de cada pantalla validado antes de generar.
     - Imagen generada enlazada en la issue correspondiente.
@@ -283,10 +287,11 @@ Contrato para preventa UKI usando ASM como medio principal. BNB/USDT quedan como
 Issues hijas:
 
 - UKI-012.1 Task - Cerrar reglas de preventa
-  - Campos: fecha inicio, fecha fin, precio UKI, ratio ASM/UKI fijo al inicio, max/min compra, wallet caps, pausas.
+  - Campos: fecha inicio primera semana de junio 2026, duracion 1 mes, precio UKI 0.01 USD, listing minimo 0.012 USD, ratio ASM/UKI fijo al inicio, max/min compra, wallet caps, pausas.
   - Acceptance criteria:
     - Reglas versionadas.
     - Casos de borde definidos: preventa agotada, compra fuera de ventana, ASM ratio, refund si aplica.
+    - Liquidez ASM -> UKI, bloqueo/quema minimo 9 meses y vesting comprador 9 meses sin cliff documentados.
 
 - UKI-012.2 Task - Implementar contrato `Presale`
   - Acceptance criteria:
@@ -298,7 +303,7 @@ Issues hijas:
 - UKI-012.3 Task - Extension opcional BNB/USDT
   - Acceptance criteria:
     - Marcado como opcional.
-    - Si se activa, define conversion a ASM o tesoreria separada.
+    - Si se activa, define conversion automatica a ASM o tesoreria separada para convertir posteriormente a ASM.
 
 Dependencias: UKI-011.
 
@@ -316,7 +321,7 @@ Issues hijas:
 - UKI-013.1 Task - Especificar calendarios de vesting
   - Compradores: lineal 9 meses sin cliff.
   - Team/Marcel/Concilium: 9 meses cliff + 24 meses vesting.
-  - Ecosistema: reglas segun tokenomics final.
+  - Ecosistema: 3% del pool de ecosistema, 30,000,000 UKI, liberado 40 dias despues del TGE; resto con 9 meses cliff + 12 meses lineal.
   - Acceptance criteria:
     - Cada pool tiene calendario, cliff, start, end y beneficiarios.
 
@@ -348,9 +353,10 @@ Issues hijas:
   - Inicial: 20,000 UKI por cupo.
   - Maximo: 5 cupos por wallet sumando rutas.
   - Requisito dinamico si se llenan cupos.
+  - UKI comprado en preventa con vesting cuenta directamente para cupos.
   - Acceptance criteria:
     - Formula versionada.
-    - Reglas de subida de requisito y ventana 48-72h definidas.
+    - Reglas de subida de requisito y ventana 48h definidas.
 
 - UKI-014.2 Task - Implementar staking UKI
   - Acceptance criteria:
@@ -362,7 +368,7 @@ Issues hijas:
 - UKI-014.3 Task - Exponer snapshots para cupos
   - Acceptance criteria:
     - Backend puede calcular cupos por wallet desde eventos o lectura directa.
-    - Se contemplan tokens con vesting que cuentan para staking segun regla final.
+    - Incluye UKI con vesting y UKI liberado/stakeado adicional segun regla vigente.
 
 Dependencias: UKI-011, UKI-013.
 
@@ -486,7 +492,8 @@ Issues hijas:
 - UKI-022.1 Task - Calculo por ruta UKI
   - Acceptance criteria:
     - Lee staked UKI on-chain/indexado.
-    - Incluye UKI con vesting si la regla final lo confirma.
+    - Incluye automaticamente UKI comprado en preventa con vesting.
+    - Suma UKI con vesting y UKI liberado/stakeado adicional.
 
 - UKI-022.2 Task - Calculo por ruta NFT
   - Puntos: comun 1, no comun 2, raro 4, epico 7, legendario 10, goat 15.
@@ -497,8 +504,9 @@ Issues hijas:
 - UKI-022.3 Task - Motor de requisito dinamico
   - Acceptance criteria:
     - Detecta cupos llenos.
-    - Inicia ventana 48-72h.
+    - Inicia ventana 48h.
     - Calcula quien conserva/pierde cupo al cierre.
+    - Mantiene el contador aunque el numero de cupos ocupados vuelva a bajar.
 
 Dependencias: UKI-014, UKI-021.
 
@@ -519,6 +527,8 @@ Issues hijas:
     - Entrega siempre a hora fija.
     - Respeta primera entrega tras 24h.
     - No entrega dos veces por periodo.
+    - Si el usuario pierde el cupo, conserva creditos ya asignados pero deja de recibir nuevas entregas.
+    - Si vuelve a cumplir requisito, reinicia espera minima de 24h.
 
 - UKI-023.2 Task - Job de expiracion de creditos
   - Acceptance criteria:
@@ -646,6 +656,7 @@ Issues hijas:
     - Config por wallet/slot.
     - Se aplica al recibir creditos.
     - Cambios fuera de ventana aplican al dia siguiente.
+    - Recompensa del dia se mantiene para quien aporto creditos aunque pierda el cupo antes del reparto.
 
 - UKI-040.3 Task - API disponibilidad para juegos
   - Acceptance criteria:
@@ -675,7 +686,7 @@ Issues hijas:
 
 - UKI-041.1 Task - Reglas soft staking NFT
   - Acceptance criteria:
-    - Define si se permite BSC, Tron o ambos para pool.
+    - Direccion actual: nuevas posiciones de pool solo en BSC; Tron se soporta para lectura/migracion salvo decision posterior.
     - Define unstake y efecto si el Cukie esta asignado a una partida.
     - Define prioridad Originales vs 2a Generacion.
 
@@ -683,12 +694,14 @@ Issues hijas:
   - Acceptance criteria:
     - Lock atomico via `NftInventoryService`.
     - Snapshot de elegibilidad tras 24h.
-    - Recompensas ponderadas por rareza.
+    - Recompensas ponderadas por rareza segun tramos: Todos, No Comun+, Raro+, Epico+, Legendario+, Goat, 16.66% cada uno.
+    - Originales y segunda generacion se contabilizan en pools separados.
 
 - UKI-041.3 Task - Asignacion de Cukie prestado a partida
   - Acceptance criteria:
     - Primero Originales, luego 2a Generacion.
     - Si no hay disponible, asigna Seiku ficticio.
+    - El Seiku se liquida de forma similar a Cukie Comun Original.
     - Libera lock temporal al finalizar/expirar sesion.
 
 Dependencias: UKI-021, UKI-040.
@@ -791,6 +804,7 @@ Issues hijas:
     - Si no hay, asigna creditos del pool.
     - Si hay Cukie propio con partidas, usuario selecciona.
     - Si no, asigna Cukie del pool o Seiku.
+    - Decision pendiente: validar si la seleccion manual de Cukie propio se mantiene o se automatiza.
 
 - UKI-051.2 Task - Calculo de UKI generado
   - Acceptance criteria:
@@ -807,6 +821,7 @@ Issues hijas:
   - Acceptance criteria:
     - Repartos coinciden con documento de funcionamiento.
     - Ranking solo afecta cuando usa creditos prestados.
+    - Casos exactos: prestado+prestado 50% pool creditos, 25% pool Cukies, jugador segun rank sobre resto; creditos prestados+Cukie propio 50% pool creditos y jugador segun rank sobre resto; creditos propios+Cukie prestado 50% pool Cukies y 50% jugador; propios+propio 100% jugador.
 
 - UKI-051.4 Task - Integracion con juego existente
   - Acceptance criteria:
@@ -869,19 +884,21 @@ Issues hijas:
 
 - UKI-060.1 Task - Reglas de pool de creditos
   - Acceptance criteria:
-    - Define si existe retorno minimo del 20% y como se financia.
-    - Si no esta validado, queda feature flag off.
+    - Retorno minimo inicial: equivalente a convertir 20% de creditos aportados al pool.
+    - Si el calculo diario queda por debajo de 0.75 UKI por cada 10 creditos aportados, se asigna 0.75 UKI por cada 10 creditos.
+    - Importes del pool semanal se reparten la semana siguiente en 7 entregas diarias y son adicionales al minimo diario.
 
 - UKI-060.2 Task - Reglas de pool de Cukies
   - Acceptance criteria:
-    - Ponderacion por rareza.
+    - Ponderacion por rareza en seis tramos acumulativos de 16.66%.
     - Snapshot de NFTs en pool durante periodo.
     - Originales y 2a Generacion separados si aplica.
 
 - UKI-060.3 Task - Reglas de tesoreria para UKI no convertidos
   - Acceptance criteria:
-    - 85% tesoreria/reserva/liquidez/ecosistema.
-    - 5% marketing/desarrollo.
+    - 80% tesoreria/reserva/liquidez/ecosistema.
+    - 5% marketing.
+    - 5% desarrollo.
     - 10% reduccion supply.
     - Marcado como pendiente si falta decision on-chain/off-chain.
 
@@ -955,11 +972,13 @@ Issues hijas:
     - Cada pantalla tiene CTA principal y maximo dos secundarias.
 
 - UKI-070.2 Task - Matriz de estados UX
+  - Documento: `docs/uki-ux-state-matrix.md`.
   - Acceptance criteria:
     - Empty/loading/error/success para cada pantalla.
     - Chain incorrecta y wallet desconectada definidos.
 
 - UKI-070.3 Task - Validacion de imagenes por pantalla
+  - Documento de preparacion: `docs/uki-ux-image-validation-plan.md`.
   - Acceptance criteria:
     - Cada pantalla tiene prompt validado por usuario antes de generar.
     - Cada imagen generada queda linkada en el issue correspondiente.
@@ -1205,12 +1224,14 @@ Dependencias: UKI-090.
 
 ## Bloqueadores actuales
 
-1. Confirmar si soft staking de NFTs permite BSC y Tron o solo BSC para pools.
-2. Confirmar si el retorno minimo del 20% al pool de creditos se mantiene, se elimina o queda como feature flag.
-3. Confirmar si preventa acepta solo ASM o tambien BNB/USDT.
-4. Confirmar mecanismo de claim: Merkle root o firma EIP-712.
-5. Confirmar si los UKI con vesting cuentan automaticamente para staking Cukie Master.
-6. Confirmar frases permitidas a nivel legal para rewards.
+1. Confirmar fecha exacta de inicio de preventa dentro de la primera semana de junio de 2026.
+2. Confirmar si preventa acepta solo ASM o tambien BNB/USDT, y si BNB/USDT se convierten automaticamente a ASM o se custodian para conversion posterior.
+3. Confirmar mecanismo de claim: Merkle root o firma EIP-712.
+4. Confirmar frases permitidas a nivel legal para rewards.
+5. Confirmar si la seleccion de Cukie propio en Treasure Hunt sera manual o automatica.
+6. Confirmar fechas de corte para Cukie Points generados por Cukies en staking y para detener crias.
+7. Confirmar ratio/limites finales de conversion Cukie Points -> creditos.
+8. Confirmar detalle operativo de migracion Tron -> BSC y posible cobro de TRX para fees.
 
 ## Plantilla para convertir cada bloque en GitHub Issue
 
@@ -1224,13 +1245,13 @@ Dependencias: UKI-090.
 ## Dependencias
 
 ## Tareas
-- [ ] 
+- [ ]
 
 ## Criterios de aceptacion
-- [ ] 
+- [ ]
 
 ## Tests / QA
-- [ ] 
+- [ ]
 
 ## UX image gate
 Estado: no aplica | pendiente de prompt | prompt validado | imagen generada | imagen aprobada

--- a/docs/uki-sale-contracts.md
+++ b/docs/uki-sale-contracts.md
@@ -3,6 +3,7 @@
 Estado: implementacion inicial.
 Issues: #27, #28, #29, #31, #32, #33, #35, #36, #68.
 Fecha: 2026-05-12.
+Fuente de producto vigente: `docs/uki-current-operating-rules.md` sincronizado el 2026-05-17.
 
 ## Decision de framework
 
@@ -96,6 +97,24 @@ Refund:
 - No se implementa refund automatico.
 - Una compra confirmada crea vesting.
 - Cualquier politica de refund necesita decision separada y contrato adicional o funcion admin auditada.
+
+## Parametros de producto vigentes 2026-05-17
+
+Estos parametros no deben entenderse como hardcodeados si el contrato los recibe por configuracion de deploy o admin. Son la referencia de producto actual para configurar preventa, UI y runbooks:
+
+| Parametro | Valor vigente |
+| --- | --- |
+| Inicio previsto | Primera semana de junio de 2026, fecha exacta pendiente. |
+| Duracion | 1 mes. |
+| Precio preventa | 1 UKI = 0.01 USD. |
+| Listing minimo | 1 UKI >= 0.012 USD. |
+| Medio principal de compra | ASM. |
+| Ratio ASM/UKI | Fijo al inicio de preventa segun precio de ASM en ese momento. |
+| Comprador | Vesting lineal 9 meses, sin cliff. |
+| Liquidez | ASM recaudado se usa para liquidez UKI; liquidez inicial bloqueada o quemada al menos 9 meses. |
+| BNB/USDT | Extension opcional pendiente; si se acepta, debe convertirse a ASM o reservarse para conversion posterior. |
+| Incentivos Concilium/Ascensum | Se iguala cantidad vendida a esa comunidad para Marcel; 9 meses cliff + 24 meses vesting. |
+| Ecosistema | 30,000,000 UKI liberados 40 dias tras TGE; resto 9 meses cliff + 12 meses lineal. |
 
 ## BSC testnet/mainnet
 

--- a/docs/uki-technical-disclaimers.md
+++ b/docs/uki-technical-disclaimers.md
@@ -4,6 +4,7 @@ Estado: borrador operativo.
 Issue: #25 `UKI-003.2`.
 Legal status: `needs-legal-validation`.
 Fecha: 2026-05-12.
+Fuente de reglas vigente: `docs/uki-current-operating-rules.md` sincronizado el 2026-05-17.
 
 ## Objetivo
 
@@ -40,6 +41,8 @@ Todos los textos de este documento deben mostrarse o tratarse internamente como 
 | Pool de Cukies | Aportar un Cukie al pool bloquea su uso en otras acciones mientras la posicion este activa. | `needs-legal-validation` |
 | Pool de creditos | Los creditos del pool se asignan segun disponibilidad y reglas del periodo. No representan tokens ni saldo transferible. | `needs-legal-validation` |
 | Creditos diarios | Los creditos son recursos internos de juego. Pueden expirar o cambiar segun reglas operativas publicadas. | `needs-legal-validation` |
+| Migracion BSC | Las nuevas acciones de staking y pools pueden requerir BNB Smart Chain. Los activos en Tron pueden necesitar migracion antes de participar. | `needs-legal-validation` |
+| Cukie Points | Los Cukie Points son recursos internos sujetos a reglas de conversion, limites diarios y fechas de corte publicadas. | `needs-legal-validation` |
 | Rewards estimadas | Esta cifra es una estimacion calculada off-chain y puede cambiar antes del cierre del periodo. | `needs-legal-validation` |
 | Rewards pendientes | Las rewards pendientes aun no estan disponibles para claim. Deben cerrarse, validarse y publicarse en un batch. | `needs-legal-validation` |
 | Rewards claimable | Estas rewards tienen datos de claim preparados. La recepcion final depende de la transaccion y confirmacion on-chain. | `needs-legal-validation` |
@@ -120,4 +123,3 @@ Alternativas preferidas:
 - Los botones de accion on-chain deben enlazar o exponer tx hash cuando exista.
 - Las APIs deben devolver codigos de estado que permitan mostrar disclaimers correctos.
 - No mezclar creditos internos con UKI transferible.
-

--- a/docs/uki-ux-image-validation-plan.md
+++ b/docs/uki-ux-image-validation-plan.md
@@ -1,0 +1,205 @@
+# UKI UX image validation plan
+
+Estado: prompts preparados, imagenes no generadas.
+Issues: #145 `UKI-004.4`, #112 `UKI-070.3`.
+Fecha: 2026-05-17.
+Fuentes: `docs/uki-brand-token-book.md`, `docs/uki-dapp-sitemap.md`, `docs/uki-ux-state-matrix.md`, `docs/uki-current-operating-rules.md`.
+
+## Regla de gate
+
+No se genera ninguna imagen de pantalla hasta que producto apruebe el prompt correspondiente. Ninguna imagen generada se usa como referencia final de implementacion sin aprobacion posterior.
+
+Este documento deja preparados prompts y criterios de validacion. El estado actual de todas las pantallas es `prompt draft`.
+
+## Proceso
+
+1. Producto revisa el prompt de una pantalla.
+2. Si lo aprueba, se genera una imagen horizontal de referencia para esa pantalla.
+3. La imagen se enlaza en la issue correspondiente.
+4. Producto aprueba, rechaza o pide iteracion.
+5. Solo con imagen aprobada se puede implementar restyling visual final, salvo excepcion explicita.
+
+## Criterios de rechazo
+
+Rechazar una propuesta visual si:
+
+- Parece una presentacion/deck en vez de una pantalla navegable.
+- Usa una landing generica con hero decorativo sin producto visible.
+- Mezcla preventa, Cukie Master, ranking, pools y rewards como si todo estuviera activo.
+- Promete rentabilidad, retorno garantizado o resultados economicos no aprobados.
+- Oculta estados importantes: compra cerrada, wallet desconectada, chain incorrecta, vesting, bloqueo o coming next.
+- Usa una paleta monocromatica sin jerarquia funcional.
+- Abusa de cards decorativas, glow o composicion de marketing sin controles reales.
+- No deja claro que la fase actual es Phase 0 / compra cerrada.
+
+## Criterios de aprobacion
+
+Una imagen puede aprobarse si:
+
+- La pantalla tiene una responsabilidad unica.
+- El CTA principal coincide con el sitemap.
+- Los estados bloqueados o coming next son visibles sin parecer error.
+- La jerarquia visual permite escanear: estado, accion, datos clave y siguiente paso.
+- Usa Cukies como identidad, pero UKI y BSC transmiten confianza y claridad.
+- Mantiene lenguaje legalmente prudente.
+- Puede implementarse con componentes reales de la dapp sin inventar flujos.
+
+## Pantallas iniciales #145
+
+### Landing / Launch
+
+Estado: `prompt draft`.
+Issue: #145.
+Ruta: `/`.
+
+Prompt propuesto:
+
+```text
+Pantalla web horizontal para Cukies World UKI launch, Phase 0 compra cerrada. Landing navegable, no deck. Hero con modulo real de preventa en estado coming soon, precio 0.01 USD, compra principal con ASM, BNB Smart Chain, vesting 9 meses y listing minimo 0.012. Visual premium gaming-finance, oscuro verdoso con acentos gold/teal controlados, Cukie como identidad jugable y UKI coin/vault como senal de token. Secciones visibles: sale facts, como comprar, token trust, Cukie Master coming next, Treasure Hunt primer juego. Sin promesas de rentabilidad, sin claims activos, sin dashboard completo, sin composicion de presentacion.
+```
+
+Debe mostrar:
+
+- Fase actual: compra cerrada / coming soon.
+- CTA principal hacia preventa o aviso.
+- Sale facts escaneables.
+- Cukie Master y Treasure Hunt como utilidad posterior, no accion activa.
+
+No debe mostrar:
+
+- Claimable rewards.
+- Ranking activo.
+- Staking activo.
+- ROI, APY o retornos prometidos.
+
+### Preventa UKI
+
+Estado: `prompt draft`.
+Issue: #145.
+Ruta: `/presale`.
+
+Prompt propuesto:
+
+```text
+Pantalla de preventa UKI para una dapp en BNB Smart Chain, estado compra cerrada o prelaunch. Interfaz funcional, no landing generica. Panel principal ASM -> UKI con wallet desconectada y chain status, precio 0.01 USD, ratio ASM/UKI pendiente de fijar al inicio, duracion 1 mes, vesting comprador 9 meses lineal sin cliff, liquidez ASM -> UKI con bloqueo/quema minimo 9 meses. Layout denso pero claro, controles reales de connect wallet, approve ASM deshabilitado, buy UKI deshabilitado hasta apertura, resumen de tokenomics y enlaces BscScan/config. Dark mode teal/gold sobrio, sin promesas de rentabilidad.
+```
+
+Debe mostrar:
+
+- Wallet desconectada o compra cerrada como estado esperado.
+- Bloqueo de approve/buy mientras no abra la venta.
+- Ratio ASM como dato pendiente hasta inicio.
+- Vesting y liquidez visibles.
+
+No debe mostrar:
+
+- BNB/USDT como flujo activo.
+- Rewards o Cukie Master como accion actual.
+- Compra confirmada ficticia.
+
+### Dashboard Wallet
+
+Estado: `prompt draft`.
+Issue: #145.
+Ruta: `/wallet`.
+
+Prompt propuesto:
+
+```text
+Dashboard wallet para economia Cukies UKI en prelaunch, pantalla de producto densa y operativa. Resumen de wallet conectada o estado desconectado, UKI comprado/staked, NFTs disponibles o bloqueados, creditos, cupos Cukie Master, rewards pendientes y alertas de chain/bridge/listing. Debe diferenciar datos activos, coming next y datos bloqueados. Estilo app gaming-finance, oscuro, teal/gold, tablas compactas, badges de estado, sin hero marketing. No mostrar rewards como claimable si no hay batch/proof.
+```
+
+Debe mostrar:
+
+- Alertas de chain/datos stale.
+- Modulos separados para UKI, NFTs, creditos, cupos y rewards.
+- Estados bloqueados/coming next.
+
+No debe mostrar:
+
+- Compra principal dentro del dashboard.
+- Configuracion avanzada de pools.
+- Claims finales sin proof.
+
+### Cukie Master
+
+Estado: `prompt draft`.
+Issue: #145.
+Ruta: `/cukie-master`.
+
+Prompt propuesto:
+
+```text
+Pantalla Cukie Master para Cukies World UKI, fase coming next. Dos rutas de cupos: staking UKI y puntos de Cukies Originales. Mostrar 500 cupos iniciales por ruta, maximo 5 cupos por wallet, requisito 20,000 UKI por cupo, 3 puntos de Cukies Originales, UKI con vesting cuenta para cupos, espera 24h para creditos diarios y aviso de requisito dinamico con ventana 48h. UI operativa con contadores, sliders/inputs de stake, tabla de rarezas, alertas claras, dark mode teal/gold. Sin ranking completo, sin partida concreta, sin prometer recompensas economicas.
+```
+
+Debe mostrar:
+
+- Dos rutas separadas.
+- Limite 5 cupos por wallet.
+- Requisito dinamico y aviso 48h.
+- Fase posterior/coming next si no esta activo.
+
+No debe mostrar:
+
+- Cukies prestados como disponibles si estan stakeados para Cukie Master.
+- Recompensas garantizadas como promesa financiera.
+
+### Games Entry / App Shell
+
+Estado: `prompt draft`.
+Issue: #145.
+Ruta: `/games/treasure-hunt` o shell de juegos.
+
+Prompt propuesto:
+
+```text
+Pantalla de entrada a juegos de Cukies UKI con Treasure Hunt como primer juego, no como economia completa. App shell navegable con sidebar/header compacto, wallet status, creditos disponibles, Cukie propio o pool/Seiku, coste 10 creditos, 2.5 al pool semanal y 7.5 en juego, ranking semanal solo para partidas con creditos del pool. Mostrar estados de recursos reservados y start run bloqueado si faltan recursos. Estilo game UI funcional, oscuro, claro para jugar, sin landing ni deck, sin promesas de rentabilidad.
+```
+
+Debe mostrar:
+
+- Treasure Hunt como primer juego conectado.
+- Coste y recursos necesarios.
+- Diferencia entre creditos propios y creditos del pool.
+- Preparacion de sesion antes de entrar al juego.
+
+No debe mostrar:
+
+- Treasure Hunt como unico futuro del ecosistema.
+- Score/reward final sin validacion.
+- Ranking aplicado a creditos propios.
+
+## Pantallas de segunda tanda #112
+
+Estas pantallas pueden prepararse despues de validar la tanda inicial.
+
+| Pantalla | Estado | Prompt base |
+| --- | --- | --- |
+| Pool de Creditos | `prompt draft` | Pantalla operativa para configurar creditos diarios en multiplos de 10 antes de la hora de corte, ledger de grants/spend/deposit/expire, pool availability, minimo 0.75 UKI por cada 10 creditos si aplica, coming next si fase cerrada. |
+| Pool de Cukies | `prompt draft` | Gestion de pool BSC-only para nuevas posiciones, inventario de Cukies con rareza/generacion, Originales y segunda generacion separados, locks, partidas disponibles y rewards/allocations sin promesas. |
+| Arena Ranking | `prompt draft` | Dashboard de ranking semanal #1-#9, rank actual/anterior, partidas validas, minimos 20 para subir y 10 para bajar, movimiento maximo +2/-2, sin claim directo. |
+| Rewards Claim | `prompt draft` | Pantalla de rewards pendientes/claimable por batch, proof status, claim on-chain en BSC, historial y estados pending/confirmed, sin mostrar estimaciones como claimable. |
+| Admin/Ops | `prompt draft` | Consola interna compacta para jobs, snapshots, reward batches, Merkle roots, inconsistencias NFT, parametros por juego y auditoria, fuera de navegacion publica. |
+
+## Registro de validacion
+
+| Pantalla | Prompt | Imagen | Decision | Issue |
+| --- | --- | --- | --- | --- |
+| Landing / Launch | Draft pendiente | No generada | Pendiente | #145 |
+| Preventa UKI | Draft pendiente | No generada | Pendiente | #145 |
+| Dashboard Wallet | Draft pendiente | No generada | Pendiente | #145 |
+| Cukie Master | Draft pendiente | No generada | Pendiente | #145 |
+| Games Entry / App Shell | Draft pendiente | No generada | Pendiente | #145 |
+| Pool de Creditos | Draft pendiente | No generada | Pendiente | #112 |
+| Pool de Cukies | Draft pendiente | No generada | Pendiente | #112 |
+| Arena Ranking | Draft pendiente | No generada | Pendiente | #112 |
+| Rewards Claim | Draft pendiente | No generada | Pendiente | #112 |
+| Admin/Ops | Draft pendiente | No generada | Pendiente | #112 |
+
+## Notas para implementacion posterior
+
+- Las imagenes aprobadas son direccion visual, no fuente de reglas economicas.
+- Si una imagen contradice `docs/uki-current-operating-rules.md`, gana el documento de reglas.
+- Si una pantalla necesita estado no cubierto, se actualiza primero `docs/uki-ux-state-matrix.md`.
+- El restyling final de #146 debe consumir imagenes aprobadas o una excepcion explicita documentada en la issue.

--- a/docs/uki-ux-state-matrix.md
+++ b/docs/uki-ux-state-matrix.md
@@ -1,0 +1,174 @@
+# UKI UX state matrix
+
+Estado: especificacion UX inicial para implementacion.
+Issue: #111 `UKI-070.2`.
+Fecha: 2026-05-17.
+Fuentes: `docs/uki-dapp-sitemap.md`, `docs/uki-current-operating-rules.md`, `docs/uki-technical-disclaimers.md`.
+
+## Objetivo
+
+Definir estados de UI para cada pantalla de la dapp UKI antes de implementar restyling o pantallas finales. La matriz evita que una pantalla mezcle responsabilidades o prometa acciones que todavia no estan disponibles.
+
+## Estados globales
+
+Estos estados se aplican a cualquier pantalla que dependa de wallet, red, datos on-chain o APIs internas.
+
+| Estado | Cuando aparece | UI esperada | Accion principal | No hacer |
+| --- | --- | --- | --- | --- |
+| Wallet desconectada | No hay wallet conectada y la pantalla necesita datos personales o transaccion. | Estado vacio con explicacion corta y bloque de datos publicos si aplica. | Connect wallet. | Mostrar balances ficticios o rewards personales. |
+| Chain incorrecta | Wallet conectada en red distinta de BNB Smart Chain para accion UKI. | Banner persistente y bloqueo de acciones on-chain. | Switch to BNB Smart Chain. | Permitir compra, staking, claim o pool actions. |
+| Datos cargando | API, indexer o contrato aun responde. | Skeletons con estructura real de pantalla. | Ninguna o cancelar si aplica. | Cambiar layout al terminar de cargar. |
+| Datos sincronizando | Hay cache parcial o indexer retrasado. | Aviso de sincronizacion y datos en solo lectura cuando sea seguro. | Retry / refresh. | Permitir acciones economicas si falta reconciliacion. |
+| Error recuperable | API/contrato falla pero el usuario puede reintentar. | Mensaje tecnico corto, codigo si existe y accion retry. | Retry. | Perder contexto de formulario o seleccion. |
+| Accion pendiente | Hay tx o job pendiente. | Estado de progreso con hash/job id cuando exista. | View on BscScan / View status. | Duplicar la accion sin idempotencia. |
+| Accion confirmada | Tx/evento/job confirmado. | Confirmacion discreta y siguiente paso claro. | Continue / view details. | Marcar claim/compra como final sin evento confirmado. |
+| Coming next | La fase no esta abierta pero se comunica utilidad futura. | Preview bloqueada con fase y criterio de apertura. | Read details / Join presale. | Simular disponibilidad real. |
+
+## Landing / Launch
+
+Ruta: `/`
+
+| Estado | UI esperada | Accion principal | Secundarias |
+| --- | --- | --- | --- |
+| Publica ready | Hero de preventa cerrada, facts de UKI, BSC, ASM, vesting y utilidad futura. | Join UKI presale / Notify me segun estado real. | Read sale details, View Treasure Hunt. |
+| Preventa aun cerrada | Mostrar fecha prevista o "coming soon" sin formulario transaccional. | Read sale details. | Connect wallet opcional si aporta valor. |
+| Wallet desconectada | Landing sigue siendo navegable; modulo de compra muestra preview sin datos personales. | Connect wallet. | Read sale details. |
+| Chain incorrecta | Banner si wallet conectada, sin bloquear lectura publica. | Switch network. | Read sale details. |
+| Datos cargando | Skeleton solo para status strip/modulo dinamico. | Ninguna. | Ninguna. |
+| Error de status | Mantener landing y marcar status de preventa como no disponible. | Retry status. | Read docs. |
+
+## Preventa UKI
+
+Ruta: `/presale`
+
+| Estado | UI esperada | Accion principal | Secundarias |
+| --- | --- | --- | --- |
+| Preventa cerrada | Condiciones visibles: precio 0.01 USD, duracion 1 mes, ASM, vesting 9 meses, liquidez. Compra bloqueada. | Connect wallet / Read rules. | View vesting rules. |
+| Wallet desconectada | Formulario en modo preview sin allowance ni balance personal. | Connect wallet. | Read sale details. |
+| Chain incorrecta | Compra, approve y vesting personal bloqueados. | Switch to BNB Smart Chain. | View public sale facts. |
+| Sin allowance ASM | Balance visible; compra bloqueada hasta approve. | Approve ASM. | Edit amount. |
+| Allowance suficiente | Quote ASM -> UKI, vesting preview y riesgos visibles. | Buy UKI. | Edit amount, View BscScan config. |
+| Compra pendiente | Hash visible, formulario bloqueado e idempotencia por tx. | View on BscScan. | Return to wallet. |
+| Compra confirmada | Resumen comprado, vesting creado/pendiente de indexar. | View vesting. | Go to wallet. |
+| Sale cap agotado | Compra bloqueada; explicar que preventa esta agotada. | View wallet. | Read tokenomics. |
+| Error compra | Mantener amount/quote y mostrar motivo: allowance, cap, ventana, red o contrato pausado. | Retry. | Edit amount. |
+
+## Dashboard Wallet
+
+Ruta: `/wallet`
+
+| Estado | UI esperada | Accion principal | Secundarias |
+| --- | --- | --- | --- |
+| Wallet desconectada | Estado vacio con valor de conectar: UKI, NFTs, creditos, cupos. | Connect wallet. | Read sale details. |
+| Chain incorrecta | Datos cacheados en solo lectura si son seguros; acciones bloqueadas. | Switch network. | Refresh data. |
+| Loading | Skeleton por modulos: UKI, NFTs, creditos, rewards, alerts. | Ninguna. | Ninguna. |
+| Sin actividad | Wallet conectada sin compra/stake/NFT detectado. | Go to presale. | Read Cukie Master. |
+| Datos inconsistentes | Alertas por NFT/listing/bridge/indexer; acciones sensibles bloqueadas. | Refresh / contact support. | View details. |
+| Ready | Resumen personal con alertas priorizadas y enlaces a pantallas especializadas. | Review wallet status. | Go to Cukie Master, View rewards. |
+
+## Cukie Master
+
+Ruta: `/cukie-master`
+
+| Estado | UI esperada | Accion principal | Secundarias |
+| --- | --- | --- | --- |
+| Coming next | Explica cupos, rutas y regla de 24h sin permitir staking si la fase no esta abierta. | Read rules. | Go to presale. |
+| Wallet desconectada | Preview de rutas y puntos por rareza; sin calculo personal. | Connect wallet. | Read rules. |
+| Chain incorrecta | Acciones UKI/NFT BSC bloqueadas. | Switch network. | View read-only summary. |
+| Sin cupos | Muestra requisito actual: 20,000 UKI o 3 puntos Cukies Originales. | Stake UKI / Review NFTs. | Go to presale. |
+| Cupo activo | Cupos, espera 24h, creditos futuros y exceso stakeado. | Manage slots. | Configure credits. |
+| Requisito subiendo | Aviso fuerte: requisito anterior/nuevo, cantidad adicional, fecha limite 48h y cupos que perderia. | Add stake / add points. | View deadline. |
+| Unstake pendiente | Impacto claro en cupos y creditos futuros. | Confirm unstake. | Cancel. |
+
+## Pool de Creditos
+
+Ruta: `/pools/credits`
+
+| Estado | UI esperada | Accion principal | Secundarias |
+| --- | --- | --- | --- |
+| Coming next | Explica aportes diarios y minimo vigente sin permitir configuracion. | Read rules. | Go to Cukie Master. |
+| Sin cupo Cukie Master | Bloquear configuracion; explicar requisito. | Go to Cukie Master. | View rules. |
+| Antes del corte | Permitir configurar multiplos de 10 para la proxima entrega. | Configure credits. | View ledger. |
+| Despues del corte | Mostrar que cambios aplican al dia siguiente. | Schedule change. | View today's pool. |
+| Sin creditos | Ledger visible; no permitir depositar manualmente si no hay creditos. | View next grant. | Go to Cukie Master. |
+| Ready | Balance, configuracion, pool availability, minimo 0.75 UKI/10 creditos si aplica. | Configure credits. | View pool history. |
+| Error ledger | Mantener configuracion local en solo lectura y permitir retry. | Retry. | Export visible rows. |
+
+## Pool de Cukies
+
+Ruta: `/pools/cukies`
+
+| Estado | UI esperada | Accion principal | Secundarias |
+| --- | --- | --- | --- |
+| Coming next | Explica BSC-only para nuevas posiciones y separacion Originales/2a gen. | Read rules. | Go to wallet. |
+| Wallet desconectada | Preview de rarezas, partidas y reparto; sin inventario personal. | Connect wallet. | Read rules. |
+| Chain incorrecta | Acciones bloqueadas; inventario Tron solo como lectura/migracion si existe. | Switch network. | View migration note. |
+| Sin Cukies elegibles | Explica si faltan NFTs, estan en Tron, listados, bridge o bloqueados. | View wallet. | Refresh inventory. |
+| Cukie bloqueado | Mostrar razon: listed, bridging, in pool, assigned, soft staked, invalidated. | View details. | Refresh. |
+| Ready | Lista densa de Cukies elegibles con rareza, generacion, partidas y estado. | Add Cukie to pool. | Withdraw Cukie, View rewards. |
+| Retirada pendiente | Si esta asignado a partida, mostrar bloqueo/expiracion. | Request withdrawal. | View assignment. |
+
+## Treasure Hunt Entry
+
+Ruta: `/games/treasure-hunt`
+
+| Estado | UI esperada | Accion principal | Secundarias |
+| --- | --- | --- | --- |
+| Coming next | Explica coste 10 creditos, 2.5 pool semanal y 7.5 en juego. | View rules. | Go to wallet. |
+| Wallet desconectada | Reglas publicas y bloqueo de start. | Connect wallet. | View rules. |
+| Sin creditos propios | Intentar asignar pool solo al iniciar, mostrando disponibilidad. | Start with pool credits. | View pool status. |
+| Con creditos propios | Indicar que no computa ranking ni usa rank para settlement. | Start run. | Select Cukie. |
+| Sin Cukie propio disponible | Mostrar asignacion de pool/Seiku al iniciar. | Start with pool Cukie. | View rules. |
+| Cukie propio disponible | Selector o decision automatica pendiente; mostrar impacto de partidas disponibles. | Select Cukie. | Start run. |
+| Recursos reservando | Bloquear doble start hasta session economy id. | Ninguna. | Cancel si backend lo permite. |
+| Session ready | Entrar al juego con token de sesion. | Start run. | View session details. |
+| Score enviado | Resultado en revision antes de ranking/rewards. | View result. | Go to Arena. |
+
+## Arena Ranking
+
+Ruta: `/arena`
+
+| Estado | UI esperada | Accion principal | Secundarias |
+| --- | --- | --- | --- |
+| Coming next | Explica ranking #1-#9 y minimos sin clasificacion activa. | Read rules. | View Treasure Hunt. |
+| Wallet desconectada | Ranking publico si existe; datos personales ocultos. | Connect wallet. | View rules. |
+| Sin partidas rankeables | Rank inicial #5 o sin periodo; explicar que solo cuentan creditos del pool. | Play Treasure Hunt. | View rules. |
+| Periodo activo | Rank actual, progreso, partidas validas, % conversion sin 2.5 iniciales. | View my rank. | View weekly rules. |
+| Cierre en progreso | Congelar cambios visibles y mostrar periodo en calculo. | Refresh. | View previous period. |
+| Ready cerrado | Rank final, movimiento +2/-2 aplicado y enlace a rewards pendientes. | View rewards. | Open history. |
+
+## Rewards Claim
+
+Ruta: `/rewards`
+
+| Estado | UI esperada | Accion principal | Secundarias |
+| --- | --- | --- | --- |
+| Wallet desconectada | Explica pending vs claimable sin datos personales. | Connect wallet. | Read disclaimers. |
+| Chain incorrecta | Claims bloqueados; historial cacheado en solo lectura si es seguro. | Switch network. | View history. |
+| Sin rewards | Empty state con origenes posibles: preventa, Cukie Master, pools, ranking. | Go to wallet. | View rules. |
+| Pending rewards | Mostrar como no claimable hasta batch/proof. | View pending details. | Refresh. |
+| Claimable | Mostrar batch/proof, importe y disclaimer final on-chain. | Claim rewards. | View proof. |
+| Claim pendiente | Hash visible y boton BscScan. | View on BscScan. | Refresh. |
+| Claim confirmado | Estado confirmed solo con evento on-chain indexado. | View history. | Go to wallet. |
+| Error claim | Mantener batch/proof y motivo de fallo. | Retry claim. | View details. |
+
+## Admin / Ops
+
+Ruta: `/admin/ops`
+
+| Estado | UI esperada | Accion principal | Secundarias |
+| --- | --- | --- | --- |
+| No autorizado | Bloqueo total sin datos sensibles. | Return home. | Contact admin. |
+| Loading | Skeleton de jobs, batches, snapshots, inconsistencias. | Ninguna. | Ninguna. |
+| Sin acciones pendientes | Estado limpio con ultimo job y proximo run. | Review schedule. | Export report. |
+| Acciones pendientes | Cola priorizada: jobs fallidos, batch approval, inconsistencias NFT, parametros. | Review pending actions. | Open job monitor. |
+| Error job | Mostrar jobRunId, periodo, input hash y retry seguro. | Retry job. | Export logs. |
+| Accion sensible | Confirmacion con actor, motivo y previsualizacion de impacto. | Confirm action. | Cancel. |
+
+## Reglas de implementacion
+
+- Los componentes deben reservar espacio estable para cada estado y evitar saltos de layout.
+- Los estados `pending`, `claimable`, `confirmed` y `failed` deben tener origen claro: contrato, backend, job o cache.
+- La UI puede mostrar previews, pero debe etiquetarlos como previews y no como saldos finales.
+- La pantalla no decide elegibilidad final; consume APIs de dominio o lectura de contrato.
+- Las acciones economicas necesitan idempotencia por tx, session id o jobRunId.


### PR DESCRIPTION
## Linked issues

Closes #111.
Refs #141, #145, #112.

## Summary

- Adds `docs/uki-current-operating-rules.md` as the current product-rule source from the new `Funcionamiento.docx` and `Preventa UKI.docx`.
- Updates technical docs/backlog/sitemap/brand/disclaimer references that were stale or still marked as pending.
- Adds `docs/uki-ux-state-matrix.md` with wallet, chain, loading, empty, error, pending and success states by screen.
- Adds `docs/uki-ux-image-validation-plan.md` with prompt drafts and validation/rejection criteria for #145/#112, without generating images.
- Implements the first landing/presale UX-state slice: runtime sale status from `/api/presale/status`, wallet disconnected/wrong-chain/ready callouts, pending-contract state, no hardcoded ASM ratio, no exact countdown unless configured, and safer public copy around rewards/pools.

## Validation

- `git diff --check` OK.
- `pnpm exec next lint --file ...` OK for the touched landing files.
- `pnpm dapp lint` still fails on pre-existing unrelated lint errors in `leaderboard`, `points`, `profile`, `quests`, and existing hook warnings outside this change.
- `pnpm dapp typecheck` still fails on pre-existing unrelated errors in generated `.next` API route types, `__tests__/components/stats-cards.test.tsx`, Telegram scripts, and chat API routes.
- Playwright loaded `http://localhost:3001` desktop and mobile: landing rendered with 0 console errors and 1 existing Next image sizing warning; Games images load after scrolling into viewport.

## Notes

- #145 and #112 are intentionally not closed: prompts are prepared, but product validation and image generation/approval are still pending.
- Existing unrelated `.gitignore` change was left unstaged and is not part of this PR.
