### PR TITLE
fix: migrate contract verification to Etherscan V2

### DIFF
--- a/docs/contract-ownership-inventory.md
+++ b/docs/contract-ownership-inventory.md
@@ -49,7 +49,7 @@ Comprobacion: RPC publico de BSC testnet.
 | `PRESALE` | `0xC0d7b04AC4DFCCc28790FD492FCB3CB16AcDfcdA` | `0xba84bffad693edbd4b3f7899fb6e3ccb0c1d7820` | `owner()`; desplegado en bloque `123291898`. |
 | `PRESALE_TREASURY` | `0x19907a00abf02975fb60d616c99565894c08d859` | N/A | `Presale.treasury()`. |
 
-El escenario activo abre del `2026-08-05T10:59:20Z` al `2026-09-04T10:59:20Z`, usa `100 UKI/ASM`, compra minima de `5 ASM`, cap de `250,000,000 UKI` y vesting lineal de 9 meses. El vault quedo financiado con el cap completo y la unica cuenta con `PRESALE_VESTING_ROLE` es el contrato `Presale` anterior.
+El escenario activo abre del `2026-08-05T10:59:20Z` al `2026-09-04T10:59:20Z`, usa `100 UKI/ASM`, compra minima de `5 ASM`, cap de `250,000,000 UKI` y vesting lineal de 9 meses. El vault quedo financiado con el cap completo, la unica cuenta con `PRESALE_VESTING_ROLE` es el contrato `Presale` anterior y ambos contratos tienen el source verificado en BscScan mediante Etherscan API V2.
 
 ## ASM BSC mainnet
 

--- a/docs/coolify-deployment.md
+++ b/docs/coolify-deployment.md
@@ -122,7 +122,7 @@ CHAIN_INDEXER_BSC_CONFIRMATIONS=12
 - Vault financiado: tx `0xaafce634b0221268ced2d9e64a1ab8438365072e09cd11aa016dafadf3e65444`.
 - Rol y apertura: tx `0x51117e37bf957a911626d797c7045c03e6ab27d9e98a21a9632d81a74e7a7b1a` y `0x4e8c4ec8ca66c7b2c449a68f60eec23b4a27b7ccbf8d8204ad1f901015cf3ed8`.
 - Compra smoke: `5 tASM -> 500 UKI` en tx `0x9b5f3a5724028f464fa582be7d3178dbf872964b6161123cd0987daf3010f9bd`.
-- Verificacion de fuente en explorer: pendiente de migrar Hardhat/BscScan desde API V1 a Etherscan API V2 y disponer de una API key V2 valida.
+- Source verificado mediante Etherscan API V2: [VestingVault](https://testnet.bscscan.com/address/0xE7cFcebA1342946ff8c382Be8D7B55F0323b1154#code) y [Presale](https://testnet.bscscan.com/address/0xC0d7b04AC4DFCCc28790FD492FCB3CB16AcDfcdA#code).
 
 Config inicial en Mongo para referidos de preventa:
 

--- a/docs/deployment-environments.md
+++ b/docs/deployment-environments.md
@@ -183,7 +183,7 @@ Antes de considerar staging valido:
 - [x] Separar las tres bases staging y habilitar transacciones mediante Mongo replica set `rs0`.
 - [x] Desplegar y financiar un nuevo `VestingVault` y `Presale` en BSC Testnet.
 - [x] Ejecutar una compra on-chain smoke de `5 tASM -> 500 UKI` y validar pago, venta y vesting.
-- [ ] Migrar la verificacion del explorer a Etherscan API V2 y verificar el source de Vault/Presale.
+- [x] Migrar la verificacion del explorer a Etherscan API V2 y verificar el source de Vault/Presale.
 - [ ] Crear usuarios Mongo con minimo privilegio y habilitar `security.authorization` tras validar los consumidores legacy.
 - [ ] Desplegar/verificar `UKIStaking` y `RewardsDistributor` en BSC Testnet.
 - [ ] Configurar HMAC exclusivos de staging y ejecutar el setup de economia v2.

--- a/packages/contracts/.env.example
+++ b/packages/contracts/.env.example
@@ -3,6 +3,9 @@ BSC_TESTNET_RPC_URL=https://data-seed-prebsc-1-s1.binance.org:8545
 DEPLOYER_PRIVATE_KEY=
 # Required by mainnet operational/handover scripts and optional for preflight deployer-cleanup checks.
 DEPLOYER_ADDRESS=
+# Preferred: one Etherscan API V2 key for BSC mainnet and testnet verification.
+ETHERSCAN_API_KEY=
+# Legacy fallback kept while local operator envs are migrated.
 BSCSCAN_API_KEY=
 
 # Existing deployed tokens / sale parameters.
@@ -52,4 +55,3 @@ UKI_REMAINDER_SOURCE_ADDRESS=
 UKI_REMAINDER_SOURCE_PRIVATE_KEY=
 # Defaults to true in handover script.
 SALE_ENABLED_AFTER_HANDOVER=true
-

--- a/packages/contracts/docs/DEPLOYMENT.md
+++ b/packages/contracts/docs/DEPLOYMENT.md
@@ -36,7 +36,7 @@ Required for deploy:
 - `SALE_OWNER_ADDRESS` for BSC testnet/mainnet. Use the launch Safe multisig/admin owner.
 - `SALE_START`, `SALE_END`, `VESTING_START`, `VESTING_DURATION`.
 - `UKI_PER_ASM`, `MIN_ASM_PER_PURCHASE`, `TOTAL_UKI_FOR_SALE`.
-- `BSCSCAN_API_KEY` for verification
+- `ETHERSCAN_API_KEY` for Etherscan API V2 verification. `BSCSCAN_API_KEY` remains a temporary fallback for existing local operator envs.
 
 Optional:
 

--- a/packages/contracts/hardhat.config.cjs
+++ b/packages/contracts/hardhat.config.cjs
@@ -38,10 +38,9 @@ module.exports = {
     }
   },
   etherscan: {
-    apiKey: {
-      bsc: process.env.BSCSCAN_API_KEY || '',
-      bscTestnet: process.env.BSCSCAN_API_KEY || ''
-    },
+    // A single key makes hardhat-verify use Etherscan API V2 for every
+    // supported chain. Keep the legacy env name as a transition fallback.
+    apiKey: process.env.ETHERSCAN_API_KEY || process.env.BSCSCAN_API_KEY || '',
     customChains: [
       {
         network: 'bsc',


### PR DESCRIPTION
## Resumen
- configura `hardhat-verify` con una API key única para activar Etherscan API V2
- conserva `BSCSCAN_API_KEY` como fallback temporal y documenta `ETHERSCAN_API_KEY`
- registra la verificación real de los contratos testnet

## Validación
- `pnpm --filter @cukies/contracts compile`: OK
- VestingVault verificado: https://testnet.bscscan.com/address/0xE7cFcebA1342946ff8c382Be8D7B55F0323b1154#code
- Presale verificada: https://testnet.bscscan.com/address/0xC0d7b04AC4DFCCc28790FD492FCB3CB16AcDfcdA#code
- `git diff --check`: OK

## Riesgos
- los entornos de operador deben migrar gradualmente a `ETHERSCAN_API_KEY`; el fallback evita romper los existentes
- no cambia runtime de dapp, workers ni contratos desplegados