### PR TITLE
fix: support economy indexes on MongoDB 4.4

### DIFF
--- a/packages/chain-indexer/src/storage/economy-indexes.test.ts
+++ b/packages/chain-indexer/src/storage/economy-indexes.test.ts
@@ -179,6 +179,12 @@ describe('economy indexes', () => {
       index.collection === 'game_economy_sessions'
       && index.keys === '{"settlementIntent.decidedAt":1,"_id":1}'
     )));
+    const pendingSettlement = ECONOMY_INDEXES.find((index) => (
+      index.options?.name === 'game_session_pending_settlement_census'
+    ));
+    assert.deepEqual(pendingSettlement?.options?.partialFilterExpression, {
+      'settlementIntent.decidedAt': { $type: 'date' },
+    });
     assert.ok(indexes.some((index) => (
       index.collection === 'game_economy_sessions'
       && index.keys === '{"validation.evidenceId":1}'

--- a/packages/chain-indexer/src/storage/economy-indexes.ts
+++ b/packages/chain-indexer/src/storage/economy-indexes.ts
@@ -502,7 +502,6 @@ const CORE_ECONOMY_INDEXES: EconomyIndexDefinition[] = [
       name: 'game_session_pending_settlement_census',
       partialFilterExpression: {
         'settlementIntent.decidedAt': { $type: 'date' },
-        settlementCommand: { $exists: false },
       },
     },
   },


### PR DESCRIPTION
## Qué corrige

MongoDB 4.4 rechaza `$exists:false` dentro de un partial index. El setup staging se detuvo en `game_session_pending_settlement_census` antes de crear el sentinel.

El índice sigue acotado a documentos con `settlementIntent.decidedAt` de tipo date; la ausencia de `settlementCommand` queda como filtro residual de la consulta. El acceso por `settlementIntent.decidedAt, _id` se conserva.

## Validación

- `pnpm --filter @cukies/chain-indexer test:economy` — 14/14 OK
- `pnpm --filter @cukies/chain-indexer test` — 15/15 OK
- `pnpm --filter @cukies/chain-indexer typecheck` — OK
- `pnpm --filter @cukies/chain-indexer build` — OK

## Alcance

- Base: `staging`.
- No crea sentinel, no activa schedulers y no toca producción.
- El setup fallido solo creó índices idempotentes válidos en `cukieshub-new-staging`.