### PR TITLE
fix: corregir fullscreen horizontal en wallets móviles

### DIFF
--- a/dapp/__tests__/components/game-layout-fullscreen.test.tsx
+++ b/dapp/__tests__/components/game-layout-fullscreen.test.tsx
@@ -186,6 +186,7 @@ describe('GameLayout fullscreen and desktop viewport', () => {
     render(<GameLayout {...props} mobileFocus />);
 
     const viewport = document.querySelector('[data-game-viewport]');
+    const landscapeSurface = document.querySelector('[data-game-landscape-surface]');
     fireEvent.click(screen.getByRole('button', { name: 'Abrir pantalla completa' }));
 
     await waitFor(() => {
@@ -193,12 +194,17 @@ describe('GameLayout fullscreen and desktop viewport', () => {
       expect(viewport).toHaveAttribute('data-game-orientation-fallback', 'css-rotated');
     });
     expect(requestFullscreen).toHaveBeenCalledTimes(1);
-    expect(viewport).toHaveClass('!h-[100vw]', '!w-[100dvh]');
-    expect(viewport).toHaveStyle({
-      left: '50%',
-      top: '50%',
-      transform: 'translate(-50%, -50%) rotate(90deg)',
-    });
+    expect(viewport).not.toHaveClass('rotate-90', '!h-[100vw]', '!w-[100dvh]');
+    expect(landscapeSurface).toHaveClass(
+      'absolute',
+      'left-1/2',
+      'top-1/2',
+      '!h-[100vw]',
+      '!w-[100dvh]',
+      '-translate-x-1/2',
+      '-translate-y-1/2',
+      'rotate-90',
+    );
     expect(screen.queryByText('Gira el móvil para jugar')).not.toBeInTheDocument();
 
     Object.defineProperty(window, 'innerWidth', {
@@ -214,7 +220,7 @@ describe('GameLayout fullscreen and desktop viewport', () => {
     await waitFor(() => {
       expect(viewport).toHaveAttribute('data-game-orientation-fallback', 'off');
     });
-    expect(viewport).not.toHaveClass('!h-[100vw]', '!w-[100dvh]');
+    expect(landscapeSurface).not.toHaveClass('rotate-90', '!h-[100vw]', '!w-[100dvh]');
   });
 
   it('reduce el horizontal sin fullscreen a una única puerta de entrada', () => {

--- a/dapp/__tests__/components/game-layout-fullscreen.test.tsx
+++ b/dapp/__tests__/components/game-layout-fullscreen.test.tsx
@@ -71,9 +71,14 @@ describe('GameLayout fullscreen and desktop viewport', () => {
   const originalUserAgent = window.navigator.userAgent;
   const originalInnerWidth = window.innerWidth;
   const originalInnerHeight = window.innerHeight;
-  const originalEthereum = (window as Window & {
-    ethereum?: { isMetaMask?: boolean };
-  }).ethereum;
+  const originalFullscreenElement = Object.getOwnPropertyDescriptor(
+    document,
+    'fullscreenElement',
+  );
+  const originalRequestFullscreen = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'requestFullscreen',
+  );
 
   beforeEach(() => {
     mockUseMobileGameShell.mockReturnValue(true);
@@ -92,10 +97,20 @@ describe('GameLayout fullscreen and desktop viewport', () => {
       configurable: true,
       value: originalInnerHeight,
     });
-    Object.defineProperty(window, 'ethereum', {
-      configurable: true,
-      value: originalEthereum,
-    });
+    if (originalFullscreenElement) {
+      Object.defineProperty(document, 'fullscreenElement', originalFullscreenElement);
+    } else {
+      Reflect.deleteProperty(document, 'fullscreenElement');
+    }
+    if (originalRequestFullscreen) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'requestFullscreen',
+        originalRequestFullscreen,
+      );
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, 'requestFullscreen');
+    }
   });
 
   it('uses a functional app-level fullscreen fallback in mobile wallet browsers', async () => {
@@ -138,10 +153,10 @@ describe('GameLayout fullscreen and desktop viewport', () => {
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
-  it('rota el viewport en MetaMask Android cuando la app nativa permanece en portrait', async () => {
+  it('rota un fullscreen nativo que SafePal mantiene en portrait y vuelve al layout nativo al girar', async () => {
     Object.defineProperty(window.navigator, 'userAgent', {
       configurable: true,
-      value: 'Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 MetaMaskMobile',
+      value: 'Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 SafePal',
     });
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
@@ -151,9 +166,21 @@ describe('GameLayout fullscreen and desktop viewport', () => {
       configurable: true,
       value: 844,
     });
-    Object.defineProperty(window, 'ethereum', {
+
+    let fullscreenElement: Element | null = null;
+    Object.defineProperty(document, 'fullscreenElement', {
       configurable: true,
-      value: { isMetaMask: true },
+      get: () => fullscreenElement,
+    });
+    const requestFullscreen = jest.fn(async function requestFullscreen(
+      this: HTMLElement,
+    ) {
+      fullscreenElement = this;
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+    Object.defineProperty(HTMLElement.prototype, 'requestFullscreen', {
+      configurable: true,
+      value: requestFullscreen,
     });
 
     render(<GameLayout {...props} mobileFocus />);
@@ -162,8 +189,10 @@ describe('GameLayout fullscreen and desktop viewport', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Abrir pantalla completa' }));
 
     await waitFor(() => {
+      expect(viewport).toHaveAttribute('data-game-fullscreen', 'native');
       expect(viewport).toHaveAttribute('data-game-orientation-fallback', 'css-rotated');
     });
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
     expect(viewport).toHaveClass('!h-[100vw]', '!w-[100dvh]');
     expect(viewport).toHaveStyle({
       left: '50%',
@@ -172,10 +201,20 @@ describe('GameLayout fullscreen and desktop viewport', () => {
     });
     expect(screen.queryByText('Gira el móvil para jugar')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Salir de pantalla completa' }));
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 844,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 390,
+    });
+    fireEvent(window, new Event('resize'));
+
     await waitFor(() => {
       expect(viewport).toHaveAttribute('data-game-orientation-fallback', 'off');
     });
+    expect(viewport).not.toHaveClass('!h-[100vw]', '!w-[100dvh]');
   });
 
   it('reduce el horizontal sin fullscreen a una única puerta de entrada', () => {

--- a/dapp/src/components/layout/GameLayout.tsx
+++ b/dapp/src/components/layout/GameLayout.tsx
@@ -386,68 +386,67 @@ export default function GameLayout({
                     : 'aspect-[11/8] w-full flex-none'
                   : 'flex-grow'
               ),
-              isFallbackFullscreen && !isCssRotatedLandscape && 'fixed inset-0 z-[100] !h-[100dvh] !w-screen !flex-none !rounded-none !border-0 [aspect-ratio:auto]',
-              isCssRotatedLandscape && 'fixed z-[100] !h-[100vw] !w-[100dvh] !flex-none !rounded-none !border-0 [aspect-ratio:auto]',
+              isFallbackFullscreen && 'fixed inset-0 z-[100] !h-[100dvh] !w-screen !flex-none !rounded-none !border-0 [aspect-ratio:auto]',
             )}
-            style={isCssRotatedLandscape ? {
-              bottom: 'auto',
-              left: '50%',
-              right: 'auto',
-              top: '50%',
-              transform: 'translate(-50%, -50%) rotate(90deg)',
-              transformOrigin: 'center',
-            } : undefined}
           >
-            <iframe
-              ref={iframeRef}
-              src={gameConfig.gameUrl}
-              className="block h-full min-h-0 w-full flex-1 overscroll-contain border-0 touch-manipulation"
-              title={gameConfig.name}
-              allow="clipboard-read; clipboard-write; fullscreen"
-              allowFullScreen
-              onLoad={handleIframeLoad}
-            />
-            {!isMobileFocus ? (
-              <div
-                className="absolute bottom-0 left-0 z-30 flex items-center gap-2"
-                style={{
-                  bottom: 'max(0.5rem, env(safe-area-inset-bottom))',
-                  left: 'max(0.5rem, env(safe-area-inset-left))',
-                }}
-              >
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="bg-black/20 text-white/60 backdrop-blur-sm hover:bg-black/45 hover:text-white"
-                  onClick={() => void handleFullScreen()}
-                  aria-label={isFullscreen ? 'Salir de pantalla completa' : 'Abrir pantalla completa'}
-                  title={isFullscreen ? 'Salir de pantalla completa' : 'Abrir pantalla completa'}
+            <div
+              data-game-landscape-surface
+              className={cn(
+                'relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden',
+                isCssRotatedLandscape && 'absolute left-1/2 top-1/2 !h-[100vw] !w-[100dvh] flex-none -translate-x-1/2 -translate-y-1/2 rotate-90',
+              )}
+            >
+              <iframe
+                ref={iframeRef}
+                src={gameConfig.gameUrl}
+                className="block h-full min-h-0 w-full flex-1 overscroll-contain border-0 touch-manipulation"
+                title={gameConfig.name}
+                allow="clipboard-read; clipboard-write; fullscreen"
+                allowFullScreen
+                onLoad={handleIframeLoad}
+              />
+              {!isMobileFocus ? (
+                <div
+                  className="absolute bottom-0 left-0 z-30 flex items-center gap-2"
+                  style={{
+                    bottom: 'max(0.5rem, env(safe-area-inset-bottom))',
+                    left: 'max(0.5rem, env(safe-area-inset-left))',
+                  }}
                 >
-                  {isFullscreen ? <Minimize2 className="h-5 w-5" /> : <Maximize className="h-5 w-5" />}
-                </Button>
-              </div>
-            ) : null}
-            {isMobileFocus && isFullscreen ? (
-              <div
-                className="absolute right-0 top-0 z-50 flex items-center gap-2"
-                style={{
-                  top: 'max(0.5rem, env(safe-area-inset-top))',
-                  right: 'max(0.5rem, env(safe-area-inset-right))',
-                }}
-              >
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => void handleFullScreen()}
-                  className="h-11 gap-2 border border-white/20 bg-black/70 px-3 text-xs font-black text-white backdrop-blur-md hover:bg-black/85"
-                  aria-label="Salir de pantalla completa"
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="bg-black/20 text-white/60 backdrop-blur-sm hover:bg-black/45 hover:text-white"
+                    onClick={() => void handleFullScreen()}
+                    aria-label={isFullscreen ? 'Salir de pantalla completa' : 'Abrir pantalla completa'}
+                    title={isFullscreen ? 'Salir de pantalla completa' : 'Abrir pantalla completa'}
+                  >
+                    {isFullscreen ? <Minimize2 className="h-5 w-5" /> : <Maximize className="h-5 w-5" />}
+                  </Button>
+                </div>
+              ) : null}
+              {isMobileFocus && isFullscreen ? (
+                <div
+                  className="absolute right-0 top-0 z-50 flex items-center gap-2"
+                  style={{
+                    top: 'max(0.5rem, env(safe-area-inset-top))',
+                    right: 'max(0.5rem, env(safe-area-inset-right))',
+                  }}
                 >
-                  <Minimize2 className="h-4 w-4" aria-hidden="true" />
-                  Salir
-                </Button>
-              </div>
-            ) : null}
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => void handleFullScreen()}
+                    className="h-11 gap-2 border border-white/20 bg-black/70 px-3 text-xs font-black text-white backdrop-blur-md hover:bg-black/85"
+                    aria-label="Salir de pantalla completa"
+                  >
+                    <Minimize2 className="h-4 w-4" aria-hidden="true" />
+                    Salir
+                  </Button>
+                </div>
+              ) : null}
+            </div>
           </div>
           
           {/* Game Instructions */}

--- a/dapp/src/components/layout/GameLayout.tsx
+++ b/dapp/src/components/layout/GameLayout.tsx
@@ -32,12 +32,6 @@ interface LockableScreenOrientation {
   unlock?: () => void;
 }
 
-interface MetaMaskBrowserWindow extends Window {
-  ethereum?: {
-    isMetaMask?: boolean;
-  };
-}
-
 interface GameLayoutComponentProps extends GameLayoutProps {
   onGameConnection?: (iframeRef: React.RefObject<HTMLIFrameElement>) => void;
   iframeRef?: React.RefObject<HTMLIFrameElement>; // Allow external ref
@@ -73,12 +67,11 @@ const renderIcon = (iconName: string, className: string = "h-4 w-4") => {
 };
 
 function needsCssLandscapeFallback() {
-  const browserWindow = window as MetaMaskBrowserWindow;
-  const isAndroid = /Android/i.test(window.navigator.userAgent);
-  const isMetaMaskBrowser = Boolean(browserWindow.ethereum?.isMetaMask);
-  const isPortraitViewport = window.innerHeight > window.innerWidth;
+  const visualViewport = window.visualViewport;
+  const width = visualViewport?.width || window.innerWidth;
+  const height = visualViewport?.height || window.innerHeight;
 
-  return isAndroid && isMetaMaskBrowser && isPortraitViewport;
+  return height > width;
 }
 
 export default function GameLayout({ 
@@ -141,7 +134,10 @@ export default function GameLayout({
         fullscreenDocument.msFullscreenElement,
       );
       setIsNativeFullscreen(active);
-      if (active) setIsFallbackFullscreen(false);
+      if (active) {
+        setIsFallbackFullscreen(false);
+        void requestLandscape();
+      }
     };
     document.addEventListener('fullscreenchange', syncFullscreenState);
     document.addEventListener('webkitfullscreenchange', syncFullscreenState);
@@ -149,7 +145,7 @@ export default function GameLayout({
       document.removeEventListener('fullscreenchange', syncFullscreenState);
       document.removeEventListener('webkitfullscreenchange', syncFullscreenState);
     };
-  }, []);
+  }, [requestLandscape]);
 
   useEffect(() => {
     if (!isFallbackFullscreen) return undefined;
@@ -175,13 +171,15 @@ export default function GameLayout({
         window.clearTimeout(syncTimeout);
       }
       syncTimeout = window.setTimeout(() => {
-        setIsCssRotatedLandscape(needsCssLandscapeFallback());
+        setIsCssRotatedLandscape(isMobileFocus && needsCssLandscapeFallback());
       }, 200);
     };
 
+    const visualViewport = window.visualViewport;
     scheduleOrientationFallbackSync();
     window.addEventListener('resize', scheduleOrientationFallbackSync);
     window.addEventListener('orientationchange', scheduleOrientationFallbackSync);
+    visualViewport?.addEventListener('resize', scheduleOrientationFallbackSync);
 
     return () => {
       if (syncTimeout !== undefined) {
@@ -189,8 +187,9 @@ export default function GameLayout({
       }
       window.removeEventListener('resize', scheduleOrientationFallbackSync);
       window.removeEventListener('orientationchange', scheduleOrientationFallbackSync);
+      visualViewport?.removeEventListener('resize', scheduleOrientationFallbackSync);
     };
-  }, [isFullscreen]);
+  }, [isFullscreen, isMobileFocus]);
 
   useEffect(() => () => unlockOrientation(), [unlockOrientation]);
 


### PR DESCRIPTION
## Resumen

- Corrige el modo horizontal de Treasure Hunt en wallets móviles cuyo navegador mantiene el viewport en vertical al entrar en pantalla completa (caso SafePal).
- Activa el fallback según la geometría real del viewport, sin depender de la marca del wallet.
- Aplica la rotación al contenedor interno del juego para evitar que las reglas nativas de `:fullscreen` del navegador anulen el tamaño y la transformación.
- Reintenta el bloqueo de orientación y recalcula el layout ante cambios de fullscreen, viewport y orientación.

## Validación

- `pnpm --dir dapp exec jest __tests__/components/game-layout-fullscreen.test.tsx --runInBand` — 5/5 OK.
- `pnpm dapp lint` — OK.
- `pnpm dapp typecheck` — OK.
- `pnpm dapp build` — OK.
- Staging `https://cukieshub.eurekand.com` desplegado con SHA `a8d1ea075db9aac65dcc642565d82e48c8c1207b`.
- Smoke real a `390×844`: superficie interna `844×390`, rotación aplicada y 0 errores de consola.

## Riesgo residual

El bloqueo nativo de orientación sigue dependiendo del soporte de cada navegador/wallet. Cuando no está disponible, el fallback CSS mantiene el juego jugable en horizontal al girar físicamente el móvil.