### PR TITLE
fix: prevent intermittent marketplace flicker

### DIFF
--- a/dapp/src/components/layout/app-layout.tsx
+++ b/dapp/src/components/layout/app-layout.tsx
@@ -328,38 +328,40 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
             backgroundSize: '120px 120px'
           }}></div>
           
-          {/* Ambient light effects */}
-          <div className={`absolute top-0 left-1/4 w-96 h-96 bg-teal-400/10 rounded-full blur-3xl ${isMarketplaceSection ? '' : 'animate-pulse'}`}></div>
-          <div className={`absolute bottom-0 right-1/4 w-80 h-80 bg-teal-400/8 rounded-full blur-3xl ${isMarketplaceSection ? '' : 'animate-pulse delay-1000'}`}></div>
-          <div className={`absolute top-1/2 left-1/2 w-72 h-72 bg-cyan-500/5 rounded-full blur-3xl ${isMarketplaceSection ? '' : 'animate-pulse delay-2000'}`}></div>
-          
-          {/* Floating gradients */}
-          <div className="absolute inset-0 overflow-hidden pointer-events-none">
-            <div className={`absolute -top-40 -right-40 w-80 h-80 bg-gradient-radial from-cyan-300/20 via-teal-400/10 to-transparent rounded-full blur-xl ${isMarketplaceSection ? '' : 'floating'}`}></div>
-            <div className={`absolute -bottom-32 -left-32 w-64 h-64 bg-gradient-radial from-cyan-300/15 via-teal-400/8 to-transparent rounded-full blur-xl ${isMarketplaceSection ? '' : 'floating delay-3000'}`}></div>
-          </div>
-          
-          {/* Animated decorative lines */}
-          <div className="absolute inset-0 overflow-hidden pointer-events-none">
-            <div className={`absolute top-1/4 left-0 w-full h-px bg-gradient-to-r from-transparent via-teal-400/30 to-transparent transform -rotate-12 ${isMarketplaceSection ? '' : 'animate-pulse'}`}></div>
-            <div className={`absolute bottom-1/3 right-0 w-full h-px bg-gradient-to-l from-transparent via-teal-400/20 to-transparent transform rotate-12 ${isMarketplaceSection ? '' : 'animate-pulse delay-1500'}`}></div>
-          </div>
-          
-          {/* Decorative floating particles */}
-          <div className="absolute inset-0 overflow-hidden pointer-events-none">
-            <div className={`absolute top-20 left-20 w-2 h-2 bg-cyan-300/60 rounded-full ${isMarketplaceSection ? '' : 'floating-slow'}`}></div>
-            <div className={`absolute top-40 right-32 w-1 h-1 bg-cyan-300/40 rounded-full ${isMarketplaceSection ? '' : 'floating-slow delay-2000'}`}></div>
-            <div className={`absolute bottom-32 left-1/3 w-3 h-3 bg-cyan-400/30 rounded-full ${isMarketplaceSection ? '' : 'floating-slow delay-4000'}`}></div>
-            <div className={`absolute top-1/2 right-20 w-1.5 h-1.5 bg-cyan-200/50 rounded-full ${isMarketplaceSection ? '' : 'floating-slow delay-6000'}`}></div>
-            <div className={`absolute bottom-20 right-1/4 w-2 h-2 bg-cyan-200/40 rounded-full ${isMarketplaceSection ? '' : 'floating-slow delay-8000'}`}></div>
-          </div>
-          
-          {/* Energy waves */}
           {!isMarketplaceSection && (
-            <div className="absolute inset-0 overflow-hidden pointer-events-none opacity-20">
-              <div className="absolute top-0 left-0 w-full h-2 bg-gradient-to-r from-teal-400/0 via-teal-400/30 to-teal-400/0 wave-animation"></div>
-              <div className="absolute bottom-0 right-0 w-full h-1 bg-gradient-to-l from-teal-400/0 via-teal-400/20 to-teal-400/0 wave-animation delay-4000"></div>
-            </div>
+            <>
+              {/* Ambient light effects */}
+              <div className="absolute top-0 left-1/4 w-96 h-96 bg-teal-400/10 rounded-full blur-3xl animate-pulse"></div>
+              <div className="absolute bottom-0 right-1/4 w-80 h-80 bg-teal-400/8 rounded-full blur-3xl animate-pulse delay-1000"></div>
+              <div className="absolute top-1/2 left-1/2 w-72 h-72 bg-cyan-500/5 rounded-full blur-3xl animate-pulse delay-2000"></div>
+              
+              {/* Floating gradients */}
+              <div className="absolute inset-0 overflow-hidden pointer-events-none">
+                <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-radial from-cyan-300/20 via-teal-400/10 to-transparent rounded-full blur-xl floating"></div>
+                <div className="absolute -bottom-32 -left-32 w-64 h-64 bg-gradient-radial from-cyan-300/15 via-teal-400/8 to-transparent rounded-full blur-xl floating delay-3000"></div>
+              </div>
+              
+              {/* Animated decorative lines */}
+              <div className="absolute inset-0 overflow-hidden pointer-events-none">
+                <div className="absolute top-1/4 left-0 w-full h-px bg-gradient-to-r from-transparent via-teal-400/30 to-transparent transform -rotate-12 animate-pulse"></div>
+                <div className="absolute bottom-1/3 right-0 w-full h-px bg-gradient-to-l from-transparent via-teal-400/20 to-transparent transform rotate-12 animate-pulse delay-1500"></div>
+              </div>
+              
+              {/* Decorative floating particles */}
+              <div className="absolute inset-0 overflow-hidden pointer-events-none">
+                <div className="absolute top-20 left-20 w-2 h-2 bg-cyan-300/60 rounded-full floating-slow"></div>
+                <div className="absolute top-40 right-32 w-1 h-1 bg-cyan-300/40 rounded-full floating-slow delay-2000"></div>
+                <div className="absolute bottom-32 left-1/3 w-3 h-3 bg-cyan-400/30 rounded-full floating-slow delay-4000"></div>
+                <div className="absolute top-1/2 right-20 w-1.5 h-1.5 bg-cyan-200/50 rounded-full floating-slow delay-6000"></div>
+                <div className="absolute bottom-20 right-1/4 w-2 h-2 bg-cyan-200/40 rounded-full floating-slow delay-8000"></div>
+              </div>
+              
+              {/* Energy waves */}
+              <div className="absolute inset-0 overflow-hidden pointer-events-none opacity-20">
+                <div className="absolute top-0 left-0 w-full h-2 bg-gradient-to-r from-teal-400/0 via-teal-400/30 to-teal-400/0 wave-animation"></div>
+                <div className="absolute bottom-0 right-0 w-full h-1 bg-gradient-to-l from-teal-400/0 via-teal-400/20 to-teal-400/0 wave-animation delay-4000"></div>
+              </div>
+            </>
           )}
           
           <Header />

--- a/dapp/src/components/layout/header.tsx
+++ b/dapp/src/components/layout/header.tsx
@@ -107,17 +107,6 @@ export default function Header() {
     }
   };
 
-  if (isAuthLoading) {
-    return (
-      <header className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-4 border-b bg-background px-4 sm:px-6">
-        <div className="flex-1"></div>
-        <Button variant="outline" disabled>
-          <p>Loading...</p>
-        </Button>
-      </header>
-    )
-  }
-
   return (
     <header className="sticky top-0 z-50 flex h-16 shrink-0 items-center gap-4 border-b border-teal-400/20 bg-black/25 backdrop-blur-md shadow-lg shadow-teal-400/10 px-4 sm:px-6">
       <Button
@@ -233,7 +222,7 @@ export default function Header() {
           <>
             <Button 
               onClick={() => !isWaitingForApproval && setIsWalletDialogOpen(true)} 
-              disabled={isWaitingForApproval}
+              disabled={isWaitingForApproval || isAuthLoading}
               className={`${
                 isWaitingForApproval 
                   ? "bg-gradient-to-r from-amber-500 to-orange-600 cursor-not-allowed" 
@@ -242,10 +231,12 @@ export default function Header() {
                 isWaitingForApproval ? "shadow-amber-500/30 animate-pulse" : "shadow-teal-400/30"
               }`}
             >
-              {isWaitingForApproval ? (
+              {isWaitingForApproval || isAuthLoading ? (
                 <>
                   <div className="animate-spin rounded-full h-4 w-4 border-2 border-white border-t-transparent md:mr-2" />
-                  <span className="hidden md:inline">Waiting for Approval...</span>
+                  <span className="hidden md:inline">
+                    {isWaitingForApproval ? 'Waiting for Approval...' : 'Loading...'}
+                  </span>
                 </>
               ) : (
                 <>

--- a/dapp/src/components/legacy-marketplace/marketplace-client.tsx
+++ b/dapp/src/components/legacy-marketplace/marketplace-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Filter, RefreshCw, Search } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -36,6 +36,7 @@ export function MarketplaceClient() {
   const [offset, setOffset] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [reloadKey, setReloadKey] = useState(0);
+  const requestIdRef = useRef(0);
 
   const queryString = useMemo(() => {
     const params = new URLSearchParams({
@@ -55,6 +56,8 @@ export function MarketplaceClient() {
 
   useEffect(() => {
     const controller = new AbortController();
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
     setIsLoading(true);
 
     fetch(`/api/cukies?${queryString}`, {
@@ -62,16 +65,22 @@ export function MarketplaceClient() {
     })
       .then(async (response) => {
         const payload = (await response.json()) as LegacyMarketplaceListResponse;
+        if (controller.signal.aborted || requestId !== requestIdRef.current) return;
         setData(payload);
       })
       .catch((error) => {
         if (error instanceof Error && error.name === 'AbortError') return;
+        if (controller.signal.aborted || requestId !== requestIdRef.current) return;
         setData({
           ...initialData,
           error: error instanceof Error ? error.message : 'Marketplace error',
         });
       })
-      .finally(() => setIsLoading(false));
+      .finally(() => {
+        if (!controller.signal.aborted && requestId === requestIdRef.current) {
+          setIsLoading(false);
+        }
+      });
 
     return () => controller.abort();
   }, [queryString, reloadKey]);


### PR DESCRIPTION
## Summary
- Keep the app header mounted while auth refreshes, avoiding full header swaps during intermittent wallet/auth loading.
- Guard marketplace fetch state updates so aborted or stale requests cannot flip loading/data state out of order.
- Remove decorative blur/particle/wave layers entirely on marketplace pages while keeping the base dashboard background.

## Validation
- `pnpm dapp lint` OK, no warnings or errors
- `pnpm dapp typecheck` OK
- `curl -I http://127.0.0.1:3000/marketplace` returned `200 OK`

## Notes
- Local unrelated `.gitignore` change was left unstaged.