### PR TITLE
fix: operationalize staging presale rehearsal

### DIFF
--- a/docs/contract-ownership-inventory.md
+++ b/docs/contract-ownership-inventory.md
@@ -1,7 +1,7 @@
 # Contract ownership inventory
 
 Estado: inventario operativo de seguridad.
-Ultima comprobacion on-chain: 2026-06-04.
+Ultima comprobacion on-chain: 2026-08-05.
 
 Este documento registra las direcciones de contratos conocidas y los owners/admins observados. Si una direccion marcada como critica aparece todavia como owner/admin, debe tratarse como riesgo activo hasta completar rotacion a una wallet limpia o multisig.
 
@@ -44,10 +44,12 @@ Comprobacion: RPC publico de BSC testnet.
 | Alias | Contract / wallet address | Owner/admin observado | Nota |
 | --- | --- | --- | --- |
 | `ASM_TESTNET` | `0xf93dd40Bf8bD8dDf7C785AA87dc13C3c3FeB6c8C` | No expone `owner()` en la comprobacion usada | Token ASM testnet / `tASM`. |
-| `UKI_TOKEN` | `0x90f87D01984A336eD1AaF8fFcdA7BcDaF839ae36` | `0xba84bffad693edbd4b3f7899fb6e3ccb0c1d7820` | `owner()`. |
-| `VESTING_VAULT` | `0xA22AF68c7AF2e13C9d7217fDA705132080e91Ba5` | `0xba84bffad693edbd4b3f7899fb6e3ccb0c1d7820` | `DEFAULT_ADMIN_ROLE`. |
-| `PRESALE` | `0x24aC03c96649C7fb8DDF4E92fB9aB072592f2ED0` | `0xba84bffad693edbd4b3f7899fb6e3ccb0c1d7820` | `owner()`. |
+| `UKI_TOKEN` | `0x42895bBEc6A6EC1b4aF0B11E144Cd2777589C23c` | `0xba84bffad693edbd4b3f7899fb6e3ccb0c1d7820` | `owner()`; token testnet reutilizado. |
+| `VESTING_VAULT` | `0xE7cFcebA1342946ff8c382Be8D7B55F0323b1154` | `0xba84bffad693edbd4b3f7899fb6e3ccb0c1d7820` | `DEFAULT_ADMIN_ROLE`; desplegado en bloque `123291890`. |
+| `PRESALE` | `0xC0d7b04AC4DFCCc28790FD492FCB3CB16AcDfcdA` | `0xba84bffad693edbd4b3f7899fb6e3ccb0c1d7820` | `owner()`; desplegado en bloque `123291898`. |
 | `PRESALE_TREASURY` | `0x19907a00abf02975fb60d616c99565894c08d859` | N/A | `Presale.treasury()`. |
+
+El escenario activo abre del `2026-08-05T10:59:20Z` al `2026-09-04T10:59:20Z`, usa `100 UKI/ASM`, compra minima de `5 ASM`, cap de `250,000,000 UKI` y vesting lineal de 9 meses. El vault quedo financiado con el cap completo y la unica cuenta con `PRESALE_VESTING_ROLE` es el contrato `Presale` anterior.
 
 ## ASM BSC mainnet
 

--- a/docs/coolify-deployment.md
+++ b/docs/coolify-deployment.md
@@ -1,6 +1,6 @@
 # Coolify deployment
 
-El despliegue de produccion debe usar `docker-compose.coolify.yml` como compose del proyecto.
+Los despliegues de staging y produccion deben usar `docker-compose.coolify.yml` como compose del proyecto.
 
 ## Servicios
 
@@ -16,9 +16,9 @@ En Coolify:
 
 1. Crear o editar el recurso como Docker Compose.
 2. Repo: `fgomezserna/cukies-hub`.
-3. Branch: `main`.
+3. Branch: `staging` para integracion y `main` para el live actual.
 4. Compose file: `docker-compose.coolify.yml`.
-5. Activar webhook/auto deploy para que cada push o merge a `main` reconstruya los tres servicios.
+5. Activar webhook/auto deploy solo para la rama asignada al recurso.
 6. Configurar dominio solo en `dapp`.
 
 ## Variables obligatorias
@@ -37,10 +37,10 @@ Dapp presale testnet:
 NEXT_PUBLIC_UKI_CHAIN_ID=97
 NEXT_PUBLIC_ASM_TOKEN_ADDRESS=0xf93dd40Bf8bD8dDf7C785AA87dc13C3c3FeB6c8C
 NEXT_PUBLIC_UKI_TOKEN_ADDRESS=0x42895bBEc6A6EC1b4aF0B11E144Cd2777589C23c
-NEXT_PUBLIC_UKI_VESTING_VAULT_ADDRESS=0x02E854eeF861B517d996D676C27B1be62665035B
-NEXT_PUBLIC_UKI_PRESALE_ADDRESS=0xb6aB8eaB37061AffCD415950C051a2EBD61Bb2C8
+NEXT_PUBLIC_UKI_VESTING_VAULT_ADDRESS=0xE7cFcebA1342946ff8c382Be8D7B55F0323b1154
+NEXT_PUBLIC_UKI_PRESALE_ADDRESS=0xC0d7b04AC4DFCCc28790FD492FCB3CB16AcDfcdA
 NEXT_PUBLIC_BSCSCAN_BASE_URL=https://testnet.bscscan.com
-NEXT_PUBLIC_UKI_PRESALE_START_ISO=2026-06-11T10:59:10.000Z
+NEXT_PUBLIC_UKI_PRESALE_START_ISO=2026-08-05T10:59:20.000Z
 NEXT_PUBLIC_UKI_PRESALE_START_LABEL=testnet abierta
 NEXT_PUBLIC_UKI_PRESALE_START_SHORT_LABEL=abierta
 ```
@@ -101,16 +101,28 @@ Indexer:
 ```bash
 CHAIN_INDEXER_CHAINS=BSC
 CHAIN_INDEXER_CONTRACT_ALIASES=PRESALE
+CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID=97
+CHAIN_INDEXER_BSC_RPC_URLS=https://bsc-testnet-rpc.publicnode.com,https://data-seed-prebsc-1-s1.bnbchain.org:8545,https://data-seed-prebsc-2-s1.bnbchain.org:8545
 CHAIN_INDEXER_BSC_RPC_URL=https://bsc-testnet-rpc.publicnode.com
 CHAIN_INDEXER_TRON_API_BASE_URL=https://api.trongrid.io/v1
-CHAIN_INDEXER_PRESALE_ADDRESS=0xb6aB8eaB37061AffCD415950C051a2EBD61Bb2C8
-CHAIN_INDEXER_START_BSC_BLOCK=112739000
-CHAIN_INDEXER_BSC_CONFIRMATIONS=3
+CHAIN_INDEXER_PRESALE_ADDRESS=0xC0d7b04AC4DFCCc28790FD492FCB3CB16AcDfcdA
+CHAIN_INDEXER_START_BSC_BLOCK=123291898
+CHAIN_INDEXER_BSC_CONFIRMATIONS=12
 ```
 
 `CHAIN_INDEXER_PRESALE_ADDRESS` debe ser el contrato `Presale` real del entorno. Si no se define, el worker seguira indexando Cukies legacy, marketplace y bridge, pero no leera compras de preventa ni generara `presale_purchases`, `presale_participants` o `presale_referral_contributions`.
 
 `CHAIN_INDEXER_START_BSC_BLOCK` debe apuntar al bloque de despliegue del contrato de preventa o a un bloque anterior cercano. Para backfill historico amplio, usar un RPC que soporte rangos de logs suficientemente antiguos.
+
+### Escenario de preventa staging 2026-08-05
+
+- Vault: `0xE7cFcebA1342946ff8c382Be8D7B55F0323b1154`; deploy tx `0x14292fc576ddff260572c4d7de7a7538d8f0aed8f3147d20f65d2cb77a0fa00b`.
+- Presale: `0xC0d7b04AC4DFCCc28790FD492FCB3CB16AcDfcdA`; deploy tx `0x846987138438bc3e77bfa8a957011b7cf6bbfc7b8fae59a548949102a0abc80e`.
+- Parametros: `100 UKI/ASM`, minimo `5 ASM`, cap `250,000,000 UKI`, ventana de 30 dias y vesting lineal de 9 meses.
+- Vault financiado: tx `0xaafce634b0221268ced2d9e64a1ab8438365072e09cd11aa016dafadf3e65444`.
+- Rol y apertura: tx `0x51117e37bf957a911626d797c7045c03e6ab27d9e98a21a9632d81a74e7a7b1a` y `0x4e8c4ec8ca66c7b2c449a68f60eec23b4a27b7ccbf8d8204ad1f901015cf3ed8`.
+- Compra smoke: `5 tASM -> 500 UKI` en tx `0x9b5f3a5724028f464fa582be7d3178dbf872964b6161123cd0987daf3010f9bd`.
+- Verificacion de fuente en explorer: pendiente de migrar Hardhat/BscScan desde API V1 a Etherscan API V2 y disponer de una API key V2 valida.
 
 Config inicial en Mongo para referidos de preventa:
 
@@ -141,7 +153,7 @@ Card worker:
 ```bash
 CARD_WORKER_MONGO_URL=...
 CARD_WORKER_DB_NAME=cukieshub-new
-CARD_WORKER_UPLOAD=true
+CARD_WORKER_UPLOAD=false
 CARD_WORKER_PUBLIC_BASE_URL=...
 CARD_WORKER_S3_BUCKET=...
 CARD_WORKER_S3_REGION=...
@@ -150,7 +162,7 @@ AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 ```
 
-No activar `CARD_WORKER_UPLOAD=true` sin bucket, region, credenciales y base publica configurados. El worker esta protegido y no procesa en modo continuo sin upload real.
+En staging, mantener `CARD_WORKER_UPLOAD=false` hasta disponer de bucket/prefijo propios. No activar `true` con el destino compartido de produccion.
 
 ## Validacion post deploy
 

--- a/docs/deployment-environments.md
+++ b/docs/deployment-environments.md
@@ -1,57 +1,35 @@
 # UKI deployment environments
 
-Estado: decision operativa inicial.
+Estado: topologia activa y checklist operativo.
 Issue: #166 `UKI-090.4`.
-Fecha: 2026-05-13.
+Fecha de ultima comprobacion: 2026-08-05.
 
 ## Decision
 
-Usamos dos carriles permanentes:
+Usamos dos carriles separados:
 
-- `main` -> staging.
-- `production` -> produccion.
+- `staging` -> staging/integracion sobre BSC Testnet y bases staging.
+- `main` -> live actual sobre `cukies.world`.
 
-Produccion no debe seguir automaticamente a `main`. El paso a produccion se hace mediante release aprobada, con PR o merge controlado hacia `production` y tag versionado.
+Los cambios se validan primero en `staging`. El paso a `main` requiere una promocion controlada y no debe arrastrar variables, contratos ni datos de testnet.
 
 La estrategia de tags recomendada es:
 
 - `staging-YYYYMMDD.N` para candidatos validados en staging si hace falta fijar un punto.
 - `prod-YYYYMMDD.N` para lo que se publica en produccion.
 
-Las ramas `release/staging-YYYY-MM-DD` son opcionales y se usan solo cuando `main` sigue avanzando mientras una release se estabiliza.
+Las ramas `release/staging-YYYY-MM-DD` son opcionales y se usan solo cuando `staging` sigue avanzando mientras una release se estabiliza.
 
 ## Estado actual observado
 
-- Existe `main`.
-- Existe rama remota `production`, creada desde `origin/main` el 2026-05-13.
-- `production` tiene proteccion de rama en GitHub:
-  - PR obligatorio,
-  - una aprobacion requerida,
-  - conversaciones resueltas,
-  - admins incluidos,
-  - force push y borrado deshabilitados.
-- La dapp tiene `dapp/apphosting.yaml`, pero el hosting activo observado es Coolify.
-- Coolify tiene una app live/integracion para `game-hub`:
-  - `applicationId`: `12`.
-  - `uuid`: `jookw8ow8woks088s44404ok`.
-  - `resourceName`/`serviceName`: `game-hub`.
-  - `project`: `cukies.world`.
-  - `environmentName`: `production` en Coolify, aunque logicamente opera como staging/integracion.
-  - rama configurada: `main`.
-  - dominio: `cukieshub.eurekand.com`.
-  - autodespliegue: activado para seguir `main`.
-- Coolify tiene una app placeholder de produccion para `game-hub`:
-  - `uuid`: `u4s804o4wwcckowgk0woo4wg`.
-  - `name`: `game-hub-production`.
-  - rama configurada: `production`.
-  - dominio publico: ninguno todavia.
-  - autodespliegue: desactivado.
-- `cukies.world` esta actualmente ocupado por la app `cukiesworld-web` (`x8s8g8o04kwg0csg8w4ww8sg`) en rama `main`.
+- Staging/integracion: Coolify app `game-hub-staging`, application ID `28`, UUID `u4s804o4wwcckowgk0woo4wg`, rama `staging`, URL `https://cukieshub.eurekand.com`.
+- Live actual: Coolify app `game-hub`, application ID `12`, UUID `jookw8ow8woks088s44404ok`, rama `main`, URL `https://cukies.world`.
+- Ambos recursos usan `docker-compose.coolify.yml`; solo `dapp` se publica mediante Traefik.
+- Staging usa BSC Testnet (`97`) y la preventa `0xC0d7b04AC4DFCCc28790FD492FCB3CB16AcDfcdA`.
+- Staging usa `cukies-hub-staging`, `cukies-legacy-staging` y `cukieshub-new-staging` sobre Mongo replica set `rs0`.
+- Produccion conserva BSC mainnet y sus bases de produccion; no se han reapuntado durante esta separacion.
 - La VM Coolify/Traefik observada es `1001` (`192.168.1.201`) y publica Traefik en `80/443`.
 - Cloudflare Tunnel ya tiene ruta para `cukieshub.eurekand.com` hacia `https://192.168.1.201:443`.
-- No se ha modificado Cloudflare para publicar `game-hub-production` en `cukies.world`.
-- No se ha observado `.github/workflows`, `vercel.json`, `netlify.toml` ni configuracion de produccion en repo.
-- `dapp/.next-dev/` aparece como archivo local no trackeado y no forma parte de este trabajo.
 
 ## Topologia objetivo
 
@@ -59,19 +37,19 @@ Las ramas `release/staging-YYYY-MM-DD` son opcionales y se usan solo cuando `mai
 | --- | --- | --- | --- | --- | --- |
 | Local | Cualquier rama local | Maquina local | Hardhat/local o testnet puntual | Dev/local | Implementacion rapida. |
 | Preview PR | Branch del PR | Coolify preview si se habilita | Sin valor real | Datos aislados o mocks | Revision visual/tecnica. |
-| Staging | `main` o `release/staging-*` | Coolify app/env staging | BSC testnet | DB staging | QA integrada. |
-| Production | `production` + tag `prod-*` | Coolify app/env production | BSC mainnet | DB production | Usuarios reales. |
+| Staging | `staging` | Coolify `game-hub-staging` | BSC testnet | DB staging | QA integrada. |
+| Production | `main` + tag `prod-*` | Coolify `game-hub` | BSC mainnet | DB production | Usuarios reales. |
 
 ## Reglas de ramas
 
 | Rama | Regla |
 | --- | --- |
 | `codex/issue-<numero>-<slug>` | Trabajo aislado por issue. PR draft hasta validar. |
-| `main` | Integracion. Debe poder desplegarse a staging. No publica a produccion. |
-| `release/staging-YYYY-MM-DD` | Congela un candidato cuando `main` necesita seguir avanzando. |
-| `production` | Rama protegida. Solo recibe release aprobada. |
+| `staging` | Integracion. Debe ser segura para testnet y datos staging. |
+| `main` | Live actual. Solo recibe cambios promovidos tras QA. |
+| `release/staging-YYYY-MM-DD` | Congela un candidato cuando `staging` necesita seguir avanzando. |
 
-Protecciones recomendadas para `production`:
+Protecciones recomendadas para `main`:
 
 - bloquear pushes directos,
 - requerir PR,
@@ -80,40 +58,36 @@ Protecciones recomendadas para `production`:
 - requerir comentario de go/no-go en la release,
 - restringir quien puede hacer merge.
 
-Protecciones recomendadas para `main`:
+Protecciones recomendadas para `staging`:
 
 - PR obligatorio,
 - checks de area cuando existan,
 - permitir PRs draft para trabajo en curso,
-- no exigir que todo este listo para produccion, solo que sea staging-safe.
+- no exigir que todo este listo para produccion, solo que sea seguro para staging.
 
 ## Flujo de promocion
 
 1. Issue hoja -> rama `codex/issue-*`.
 2. PR draft -> validacion tecnica.
-3. PR ready -> merge a `main`.
-4. `main` -> deploy a staging.
+3. PR ready -> merge a `staging`.
+4. `staging` -> deploy a staging.
 5. Staging QA -> evidencia en issue/release candidate.
 6. Release candidate -> go/no-go.
-7. Merge controlado a `production` o tag `prod-*`.
+7. Merge controlado de `staging` a `main` y tag `prod-*`.
 8. Deploy production.
 9. Validacion post-deploy.
 10. Cierre de issues que realmente quedaron publicadas o cumplidas.
 
 ## Configuracion Coolify
 
-El proveedor activo observado es Coolify. La app que sirve `cukieshub.eurekand.com` debe seguir `main`. La app de produccion real queda preparada como placeholder sobre `production`, sin dominio publico ni autodespliegue hasta go/no-go.
+El proveedor activo observado es Coolify. `cukieshub.eurekand.com` sigue `staging`; `cukies.world` sigue `main`.
 
 Trabajo pendiente en Coolify:
 
-- separar secrets/env vars por entorno,
-- cargar `DATABASE_URL` staging y secrets OAuth/Pusher/Resend/Telegram separados,
-- cargar `CUKIES_DATABASE_URL` staging contra la replica legacy sanitizada,
-- ejecutar o verificar deploy de `cukieshub.eurekand.com` desde `main`,
-- antes de go-live, asignar `cukies.world` a `game-hub-production` y retirar o reemplazar la app actual `cukiesworld-web`,
-- no modificar Cloudflare para `cukies.world` hasta aprobacion de publicacion,
-- documentar rollback concreto desde Coolify tras el primer deploy,
-- confirmar si los juegos tienen hosting separado o se sirven desde la dapp.
+- completar usuarios/credenciales Mongo limitados a las tres bases staging antes de QA externa,
+- separar OAuth, Pusher, Resend y Telegram,
+- desplegar los contratos de economia pendientes y mantener schedulers desactivados hasta completar sus gates,
+- documentar rollback por commit y por variables para cada promocion a `main`.
 
 Nada de esto debe usar secrets en el repo.
 
@@ -121,16 +95,15 @@ Nada de esto debe usar secrets en el repo.
 
 | Entorno | Coolify project | Coolify environment | Branch | Dominio |
 | --- | --- | --- | --- | --- |
-| Staging/integracion | `cukies.world` | `production` en Coolify | `main` | `cukieshub.eurekand.com` |
-| Production placeholder | `cukies.world` | `production` | `production` | sin dominio hasta go-live |
-| Production final | `cukies.world` | `production` | `production` | `cukies.world` |
+| Staging/integracion | `cukies.world` | `production` en Coolify | `staging` | `cukieshub.eurekand.com` |
+| Production/live | `cukies.world` | `production` en Coolify | `main` | `cukies.world` |
 
 Reglas operativas:
 
 - staging debe tener `NEXTAUTH_URL` y callbacks OAuth propios,
 - staging debe usar base de datos y secrets separados,
-- production no debe autodesplegar commits de `main`,
-- `cukies.world` no debe reasignarse al hub hasta aprobacion de publicacion,
+- `main` solo debe recibir merges promovidos tras QA y go/no-go,
+- `cukies.world` no debe recibir variables ni contratos de staging,
 - los nombres de routers Traefik deben ser unicos por entorno,
 - ambos servicios deben vivir en la red Docker externa `coolify`.
 
@@ -196,19 +169,38 @@ Reglas operativas:
 
 Antes de considerar staging valido:
 
-- deploy de staging apunta a `main` o release candidate acordada,
+- deploy de staging apunta a `staging` o a una release candidate acordada,
 - env staging no comparte DB ni secrets con produccion,
 - `NEXT_PUBLIC_UKI_CHAIN_ID=97` si hay flujo on-chain,
 - contratos testnet y direcciones documentadas si la pantalla los usa,
 - smoke test de rutas criticas documentado,
 - fallos de lint/typecheck/test documentados si son preexistentes.
 
+### Checklist posterior a la separacion
+
+- [x] Integrar el guardarrail de RPC/chain id de BSC Testnet en `staging` (PR #188, merge `290cc643`).
+- [x] Reapuntar el recurso Coolify staging a la rama `staging`.
+- [x] Separar las tres bases staging y habilitar transacciones mediante Mongo replica set `rs0`.
+- [x] Desplegar y financiar un nuevo `VestingVault` y `Presale` en BSC Testnet.
+- [x] Ejecutar una compra on-chain smoke de `5 tASM -> 500 UKI` y validar pago, venta y vesting.
+- [ ] Migrar la verificacion del explorer a Etherscan API V2 y verificar el source de Vault/Presale.
+- [ ] Crear usuarios Mongo con minimo privilegio y habilitar `security.authorization` tras validar los consumidores legacy.
+- [ ] Desplegar/verificar `UKIStaking` y `RewardsDistributor` en BSC Testnet.
+- [ ] Configurar HMAC exclusivos de staging y ejecutar el setup de economia v2.
+- [ ] Cargar reglas aprobadas de creditos, juegos, pools y ranking.
+- [ ] Desplegar los cinco schedulers con gates desactivados; activarlos uno a uno tras validar heartbeats, leases e idempotencia.
+- [ ] Dar al card worker un bucket/prefijo staging propio o retirarlo del compose de staging.
+- [ ] Separar OAuth, Pusher, Resend y Telegram antes de QA externa.
+- [ ] Completar smoke E2E con una segunda wallet desde la UI y conservar evidencia de APIs, Mongo e indexer.
+
+Tras el escenario de preventa, el siguiente bloque recomendado es `UKIStaking` + `RewardsDistributor`, seguido del setup transaccional de economia v2. Los schedulers deben quedarse cerrados hasta que contratos, reglas y secretos internos esten verificados.
+
 ## Gates para produccion
 
 Antes de publicar produccion:
 
 - release candidate validada en staging,
-- PR/merge hacia `production` aprobado,
+- PR/merge de promocion hacia `main` aprobado,
 - tag `prod-*` creado,
 - env production revisado por ops,
 - contratos mainnet congelados y verificados si la release toca on-chain,
@@ -221,7 +213,7 @@ Antes de publicar produccion:
 Rollback de app:
 
 1. identificar tag/commit estable anterior,
-2. redeploy desde `production` anterior o tag anterior,
+2. redeploy desde el commit estable anterior de `main` o desde el tag anterior,
 3. validar health/smoke,
 4. comentar issue de release con hora, commit y motivo.
 
@@ -240,19 +232,6 @@ Contratos:
 4. reconciliar backend/indexer,
 5. no asumir que se puede hacer rollback on-chain.
 
-## Checklist de ejecucion para #166
-
-- [x] Crear rama remota `production` desde un commit aprobado.
-- [x] Proteger `production`.
-- [x] Configurar `cukieshub.eurekand.com` para seguir `main`.
-- [x] Crear placeholder production sobre rama `production` sin dominio publico.
-- [x] Confirmar que no se publica `cukies.world` todavia.
-- [x] Documentar refresh Mongo production -> staging con backup y sanitizacion.
-- [ ] Separar secrets/env vars.
-- [x] Documentar URLs finales de staging y produccion.
-- [ ] Documentar rollback concreto del proveedor.
-- [ ] Ejecutar dry-run de release en #168.
-
 ## Resultado esperado
 
-Despues de aplicar esta decision, el equipo puede seguir desarrollando en `main` y ramas de issue mientras produccion solo cambia por release aprobada. Staging se convierte en el punto de integracion real y deja de ser una idea informal.
+El equipo integra en `staging`, valida contra BSC Testnet y bases aisladas, y solo promociona a `main` mediante una release aprobada. Produccion no comparte contratos, datos ni secretos con staging.

--- a/packages/contracts/docs/DEPLOYMENT.md
+++ b/packages/contracts/docs/DEPLOYMENT.md
@@ -18,7 +18,7 @@ pnpm --filter @cukies/contracts deploy:testnet
 pnpm --filter @cukies/contracts deploy:testnet:operational
 pnpm --filter @cukies/contracts deploy:mainnet:operational
 pnpm --filter @cukies/contracts handover:mainnet:safe
-pnpm --filter @cukies/contracts preflight:presale -- --network bscTestnet
+pnpm --filter @cukies/contracts preflight:presale --network bscTestnet
 pnpm --filter @cukies/contracts export:abi
 pnpm --filter @cukies/contracts freeze:manifest
 ```
@@ -242,7 +242,7 @@ TOTAL_UKI_FOR_SALE=... \
 SALE_ENABLED=false \
 VESTING_CONFIG_FROZEN=false \
 DEPLOYER_ADDRESS=0x... \
-pnpm --filter @cukies/contracts preflight:presale -- --network bscTestnet
+pnpm --filter @cukies/contracts preflight:presale --network bscTestnet
 ```
 
 The preflight fails unless:
@@ -256,7 +256,8 @@ The preflight fails unless:
 - `Presale` and `UKIToken` are not paused,
 - `Presale` points to the expected vault,
 - `Presale` has `PRESALE_VESTING_ROLE` and is the only holder of that role,
-- deployer has no owner/admin/manager powers when `DEPLOYER_ADDRESS` is provided,
+- en BSC mainnet, el deployer no conserva ownership ni permisos admin/manager cuando se proporciona `DEPLOYER_ADDRESS`,
+- en BSC testnet el deployer puede conservar ownership/admin para operar el ensayo, pero no puede tener `PRESALE_VESTING_ROLE` ni `ALLOCATION_MANAGER_ROLE`,
 - `DEFAULT_ADMIN_ROLE`, `PRESALE_VESTING_ROLE` and `ALLOCATION_MANAGER_ROLE` holder sets exactly match the approved matrix,
 - vault unallocated UKI covers `totalUkiForSale`,
 - `VestingVault.unallocatedWithdrawalUnlockTime()` equals `SALE_END`,

--- a/packages/contracts/docs/FREEZE_CHECKLIST.md
+++ b/packages/contracts/docs/FREEZE_CHECKLIST.md
@@ -54,7 +54,7 @@ The final freeze PR must include:
 | Vault funding | `VestingVault` funded with at least `totalUkiForSale`. | Pending deploy. |
 | Presale role grant | `Presale` has `PRESALE_VESTING_ROLE`. | Pending deploy. |
 | Sale enable gate | `Presale.saleEnabled()` matches the intended phase: false before launch, true while open. | Pending deploy. |
-| Preflight | `pnpm --filter @cukies/contracts preflight:presale -- --network <target>` passes. | Pending deploy. |
+| Preflight | `pnpm --filter @cukies/contracts preflight:presale --network <target>` passes. | Pending deploy. |
 | Dapp config | `NEXT_PUBLIC_*` env values match deployed addresses. | Pending deploy. |
 | ABI versioning | ABI export committed and hash recorded in manifest. | Pending final deploy. |
 | External review | Audit or independent review complete. | Pending. |

--- a/packages/contracts/docs/SECURITY.md
+++ b/packages/contracts/docs/SECURITY.md
@@ -11,7 +11,7 @@ pnpm --filter @cukies/contracts compile
 pnpm --filter @cukies/contracts test
 pnpm --filter @cukies/contracts coverage
 pnpm --filter @cukies/contracts security:slither
-pnpm --filter @cukies/contracts preflight:presale -- --network bscTestnet
+pnpm --filter @cukies/contracts preflight:presale --network bscTestnet
 ```
 
 ## Static analysis

--- a/packages/contracts/scripts/deploy-presale.cjs
+++ b/packages/contracts/scripts/deploy-presale.cjs
@@ -132,7 +132,7 @@ async function main() {
   console.log(`   UKI_VESTING_VAULT_ADDRESS=${await vestingVault.getAddress()} \\`);
   console.log(`   SALE_OWNER_ADDRESS=${owner} \\`);
   console.log(`   SALE_TREASURY_ADDRESS=${treasury} \\`);
-  console.log(`   pnpm --filter @cukies/contracts preflight:presale -- --network ${hre.network.name}`);
+  console.log(`   pnpm --filter @cukies/contracts preflight:presale --network ${hre.network.name}`);
   console.log('8. Verify contracts with hardhat verify once constructor args are recorded.');
 }
 

--- a/packages/contracts/scripts/preflight-presale.cjs
+++ b/packages/contracts/scripts/preflight-presale.cjs
@@ -179,9 +179,17 @@ async function main() {
   );
   if (deployerAddress) {
     const deployer = normalizeAddress(deployerAddress, 'DEPLOYER_ADDRESS');
-    record('deployer is not UKI owner', ukiOwner !== deployer, deployer);
-    record('deployer is not Presale owner', presaleOwner !== deployer, deployer);
-    record('deployer does not have DEFAULT_ADMIN_ROLE', !(await vault.hasRole(defaultAdminRole, deployer)), deployer);
+    if (hre.network.config.chainId === 56) {
+      record('deployer is not UKI owner', ukiOwner !== deployer, deployer);
+      record('deployer is not Presale owner', presaleOwner !== deployer, deployer);
+      record('deployer does not have DEFAULT_ADMIN_ROLE', !(await vault.hasRole(defaultAdminRole, deployer)), deployer);
+    } else {
+      record(
+        'deployer ownership cleanup is mainnet-only',
+        true,
+        `chain id ${hre.network.config.chainId}; testnet may retain deployer ownership for the rehearsal`,
+      );
+    }
     record('deployer does not have PRESALE_VESTING_ROLE', !(await vault.hasRole(presaleRole, deployer)), deployer);
     record('deployer does not have ALLOCATION_MANAGER_ROLE', !(await vault.hasRole(allocationRole, deployer)), deployer);
   }


### PR DESCRIPTION
## Resumen
- corrige el preflight para aplicar la retirada de ownership del deployer solo en BSC mainnet
- corrige el comando pnpm del preflight en scripts y runbooks
- documenta la topología staging/main activa y el nuevo escenario Presale de BSC Testnet
- registra direcciones, bloques y transacciones de despliegue/configuración/smoke

## Validación
- `pnpm --filter @cukies/contracts test`: 34/34 OK
- `pnpm --filter @cukies/contracts simulate:deploy`: OK
- preflight real BSC Testnet: `ready: true`
- compra real: 5 tASM -> 500 UKI, tx `0x9b5f3a5724028f464fa582be7d3178dbf872964b6161123cd0987daf3010f9bd`
- `git diff --check`: OK

## Riesgos y pendientes
- la verificación de source en explorer queda pendiente: la configuración actual usa BscScan API V1, retirada; hay que migrar a Etherscan API V2 y usar una key V2 válida
- el vesting config permanece sin congelar hasta fijar TGE, como exige el flujo operativo
- este PR no toca producción ni sus variables