### PR TITLE
feat: deploy economy schedulers disabled in staging

### DIFF
--- a/dapp/package.json
+++ b/dapp/package.json
@@ -13,6 +13,7 @@
     "postinstall": "prisma generate",
     "init-chat-rooms": "node scripts/init-chat-rooms-with-env.mjs",
     "test": "jest",
+    "test:schedulers": "node --test scripts/*scheduler-policy.test.mjs",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
   },

--- a/dapp/scripts/competition-credit-scheduler-policy.mjs
+++ b/dapp/scripts/competition-credit-scheduler-policy.mjs
@@ -1,0 +1,108 @@
+const DEFAULT_INTERVAL_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 240_000;
+
+function strictBoolean(value, fallback, name) {
+  if (value === undefined || String(value).trim() === '') return fallback;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  throw new Error(`${name} debe ser true o false.`);
+}
+
+function boundedInteger(value, fallback, minimum, maximum, name) {
+  if (value === undefined || String(value).trim() === '') return fallback;
+  const raw = String(value).trim();
+  if (!/^\d+$/.test(raw)) throw new Error(`${name} debe ser un entero.`);
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${name} debe estar entre ${minimum} y ${maximum}.`);
+  }
+  return parsed;
+}
+
+function required(environment, name) {
+  const value = environment[name]?.trim();
+  if (!value) throw new Error(`${name} es obligatorio con el scheduler activo.`);
+  return value;
+}
+
+function schedulerId(value, host) {
+  const candidate = (value?.trim() || host || 'scheduler').slice(0, 64);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(candidate)) {
+    throw new Error('COMPETITION_CREDITS_SCHEDULER_ID tiene formato invalido.');
+  }
+  return candidate;
+}
+
+export function loadCompetitionCreditSchedulerConfig(environment, host) {
+  const enabled = strictBoolean(
+    environment.COMPETITION_CREDITS_SCHEDULER_ENABLED,
+    false,
+    'COMPETITION_CREDITS_SCHEDULER_ENABLED',
+  );
+  const intervalMs = boundedInteger(
+    environment.COMPETITION_CREDITS_SCHEDULER_INTERVAL_MS,
+    DEFAULT_INTERVAL_MS,
+    5_000,
+    10 * 60_000,
+    'COMPETITION_CREDITS_SCHEDULER_INTERVAL_MS',
+  );
+  const tickTimeoutMs = boundedInteger(
+    environment.COMPETITION_CREDITS_TICK_TIMEOUT_MS,
+    DEFAULT_TIMEOUT_MS,
+    10_000,
+    600_000,
+    'COMPETITION_CREDITS_TICK_TIMEOUT_MS',
+  );
+  if (!enabled) {
+    return {
+      enabled,
+      intervalMs,
+      tickTimeoutMs,
+      schedulerId: schedulerId(environment.COMPETITION_CREDITS_SCHEDULER_ID, host),
+    };
+  }
+
+  const secret = required(environment, 'ECONOMY_INTERNAL_HMAC_SECRET');
+  if (Buffer.byteLength(secret, 'utf8') < 32) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET debe tener al menos 32 bytes.');
+  }
+  if (
+    new Set(secret).size < 10
+    || /^(.)\1+$/.test(secret)
+    || /(change[-_ ]?me|example|placeholder|default|secret123|password)/i.test(secret)
+  ) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET parece predecible o de ejemplo.');
+  }
+  if (Object.entries(environment).some(([name, value]) => (
+    name.startsWith('NEXT_PUBLIC_') && typeof value === 'string' && value.trim() === secret
+  ))) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET no puede reutilizar NEXT_PUBLIC.');
+  }
+  const keyId = required(environment, 'ECONOMY_INTERNAL_HMAC_KEY_ID');
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(keyId)) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_KEY_ID tiene formato invalido.');
+  }
+  const baseUrl = (environment.COMPETITION_CREDITS_SCHEDULER_BASE_URL?.trim()
+    || 'http://dapp:3000').replace(/\/$/, '');
+  const parsedBaseUrl = new URL(baseUrl);
+  if (!['http:', 'https:'].includes(parsedBaseUrl.protocol) || parsedBaseUrl.username || parsedBaseUrl.password) {
+    throw new Error('COMPETITION_CREDITS_SCHEDULER_BASE_URL debe ser HTTP(S) sin credenciales.');
+  }
+  const dbName = required(environment, 'CHAIN_INDEXER_DB_NAME');
+  if (!new Set(['cukieshub-new', 'cukieshub-new-staging']).has(dbName)) {
+    throw new Error(
+      'CHAIN_INDEXER_DB_NAME debe ser cukieshub-new o cukieshub-new-staging para credits.',
+    );
+  }
+  return {
+    enabled,
+    intervalMs,
+    tickTimeoutMs,
+    schedulerId: schedulerId(environment.COMPETITION_CREDITS_SCHEDULER_ID, host),
+    baseUrl,
+    keyId,
+    secret,
+    mongoUrl: required(environment, 'CHAIN_INDEXER_MONGO_URL'),
+    dbName,
+  };
+}

--- a/dapp/scripts/competition-credit-scheduler-policy.test.mjs
+++ b/dapp/scripts/competition-credit-scheduler-policy.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { loadCompetitionCreditSchedulerConfig } from './competition-credit-scheduler-policy.mjs';
+
+const STRONG_SECRET = 'B7!qL2@zN9#vR4$xC8%mK5&wT1*eY6+pD3=sH0_uF7-jS2.a';
+
+function environment(overrides = {}) {
+  return {
+    COMPETITION_CREDITS_SCHEDULER_ENABLED: 'true',
+    CHAIN_INDEXER_MONGO_URL: 'mongodb://mongo:27017',
+    CHAIN_INDEXER_DB_NAME: 'cukieshub-new',
+    ECONOMY_INTERNAL_HMAC_KEY_ID: 'competition-credits-2026-01',
+    ECONOMY_INTERNAL_HMAC_SECRET: STRONG_SECRET,
+    ...overrides,
+  };
+}
+
+describe('competition credit scheduler policy', () => {
+  it('stays disabled without credentials by default', () => {
+    const config = loadCompetitionCreditSchedulerConfig({}, 'host-a');
+    assert.equal(config.enabled, false);
+    assert.equal(config.schedulerId, 'host-a');
+  });
+
+  it('loads only a bounded scheduler for cukieshub-new', () => {
+    const config = loadCompetitionCreditSchedulerConfig(environment(), 'host-a');
+    assert.equal(config.enabled, true);
+    assert.equal(config.dbName, 'cukieshub-new');
+    assert.equal(config.baseUrl, 'http://dapp:3000');
+    assert.equal(config.tickTimeoutMs, 240_000);
+  });
+
+  it('accepts the isolated staging economy database', () => {
+    const config = loadCompetitionCreditSchedulerConfig(environment({
+      CHAIN_INDEXER_DB_NAME: 'cukieshub-new-staging',
+    }), 'host-staging');
+    assert.equal(config.enabled, true);
+    assert.equal(config.dbName, 'cukieshub-new-staging');
+  });
+
+  it('rejects weak/public credentials, legacy DB and unsafe URLs', () => {
+    assert.throws(() => loadCompetitionCreditSchedulerConfig(environment({
+      ECONOMY_INTERNAL_HMAC_SECRET: 'a'.repeat(64),
+    }), 'host-a'), /predecible/);
+    assert.throws(() => loadCompetitionCreditSchedulerConfig(environment({
+      NEXT_PUBLIC_REUSED_SECRET: STRONG_SECRET,
+    }), 'host-a'), /NEXT_PUBLIC/);
+    assert.throws(() => loadCompetitionCreditSchedulerConfig(environment({
+      CHAIN_INDEXER_DB_NAME: 'cukies',
+    }), 'host-a'), /cukieshub-new/);
+    assert.throws(() => loadCompetitionCreditSchedulerConfig(environment({
+      COMPETITION_CREDITS_SCHEDULER_BASE_URL: 'https://user:pass@example.com',
+    }), 'host-a'), /sin credenciales/);
+  });
+});

--- a/dapp/scripts/competition-credit-scheduler.mjs
+++ b/dapp/scripts/competition-credit-scheduler.mjs
@@ -1,0 +1,133 @@
+import { createHash, createHmac, randomBytes } from 'node:crypto';
+import { hostname } from 'node:os';
+
+import { MongoClient } from 'mongodb';
+
+import { loadCompetitionCreditSchedulerConfig } from './competition-credit-scheduler-policy.mjs';
+
+const path = '/api/economy/v1/internal/credits/tick';
+const config = loadCompetitionCreditSchedulerConfig(process.env, hostname());
+const heartbeatId = `scheduler-heartbeat:${config.schedulerId}`;
+const mongoClient = config.enabled ? new MongoClient(config.mongoUrl) : null;
+const heartbeatCollection = mongoClient
+  ? mongoClient.db(config.dbName).collection('competition_credit_runtime_state')
+  : null;
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function schedulerErrorCode(error) {
+  if (error instanceof Error && /^Tick credits fallo con HTTP \d+$/.test(error.message)) {
+    return error.message.replace('Tick credits fallo con ', '').replace(' ', '_');
+  }
+  if (error instanceof Error && error.name === 'TimeoutError') return 'TICK_TIMEOUT';
+  return 'TICK_FAILED';
+}
+
+async function recordHeartbeat(status, errorCode = null) {
+  if (!heartbeatCollection) return;
+  const now = new Date();
+  if (status === 'attempt') {
+    await heartbeatCollection.updateOne(
+      { _id: heartbeatId },
+      {
+        $set: {
+          schedulerId: config.schedulerId,
+          status: 'running',
+          lastAttemptAt: now,
+          updatedAt: now,
+        },
+        $setOnInsert: { _id: heartbeatId, createdAt: now, consecutiveFailures: 0 },
+      },
+      { upsert: true },
+    );
+    return;
+  }
+  if (status === 'success') {
+    await heartbeatCollection.updateOne(
+      { _id: heartbeatId },
+      {
+        $set: {
+          schedulerId: config.schedulerId,
+          status: 'success',
+          lastAttemptAt: now,
+          lastSuccessAt: now,
+          consecutiveFailures: 0,
+          updatedAt: now,
+        },
+        $unset: { lastErrorCode: '' },
+        $setOnInsert: { _id: heartbeatId, createdAt: now },
+      },
+      { upsert: true },
+    );
+    return;
+  }
+  await heartbeatCollection.updateOne(
+    { _id: heartbeatId },
+    {
+      $set: {
+        schedulerId: config.schedulerId,
+        status: 'error',
+        lastAttemptAt: now,
+        lastErrorCode: errorCode,
+        updatedAt: now,
+      },
+      $inc: { consecutiveFailures: 1 },
+      $setOnInsert: { _id: heartbeatId, createdAt: now },
+    },
+    { upsert: true },
+  );
+}
+
+async function tick() {
+  const body = JSON.stringify({ workerId: `scheduler:${config.schedulerId}` });
+  const timestamp = String(Date.now());
+  const nonce = randomBytes(16).toString('base64url');
+  const canonical = [
+    'cukies-economy-hmac-v1',
+    config.keyId,
+    'POST',
+    path,
+    timestamp,
+    nonce,
+    sha256(Buffer.from(body, 'utf8')),
+  ].join('\n');
+  const signature = createHmac('sha256', Buffer.from(config.secret, 'utf8'))
+    .update(canonical, 'utf8')
+    .digest('hex');
+  const response = await fetch(`${config.baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-economy-key-id': config.keyId,
+      'x-economy-timestamp': timestamp,
+      'x-economy-nonce': nonce,
+      'x-economy-signature': `v1=${signature}`,
+    },
+    body,
+    signal: AbortSignal.timeout(config.tickTimeoutMs),
+  });
+  if (!response.ok) throw new Error(`Tick credits fallo con HTTP ${response.status}`);
+}
+
+if (mongoClient) await mongoClient.connect();
+
+while (true) {
+  if (config.enabled) {
+    try {
+      await recordHeartbeat('attempt');
+      await tick();
+      await recordHeartbeat('success');
+    } catch (error) {
+      const errorCode = schedulerErrorCode(error);
+      try {
+        await recordHeartbeat('error', errorCode);
+      } catch {
+        process.stderr.write(`${new Date().toISOString()} CREDIT_SCHEDULER_HEARTBEAT_WRITE_FAILED\n`);
+      }
+      process.stderr.write(`${new Date().toISOString()} ${errorCode}\n`);
+    }
+  }
+  await new Promise((resolve) => setTimeout(resolve, config.intervalMs));
+}

--- a/dapp/scripts/cukie-master-scheduler-policy.mjs
+++ b/dapp/scripts/cukie-master-scheduler-policy.mjs
@@ -1,0 +1,112 @@
+const DEFAULT_DB_NAME = 'cukieshub-new';
+
+function boundedInteger(environment, name, fallback, minimum, maximum) {
+  const raw = environment[name]?.trim();
+  if (!raw) return fallback;
+  if (!/^\d+$/.test(raw)) throw new Error(`${name} debe ser un entero positivo.`);
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} debe estar entre ${minimum} y ${maximum}.`);
+  }
+  return value;
+}
+
+function required(environment, name) {
+  const value = environment[name]?.trim();
+  if (!value) throw new Error(`${name} es obligatorio para el scheduler Cukie Master.`);
+  return value;
+}
+
+function validateHmac(environment) {
+  const keyId = required(environment, 'ECONOMY_INTERNAL_HMAC_KEY_ID');
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(keyId)) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_KEY_ID tiene un formato invalido.');
+  }
+  const secret = required(environment, 'ECONOMY_INTERNAL_HMAC_SECRET');
+  const publicReuse = Object.entries(environment).some(([name, value]) => (
+    name.startsWith('NEXT_PUBLIC_')
+    && typeof value === 'string'
+    && value.trim().length > 0
+    && value.trim() === secret
+  ));
+  if (publicReuse) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET no puede reutilizar una variable NEXT_PUBLIC.');
+  }
+  if (Buffer.byteLength(secret, 'utf8') < 32) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET debe tener al menos 32 bytes.');
+  }
+  if (
+    new Set(secret).size < 10
+    || /^(.)\1+$/.test(secret)
+    || /(change[-_ ]?me|example|placeholder|default|secret123|password)/i.test(secret)
+  ) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET parece predecible o de ejemplo.');
+  }
+  return { keyId, secret };
+}
+
+export function loadCukieMasterSchedulerConfig(environment = process.env, host = 'scheduler') {
+  const enabled = environment.CHAIN_INDEXER_CUKIE_MASTER_ENABLED?.trim().toLowerCase() === 'true';
+  const intervalMs = boundedInteger(
+    environment,
+    'CUKIE_MASTER_SCHEDULER_INTERVAL_MS',
+    60_000,
+    10_000,
+    60 * 60_000,
+  );
+  const tickTimeoutMs = boundedInteger(
+    environment,
+    'CUKIE_MASTER_TICK_TIMEOUT_MS',
+    300_000,
+    10_000,
+    600_000,
+  );
+  const queueLimit = boundedInteger(
+    environment,
+    'CUKIE_MASTER_QUEUE_LIMIT',
+    100,
+    1,
+    500,
+  );
+  const baseUrl = (environment.CUKIE_MASTER_DAPP_INTERNAL_URL ?? 'http://dapp:3000')
+    .trim().replace(/\/$/, '');
+  if (!/^https?:\/\//i.test(baseUrl)) {
+    throw new Error('CUKIE_MASTER_DAPP_INTERNAL_URL debe ser una URL HTTP(S).');
+  }
+  const schedulerId = (environment.CUKIE_MASTER_SCHEDULER_ID ?? host).trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(schedulerId)) {
+    throw new Error('CUKIE_MASTER_SCHEDULER_ID tiene un formato invalido.');
+  }
+  if (!enabled) {
+    return {
+      enabled,
+      intervalMs,
+      tickTimeoutMs,
+      queueLimit,
+      baseUrl,
+      schedulerId,
+      keyId: null,
+      secret: null,
+      mongoUrl: null,
+      dbName: null,
+    };
+  }
+  const { keyId, secret } = validateHmac(environment);
+  const mongoUrl = required(environment, 'CHAIN_INDEXER_MONGO_URL');
+  const dbName = (environment.CHAIN_INDEXER_DB_NAME ?? DEFAULT_DB_NAME).trim();
+  if (!dbName || dbName.toLowerCase() === 'cukies') {
+    throw new Error('CHAIN_INDEXER_DB_NAME no puede estar vacio ni apuntar a `cukies`.');
+  }
+  return {
+    enabled,
+    intervalMs,
+    tickTimeoutMs,
+    queueLimit,
+    baseUrl,
+    schedulerId,
+    keyId,
+    secret,
+    mongoUrl,
+    dbName,
+  };
+}

--- a/dapp/scripts/cukie-master-scheduler-policy.test.mjs
+++ b/dapp/scripts/cukie-master-scheduler-policy.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { loadCukieMasterSchedulerConfig } from './cukie-master-scheduler-policy.mjs';
+
+const STRONG_SECRET = 'B7!qL2@zN9#vR4$xC8%mK5&wT1*eY6+pD3=sH0_uF7-jS2.a';
+
+function environment(overrides = {}) {
+  return {
+    CHAIN_INDEXER_CUKIE_MASTER_ENABLED: 'true',
+    CHAIN_INDEXER_MONGO_URL: 'mongodb://mongo:27017',
+    CHAIN_INDEXER_DB_NAME: 'cukieshub-new',
+    ECONOMY_INTERNAL_HMAC_KEY_ID: 'cukie-master-2026-01',
+    ECONOMY_INTERNAL_HMAC_SECRET: STRONG_SECRET,
+    CUKIE_MASTER_QUEUE_LIMIT: '100',
+    ...overrides,
+  };
+}
+
+describe('Cukie Master scheduler policy', () => {
+  it('loads a bounded production configuration', () => {
+    const config = loadCukieMasterSchedulerConfig(environment(), 'host-a');
+    assert.equal(config.enabled, true);
+    assert.equal(config.queueLimit, 100);
+    assert.equal(config.schedulerId, 'host-a');
+    assert.equal(config.dbName, 'cukieshub-new');
+  });
+
+  it('rejects weak, public-reused and malformed HMAC credentials', () => {
+    assert.throws(() => loadCukieMasterSchedulerConfig(environment({
+      ECONOMY_INTERNAL_HMAC_KEY_ID: 'bad key',
+    })), /formato invalido/);
+    assert.throws(() => loadCukieMasterSchedulerConfig(environment({
+      ECONOMY_INTERNAL_HMAC_SECRET: 'a'.repeat(64),
+    })), /predecible/);
+    assert.throws(() => loadCukieMasterSchedulerConfig(environment({
+      NEXT_PUBLIC_REUSED_SECRET: STRONG_SECRET,
+    })), /NEXT_PUBLIC/);
+  });
+
+  it('rejects queue limits outside 1..500 and the legacy database', () => {
+    assert.throws(() => loadCukieMasterSchedulerConfig(environment({
+      CUKIE_MASTER_QUEUE_LIMIT: '0',
+    })), /entre 1 y 500/);
+    assert.throws(() => loadCukieMasterSchedulerConfig(environment({
+      CUKIE_MASTER_QUEUE_LIMIT: '501',
+    })), /entre 1 y 500/);
+    assert.throws(() => loadCukieMasterSchedulerConfig(environment({
+      CHAIN_INDEXER_DB_NAME: 'cukies',
+    })), /no puede/);
+  });
+});

--- a/dapp/scripts/cukie-master-scheduler.mjs
+++ b/dapp/scripts/cukie-master-scheduler.mjs
@@ -1,0 +1,141 @@
+import { createHash, createHmac, randomBytes } from 'node:crypto';
+import { hostname } from 'node:os';
+
+import { MongoClient } from 'mongodb';
+
+import { loadCukieMasterSchedulerConfig } from './cukie-master-scheduler-policy.mjs';
+
+const path = '/api/economy/v1/internal/cukie-master/tick';
+const config = loadCukieMasterSchedulerConfig(process.env, hostname());
+const heartbeatId = `scheduler-heartbeat:${config.schedulerId}`;
+const mongoClient = config.enabled ? new MongoClient(config.mongoUrl) : null;
+const heartbeatCollection = mongoClient
+  ? mongoClient.db(config.dbName).collection('cukie_master_runtime_state')
+  : null;
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function schedulerErrorCode(error) {
+  if (error instanceof Error && /^Tick Cukie Master fallo con HTTP \d+$/.test(error.message)) {
+    return error.message.replace('Tick Cukie Master fallo con ', '').replace(' ', '_');
+  }
+  if (error instanceof Error && error.name === 'TimeoutError') return 'TICK_TIMEOUT';
+  return 'TICK_FAILED';
+}
+
+async function recordHeartbeat(status, errorCode = null) {
+  if (!heartbeatCollection) return;
+  const now = new Date();
+  if (status === 'attempt') {
+    await heartbeatCollection.updateOne(
+      { _id: heartbeatId },
+      {
+        $set: {
+          schedulerId: config.schedulerId,
+          status: 'running',
+          lastAttemptAt: now,
+          updatedAt: now,
+        },
+        $setOnInsert: {
+          _id: heartbeatId,
+          createdAt: now,
+          consecutiveFailures: 0,
+        },
+      },
+      { upsert: true },
+    );
+    return;
+  }
+  if (status === 'success') {
+    await heartbeatCollection.updateOne(
+      { _id: heartbeatId },
+      {
+        $set: {
+          schedulerId: config.schedulerId,
+          status: 'success',
+          lastAttemptAt: now,
+          lastSuccessAt: now,
+          consecutiveFailures: 0,
+          updatedAt: now,
+        },
+        $unset: { lastErrorCode: '' },
+        $setOnInsert: { _id: heartbeatId, createdAt: now },
+      },
+      { upsert: true },
+    );
+    return;
+  }
+  await heartbeatCollection.updateOne(
+    { _id: heartbeatId },
+    {
+      $set: {
+        schedulerId: config.schedulerId,
+        status: 'error',
+        lastAttemptAt: now,
+        lastErrorCode: errorCode,
+        updatedAt: now,
+      },
+      $inc: { consecutiveFailures: 1 },
+      $setOnInsert: { _id: heartbeatId, createdAt: now },
+    },
+    { upsert: true },
+  );
+}
+
+async function tick() {
+  const body = JSON.stringify({
+    workerId: `scheduler:${config.schedulerId}`,
+    queueLimit: config.queueLimit,
+  });
+  const timestamp = String(Date.now());
+  const nonce = randomBytes(16).toString('base64url');
+  const bodyHash = sha256(Buffer.from(body, 'utf8'));
+  const canonical = [
+    'cukies-economy-hmac-v1',
+    config.keyId,
+    'POST',
+    path,
+    timestamp,
+    nonce,
+    bodyHash,
+  ].join('\n');
+  const signature = createHmac('sha256', Buffer.from(config.secret, 'utf8'))
+    .update(canonical, 'utf8')
+    .digest('hex');
+  const response = await fetch(`${config.baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-economy-key-id': config.keyId,
+      'x-economy-timestamp': timestamp,
+      'x-economy-nonce': nonce,
+      'x-economy-signature': `v1=${signature}`,
+    },
+    body,
+    signal: AbortSignal.timeout(config.tickTimeoutMs),
+  });
+  if (!response.ok) throw new Error(`Tick Cukie Master fallo con HTTP ${response.status}`);
+}
+
+if (mongoClient) await mongoClient.connect();
+
+while (true) {
+  if (config.enabled) {
+    try {
+      await recordHeartbeat('attempt');
+      await tick();
+      await recordHeartbeat('success');
+    } catch (error) {
+      const errorCode = schedulerErrorCode(error);
+      try {
+        await recordHeartbeat('error', errorCode);
+      } catch {
+        process.stderr.write(`${new Date().toISOString()} SCHEDULER_HEARTBEAT_WRITE_FAILED\n`);
+      }
+      process.stderr.write(`${new Date().toISOString()} ${errorCode}\n`);
+    }
+  }
+  await new Promise((resolve) => setTimeout(resolve, config.intervalMs));
+}

--- a/dapp/scripts/cukie-pool-scheduler-policy.mjs
+++ b/dapp/scripts/cukie-pool-scheduler-policy.mjs
@@ -1,0 +1,107 @@
+const DEFAULT_DB_NAME = 'cukieshub-new';
+
+function boundedInteger(environment, name, fallback, minimum, maximum) {
+  const raw = environment[name]?.trim();
+  if (!raw) return fallback;
+  if (!/^\d+$/.test(raw)) throw new Error(`${name} debe ser un entero positivo.`);
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} debe estar entre ${minimum} y ${maximum}.`);
+  }
+  return value;
+}
+
+function required(environment, name) {
+  const value = environment[name]?.trim();
+  if (!value) throw new Error(`${name} es obligatorio para el scheduler del pool de Cukies.`);
+  return value;
+}
+
+function validateHmac(environment) {
+  const keyId = required(environment, 'ECONOMY_INTERNAL_HMAC_KEY_ID');
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(keyId)) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_KEY_ID tiene un formato invalido.');
+  }
+  const secret = required(environment, 'ECONOMY_INTERNAL_HMAC_SECRET');
+  const publicReuse = Object.entries(environment).some(([name, value]) => (
+    name.startsWith('NEXT_PUBLIC_')
+    && typeof value === 'string'
+    && value.trim().length > 0
+    && value.trim() === secret
+  ));
+  if (publicReuse) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET no puede reutilizar una variable NEXT_PUBLIC.');
+  }
+  if (Buffer.byteLength(secret, 'utf8') < 32) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET debe tener al menos 32 bytes.');
+  }
+  if (
+    new Set(secret).size < 10
+    || /^(.)\1+$/.test(secret)
+    || /(change[-_ ]?me|example|placeholder|default|secret123|password)/i.test(secret)
+  ) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET parece predecible o de ejemplo.');
+  }
+  return { keyId, secret };
+}
+
+export function loadCukiePoolSchedulerConfig(environment = process.env, host = 'scheduler') {
+  const rawEnabled = environment.CUKIE_POOL_RUNTIME_ENABLED?.trim();
+  if (rawEnabled && rawEnabled !== 'true' && rawEnabled !== 'false') {
+    throw new Error('CUKIE_POOL_RUNTIME_ENABLED debe ser true o false.');
+  }
+  const enabled = rawEnabled === 'true';
+  const intervalMs = boundedInteger(
+    environment,
+    'CUKIE_POOL_SCHEDULER_INTERVAL_MS',
+    30_000,
+    10_000,
+    60 * 60_000,
+  );
+  const tickTimeoutMs = boundedInteger(
+    environment,
+    'CUKIE_POOL_TICK_TIMEOUT_MS',
+    240_000,
+    10_000,
+    600_000,
+  );
+  const baseUrl = (environment.CUKIE_POOL_DAPP_INTERNAL_URL ?? 'http://dapp:3000')
+    .trim().replace(/\/$/, '');
+  if (!/^https?:\/\//i.test(baseUrl)) {
+    throw new Error('CUKIE_POOL_DAPP_INTERNAL_URL debe ser una URL HTTP(S).');
+  }
+  const schedulerId = (environment.CUKIE_POOL_SCHEDULER_ID ?? host).trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(schedulerId)) {
+    throw new Error('CUKIE_POOL_SCHEDULER_ID tiene un formato invalido.');
+  }
+  if (!enabled) {
+    return {
+      enabled,
+      intervalMs,
+      tickTimeoutMs,
+      baseUrl,
+      schedulerId,
+      keyId: null,
+      secret: null,
+      mongoUrl: null,
+      dbName: null,
+    };
+  }
+  const { keyId, secret } = validateHmac(environment);
+  const mongoUrl = required(environment, 'CHAIN_INDEXER_MONGO_URL');
+  const dbName = (environment.CHAIN_INDEXER_DB_NAME ?? DEFAULT_DB_NAME).trim();
+  if (!dbName || dbName.toLowerCase() === 'cukies') {
+    throw new Error('CHAIN_INDEXER_DB_NAME no puede estar vacio ni apuntar a `cukies`.');
+  }
+  return {
+    enabled,
+    intervalMs,
+    tickTimeoutMs,
+    baseUrl,
+    schedulerId,
+    keyId,
+    secret,
+    mongoUrl,
+    dbName,
+  };
+}

--- a/dapp/scripts/cukie-pool-scheduler-policy.test.mjs
+++ b/dapp/scripts/cukie-pool-scheduler-policy.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { loadCukiePoolSchedulerConfig } from './cukie-pool-scheduler-policy.mjs';
+
+const SECRET = 'pool-scheduler-secret-with-entropy-A9!';
+
+test('scheduler remains inert without pool runtime enablement', () => {
+  assert.deepEqual(loadCukiePoolSchedulerConfig({}, 'test-host'), {
+    enabled: false,
+    intervalMs: 30_000,
+    tickTimeoutMs: 240_000,
+    baseUrl: 'http://dapp:3000',
+    schedulerId: 'test-host',
+    keyId: null,
+    secret: null,
+    mongoUrl: null,
+    dbName: null,
+  });
+});
+
+test('enabled scheduler requires private HMAC and economy Mongo identity', () => {
+  assert.throws(() => loadCukiePoolSchedulerConfig({
+    CUKIE_POOL_RUNTIME_ENABLED: 'true',
+  }), /ECONOMY_INTERNAL_HMAC_KEY_ID/);
+  assert.throws(() => loadCukiePoolSchedulerConfig({
+    CUKIE_POOL_RUNTIME_ENABLED: 'true',
+    ECONOMY_INTERNAL_HMAC_KEY_ID: 'pool',
+    ECONOMY_INTERNAL_HMAC_SECRET: SECRET,
+  }), /CHAIN_INDEXER_MONGO_URL/);
+  assert.deepEqual(loadCukiePoolSchedulerConfig({
+    CUKIE_POOL_RUNTIME_ENABLED: 'true',
+    ECONOMY_INTERNAL_HMAC_KEY_ID: 'pool',
+    ECONOMY_INTERNAL_HMAC_SECRET: SECRET,
+    CHAIN_INDEXER_MONGO_URL: 'mongodb://economy.example/cukieshub-new',
+    CHAIN_INDEXER_DB_NAME: 'cukieshub-new',
+  }, 'test-host'), {
+    enabled: true,
+    intervalMs: 30_000,
+    tickTimeoutMs: 240_000,
+    baseUrl: 'http://dapp:3000',
+    schedulerId: 'test-host',
+    keyId: 'pool',
+    secret: SECRET,
+    mongoUrl: 'mongodb://economy.example/cukieshub-new',
+    dbName: 'cukieshub-new',
+  });
+});
+
+test('scheduler rejects public secret reuse and legacy database', () => {
+  const base = {
+    CUKIE_POOL_RUNTIME_ENABLED: 'true',
+    ECONOMY_INTERNAL_HMAC_KEY_ID: 'pool',
+    ECONOMY_INTERNAL_HMAC_SECRET: SECRET,
+    CHAIN_INDEXER_MONGO_URL: 'mongodb://economy.example/cukieshub-new',
+  };
+  assert.throws(() => loadCukiePoolSchedulerConfig({
+    ...base,
+    NEXT_PUBLIC_POOL_SECRET: SECRET,
+  }), /NEXT_PUBLIC/);
+  assert.throws(() => loadCukiePoolSchedulerConfig({
+    ...base,
+    CHAIN_INDEXER_DB_NAME: 'cukies',
+  }), /cukies/);
+});

--- a/dapp/scripts/cukie-pool-scheduler.mjs
+++ b/dapp/scripts/cukie-pool-scheduler.mjs
@@ -1,0 +1,132 @@
+import { createHash, createHmac, randomBytes } from 'node:crypto';
+import { hostname } from 'node:os';
+
+import { MongoClient } from 'mongodb';
+
+import { loadCukiePoolSchedulerConfig } from './cukie-pool-scheduler-policy.mjs';
+
+const path = '/api/economy/v1/internal/cukie-pool/tick';
+const config = loadCukiePoolSchedulerConfig(process.env, hostname());
+const heartbeatId = `scheduler-heartbeat:${config.schedulerId}`;
+const mongoClient = config.enabled ? new MongoClient(config.mongoUrl) : null;
+const heartbeatCollection = mongoClient
+  ? mongoClient.db(config.dbName).collection('cukie_pool_runtime_state')
+  : null;
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function schedulerErrorCode(error) {
+  if (error instanceof Error && /^Tick del pool fallo con HTTP \d+$/.test(error.message)) {
+    return error.message.replace('Tick del pool fallo con ', '').replace(' ', '_');
+  }
+  if (error instanceof Error && error.name === 'TimeoutError') return 'TICK_TIMEOUT';
+  return 'TICK_FAILED';
+}
+
+async function recordHeartbeat(status, errorCode = null) {
+  if (!heartbeatCollection) return;
+  const now = new Date();
+  if (status === 'attempt') {
+    await heartbeatCollection.updateOne(
+      { _id: heartbeatId },
+      {
+        $set: {
+          schedulerId: config.schedulerId,
+          status: 'running',
+          lastAttemptAt: now,
+          updatedAt: now,
+        },
+        $setOnInsert: { _id: heartbeatId, createdAt: now, consecutiveFailures: 0 },
+      },
+      { upsert: true },
+    );
+    return;
+  }
+  if (status === 'success') {
+    await heartbeatCollection.updateOne(
+      { _id: heartbeatId },
+      {
+        $set: {
+          schedulerId: config.schedulerId,
+          status: 'success',
+          lastSuccessAt: now,
+          consecutiveFailures: 0,
+          updatedAt: now,
+        },
+        $unset: { lastErrorCode: '' },
+        $setOnInsert: { _id: heartbeatId, createdAt: now },
+      },
+      { upsert: true },
+    );
+    return;
+  }
+  await heartbeatCollection.updateOne(
+    { _id: heartbeatId },
+    {
+      $set: {
+        schedulerId: config.schedulerId,
+        status: 'error',
+        lastErrorCode: errorCode,
+        updatedAt: now,
+      },
+      $inc: { consecutiveFailures: 1 },
+      $setOnInsert: { _id: heartbeatId, createdAt: now },
+    },
+    { upsert: true },
+  );
+}
+
+async function tick() {
+  const body = JSON.stringify({ workerId: `scheduler:${config.schedulerId}` });
+  const timestamp = String(Date.now());
+  const nonce = randomBytes(16).toString('base64url');
+  const bodyHash = sha256(Buffer.from(body, 'utf8'));
+  const canonical = [
+    'cukies-economy-hmac-v1',
+    config.keyId,
+    'POST',
+    path,
+    timestamp,
+    nonce,
+    bodyHash,
+  ].join('\n');
+  const signature = createHmac('sha256', Buffer.from(config.secret, 'utf8'))
+    .update(canonical, 'utf8')
+    .digest('hex');
+  const response = await fetch(`${config.baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-economy-key-id': config.keyId,
+      'x-economy-timestamp': timestamp,
+      'x-economy-nonce': nonce,
+      'x-economy-signature': `v1=${signature}`,
+    },
+    body,
+    signal: AbortSignal.timeout(config.tickTimeoutMs),
+  });
+  if (!response.ok) throw new Error(`Tick del pool fallo con HTTP ${response.status}`);
+}
+
+if (mongoClient) await mongoClient.connect();
+
+while (true) {
+  if (config.enabled) {
+    try {
+      await recordHeartbeat('attempt');
+      await tick();
+      await recordHeartbeat('success');
+    } catch (error) {
+      const errorCode = schedulerErrorCode(error);
+      try {
+        await recordHeartbeat('error', errorCode);
+      } catch {
+        process.stderr.write(`${new Date().toISOString()} SCHEDULER_HEARTBEAT_WRITE_FAILED\n`);
+      }
+      process.stderr.write(`${new Date().toISOString()} ${errorCode}\n`);
+    }
+  }
+  await new Promise((resolve) => setTimeout(resolve, config.intervalMs));
+}

--- a/dapp/scripts/game-economy-scheduler-policy.mjs
+++ b/dapp/scripts/game-economy-scheduler-policy.mjs
@@ -1,0 +1,81 @@
+const DEFAULT_DB_NAME = 'cukieshub-new';
+
+function required(environment, name) {
+  const value = environment[name]?.trim();
+  if (!value) throw new Error(`${name} es obligatorio para el scheduler GameEconomy.`);
+  return value;
+}
+
+function bounded(environment, name, fallback, minimum, maximum) {
+  const raw = environment[name]?.trim();
+  if (!raw) return fallback;
+  if (!/^\d+$/.test(raw)) throw new Error(`${name} debe ser un entero.`);
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} debe estar entre ${minimum} y ${maximum}.`);
+  }
+  return value;
+}
+
+export function loadGameEconomySchedulerConfig(environment = process.env, host = 'scheduler') {
+  const rawEnabled = environment.GAME_ECONOMY_RUNTIME_ENABLED?.trim();
+  if (rawEnabled && rawEnabled !== 'true' && rawEnabled !== 'false') {
+    throw new Error('GAME_ECONOMY_RUNTIME_ENABLED debe ser true o false.');
+  }
+  const enabled = rawEnabled === 'true';
+  const baseUrl = (environment.GAME_ECONOMY_DAPP_INTERNAL_URL ?? 'http://dapp:3000')
+    .trim().replace(/\/$/, '');
+  if (!/^https?:\/\//i.test(baseUrl)) {
+    throw new Error('GAME_ECONOMY_DAPP_INTERNAL_URL debe ser HTTP(S).');
+  }
+  const schedulerId = (environment.GAME_ECONOMY_SCHEDULER_ID ?? host).trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(schedulerId)) {
+    throw new Error('GAME_ECONOMY_SCHEDULER_ID tiene formato invalido.');
+  }
+  const shared = {
+    enabled,
+    baseUrl,
+    schedulerId,
+    intervalMs: bounded(
+      environment,
+      'GAME_ECONOMY_SCHEDULER_INTERVAL_MS',
+      30_000,
+      10_000,
+      60 * 60_000,
+    ),
+    tickTimeoutMs: bounded(
+      environment,
+      'GAME_ECONOMY_TICK_TIMEOUT_MS',
+      240_000,
+      10_000,
+      600_000,
+    ),
+  };
+  if (!enabled) {
+    return { ...shared, keyId: null, secret: null, mongoUrl: null, dbName: null };
+  }
+  const keyId = required(environment, 'ECONOMY_INTERNAL_HMAC_KEY_ID');
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(keyId)) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_KEY_ID tiene formato invalido.');
+  }
+  const secret = required(environment, 'ECONOMY_INTERNAL_HMAC_SECRET');
+  if (Buffer.byteLength(secret, 'utf8') < 32 || new Set(secret).size < 10) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET no tiene entropia suficiente.');
+  }
+  if (Object.entries(environment).some(([name, value]) => (
+    name.startsWith('NEXT_PUBLIC_') && typeof value === 'string' && value.trim() === secret
+  ))) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET no puede ser publica.');
+  }
+  const dbName = (environment.CHAIN_INDEXER_DB_NAME ?? DEFAULT_DB_NAME).trim();
+  if (!dbName || dbName.toLowerCase() === 'cukies') {
+    throw new Error('CHAIN_INDEXER_DB_NAME no puede apuntar a la base legacy.');
+  }
+  return {
+    ...shared,
+    keyId,
+    secret,
+    mongoUrl: required(environment, 'CHAIN_INDEXER_MONGO_URL'),
+    dbName,
+  };
+}

--- a/dapp/scripts/game-economy-scheduler-policy.test.mjs
+++ b/dapp/scripts/game-economy-scheduler-policy.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { loadGameEconomySchedulerConfig } from './game-economy-scheduler-policy.mjs';
+
+test('scheduler GameEconomy desactivado no exige secretos', () => {
+  const config = loadGameEconomySchedulerConfig({ GAME_ECONOMY_RUNTIME_ENABLED: 'false' });
+  assert.equal(config.enabled, false);
+  assert.equal(config.secret, null);
+});
+
+test('scheduler GameEconomy activo exige Mongo y HMAC fuerte', () => {
+  assert.throws(() => loadGameEconomySchedulerConfig({
+    GAME_ECONOMY_RUNTIME_ENABLED: 'true',
+  }), /ECONOMY_INTERNAL_HMAC_KEY_ID/);
+});
+
+test('scheduler GameEconomy activo carga configuracion aislada', () => {
+  const config = loadGameEconomySchedulerConfig({
+    GAME_ECONOMY_RUNTIME_ENABLED: 'true',
+    ECONOMY_INTERNAL_HMAC_KEY_ID: 'admin-v1',
+    ECONOMY_INTERNAL_HMAC_SECRET: 'A-very-long-secret-with-many-symbols-1234567890',
+    CHAIN_INDEXER_MONGO_URL: 'mongodb://mongo:27017',
+    CHAIN_INDEXER_DB_NAME: 'cukieshub-new',
+  }, 'host-a');
+  assert.equal(config.enabled, true);
+  assert.equal(config.schedulerId, 'host-a');
+  assert.equal(config.dbName, 'cukieshub-new');
+});

--- a/dapp/scripts/game-economy-scheduler.mjs
+++ b/dapp/scripts/game-economy-scheduler.mjs
@@ -1,0 +1,111 @@
+import { createHash, createHmac, randomBytes } from 'node:crypto';
+import { hostname } from 'node:os';
+
+import { MongoClient } from 'mongodb';
+
+import { loadGameEconomySchedulerConfig } from './game-economy-scheduler-policy.mjs';
+
+const path = '/api/economy/v1/internal/games/tick';
+const config = loadGameEconomySchedulerConfig(process.env, hostname());
+const heartbeatId = `scheduler-heartbeat:${config.schedulerId}`;
+const client = config.enabled ? new MongoClient(config.mongoUrl) : null;
+const heartbeats = client
+  ? client.db(config.dbName).collection('game_economy_runtime_state')
+  : null;
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+async function heartbeat(status, errorCode = null) {
+  if (!heartbeats) return;
+  const now = new Date();
+  const base = {
+    schedulerId: config.schedulerId,
+    status,
+    lastAttemptAt: now,
+    updatedAt: now,
+  };
+  if (status === 'success') {
+    await heartbeats.updateOne(
+      { _id: heartbeatId },
+      {
+        $set: { ...base, lastSuccessAt: now, consecutiveFailures: 0 },
+        $unset: { lastErrorCode: '' },
+        $setOnInsert: { _id: heartbeatId, createdAt: now },
+      },
+      { upsert: true },
+    );
+  } else if (status === 'error') {
+    await heartbeats.updateOne(
+      { _id: heartbeatId },
+      {
+        $set: { ...base, lastErrorCode: errorCode },
+        $inc: { consecutiveFailures: 1 },
+        $setOnInsert: { _id: heartbeatId, createdAt: now },
+      },
+      { upsert: true },
+    );
+  } else {
+    await heartbeats.updateOne(
+      { _id: heartbeatId },
+      {
+        $set: base,
+        $setOnInsert: { _id: heartbeatId, createdAt: now, consecutiveFailures: 0 },
+      },
+      { upsert: true },
+    );
+  }
+}
+
+async function tick() {
+  const body = JSON.stringify({ workerId: `scheduler:${config.schedulerId}` });
+  const timestamp = String(Date.now());
+  const nonce = randomBytes(16).toString('base64url');
+  const canonical = [
+    'cukies-economy-hmac-v1',
+    config.keyId,
+    'POST',
+    path,
+    timestamp,
+    nonce,
+    sha256(Buffer.from(body, 'utf8')),
+  ].join('\n');
+  const signature = createHmac('sha256', Buffer.from(config.secret, 'utf8'))
+    .update(canonical, 'utf8')
+    .digest('hex');
+  const response = await fetch(`${config.baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-economy-key-id': config.keyId,
+      'x-economy-timestamp': timestamp,
+      'x-economy-nonce': nonce,
+      'x-economy-signature': `v1=${signature}`,
+    },
+    body,
+    signal: AbortSignal.timeout(config.tickTimeoutMs),
+  });
+  if (!response.ok) throw new Error(`GAME_TICK_HTTP_${response.status}`);
+}
+
+if (client) await client.connect();
+
+while (true) {
+  if (config.enabled) {
+    try {
+      await heartbeat('running');
+      await tick();
+      await heartbeat('success');
+    } catch (error) {
+      const code = error instanceof Error ? error.message.slice(0, 120) : 'GAME_TICK_FAILED';
+      try {
+        await heartbeat('error', code);
+      } catch {
+        process.stderr.write(`${new Date().toISOString()} GAME_SCHEDULER_HEARTBEAT_FAILED\n`);
+      }
+      process.stderr.write(`${new Date().toISOString()} ${code}\n`);
+    }
+  }
+  await new Promise((resolve) => setTimeout(resolve, config.intervalMs));
+}

--- a/dapp/scripts/weekly-ranking-scheduler-policy.mjs
+++ b/dapp/scripts/weekly-ranking-scheduler-policy.mjs
@@ -1,0 +1,79 @@
+const DEFAULT_DB_NAME = 'cukieshub-new';
+
+function required(environment, name) {
+  const value = environment[name]?.trim();
+  if (!value) throw new Error(`${name} es obligatorio para el scheduler de ranking semanal.`);
+  return value;
+}
+
+function bounded(environment, name, fallback, minimum, maximum) {
+  const raw = environment[name]?.trim();
+  if (!raw) return fallback;
+  if (!/^\d+$/.test(raw)) throw new Error(`${name} debe ser un entero.`);
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} debe estar entre ${minimum} y ${maximum}.`);
+  }
+  return value;
+}
+
+export function loadWeeklyRankingSchedulerConfig(environment = process.env, host = 'scheduler') {
+  const rawEnabled = environment.WEEKLY_RANKING_RUNTIME_ENABLED?.trim();
+  if (rawEnabled && rawEnabled !== 'true' && rawEnabled !== 'false') {
+    throw new Error('WEEKLY_RANKING_RUNTIME_ENABLED debe ser true o false.');
+  }
+  const enabled = rawEnabled === 'true';
+  const baseUrl = (environment.WEEKLY_RANKING_DAPP_INTERNAL_URL ?? 'http://dapp:3000')
+    .trim().replace(/\/$/, '');
+  if (!/^https?:\/\//i.test(baseUrl)) {
+    throw new Error('WEEKLY_RANKING_DAPP_INTERNAL_URL debe ser HTTP(S).');
+  }
+  const schedulerId = (environment.WEEKLY_RANKING_SCHEDULER_ID ?? host).trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(schedulerId)) {
+    throw new Error('WEEKLY_RANKING_SCHEDULER_ID tiene formato invalido.');
+  }
+  const shared = {
+    enabled,
+    baseUrl,
+    schedulerId,
+    intervalMs: bounded(
+      environment,
+      'WEEKLY_RANKING_SCHEDULER_INTERVAL_MS',
+      6 * 60 * 60_000,
+      60_000,
+      7 * 24 * 60 * 60_000,
+    ),
+    tickTimeoutMs: bounded(
+      environment,
+      'WEEKLY_RANKING_TICK_TIMEOUT_MS',
+      240_000,
+      10_000,
+      600_000,
+    ),
+  };
+  if (!enabled) return { ...shared, keyId: null, secret: null, mongoUrl: null, dbName: null };
+  const keyId = required(environment, 'ECONOMY_INTERNAL_HMAC_KEY_ID');
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(keyId)) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_KEY_ID tiene formato invalido.');
+  }
+  const secret = required(environment, 'ECONOMY_INTERNAL_HMAC_SECRET');
+  if (Buffer.byteLength(secret, 'utf8') < 32 || new Set(secret).size < 10) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET no tiene entropia suficiente.');
+  }
+  if (Object.entries(environment).some(([name, value]) => (
+    name.startsWith('NEXT_PUBLIC_') && typeof value === 'string' && value.trim() === secret
+  ))) {
+    throw new Error('ECONOMY_INTERNAL_HMAC_SECRET no puede ser publica.');
+  }
+  const dbName = (environment.CHAIN_INDEXER_DB_NAME ?? DEFAULT_DB_NAME).trim();
+  if (!dbName || dbName.toLowerCase() === 'cukies') {
+    throw new Error('CHAIN_INDEXER_DB_NAME no puede apuntar a la base legacy.');
+  }
+  return {
+    ...shared,
+    keyId,
+    secret,
+    mongoUrl: required(environment, 'CHAIN_INDEXER_MONGO_URL'),
+    dbName,
+  };
+}

--- a/dapp/scripts/weekly-ranking-scheduler-policy.test.mjs
+++ b/dapp/scripts/weekly-ranking-scheduler-policy.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { loadWeeklyRankingSchedulerConfig } from './weekly-ranking-scheduler-policy.mjs';
+
+const secret = 'weekly-ranking-secret-with-enough-entropy-123456789';
+
+describe('weekly ranking scheduler policy', () => {
+  it('stays disabled without credentials', () => {
+    const config = loadWeeklyRankingSchedulerConfig({}, 'host-a');
+    assert.equal(config.enabled, false);
+    assert.equal(config.schedulerId, 'host-a');
+    assert.equal(config.keyId, null);
+  });
+
+  it('requires private HMAC and the new economy database when enabled', () => {
+    assert.throws(() => loadWeeklyRankingSchedulerConfig({
+      WEEKLY_RANKING_RUNTIME_ENABLED: 'true',
+    }), /ECONOMY_INTERNAL_HMAC_KEY_ID/);
+    assert.throws(() => loadWeeklyRankingSchedulerConfig({
+      WEEKLY_RANKING_RUNTIME_ENABLED: 'true',
+      ECONOMY_INTERNAL_HMAC_KEY_ID: 'ranking-v1',
+      ECONOMY_INTERNAL_HMAC_SECRET: secret,
+      CHAIN_INDEXER_MONGO_URL: 'mongodb://example',
+      CHAIN_INDEXER_DB_NAME: 'cukies',
+    }), /legacy/);
+    assert.throws(() => loadWeeklyRankingSchedulerConfig({
+      WEEKLY_RANKING_RUNTIME_ENABLED: 'true',
+      ECONOMY_INTERNAL_HMAC_KEY_ID: 'ranking-v1',
+      ECONOMY_INTERNAL_HMAC_SECRET: secret,
+      NEXT_PUBLIC_BAD_SECRET: secret,
+      CHAIN_INDEXER_MONGO_URL: 'mongodb://example',
+    }), /no puede ser publica/);
+  });
+
+  it('loads the enabled bounded policy', () => {
+    const config = loadWeeklyRankingSchedulerConfig({
+      WEEKLY_RANKING_RUNTIME_ENABLED: 'true',
+      ECONOMY_INTERNAL_HMAC_KEY_ID: 'ranking-v1',
+      ECONOMY_INTERNAL_HMAC_SECRET: secret,
+      CHAIN_INDEXER_MONGO_URL: 'mongodb://example',
+      CHAIN_INDEXER_DB_NAME: 'cukieshub-new',
+      WEEKLY_RANKING_SCHEDULER_INTERVAL_MS: '3600000',
+    }, 'host-a');
+    assert.equal(config.enabled, true);
+    assert.equal(config.intervalMs, 3_600_000);
+    assert.equal(config.dbName, 'cukieshub-new');
+  });
+});

--- a/dapp/scripts/weekly-ranking-scheduler.mjs
+++ b/dapp/scripts/weekly-ranking-scheduler.mjs
@@ -1,0 +1,103 @@
+import { createHash, createHmac, randomBytes } from 'node:crypto';
+import { hostname } from 'node:os';
+
+import { MongoClient } from 'mongodb';
+
+import { loadWeeklyRankingSchedulerConfig } from './weekly-ranking-scheduler-policy.mjs';
+
+const path = '/api/economy/v1/internal/ranking/tick';
+const config = loadWeeklyRankingSchedulerConfig(process.env, hostname());
+const heartbeatId = `scheduler-heartbeat:${config.schedulerId}`;
+const client = config.enabled ? new MongoClient(config.mongoUrl) : null;
+const heartbeats = client
+  ? client.db(config.dbName).collection('weekly_ranking_runtime_state')
+  : null;
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+async function heartbeat(status, errorCode = null) {
+  if (!heartbeats) return;
+  const now = new Date();
+  const base = { schedulerId: config.schedulerId, status, lastAttemptAt: now, updatedAt: now };
+  if (status === 'success') {
+    await heartbeats.updateOne(
+      { _id: heartbeatId },
+      {
+        $set: { ...base, lastSuccessAt: now, consecutiveFailures: 0 },
+        $unset: { lastErrorCode: '' },
+        $setOnInsert: { _id: heartbeatId, createdAt: now },
+      },
+      { upsert: true },
+    );
+  } else if (status === 'error') {
+    await heartbeats.updateOne(
+      { _id: heartbeatId },
+      {
+        $set: { ...base, lastFailureAt: now, lastErrorCode: errorCode },
+        $inc: { consecutiveFailures: 1 },
+        $setOnInsert: { _id: heartbeatId, createdAt: now },
+      },
+      { upsert: true },
+    );
+  } else {
+    await heartbeats.updateOne(
+      { _id: heartbeatId },
+      { $set: base, $setOnInsert: { _id: heartbeatId, createdAt: now, consecutiveFailures: 0 } },
+      { upsert: true },
+    );
+  }
+}
+
+async function tick() {
+  const body = JSON.stringify({ workerId: `scheduler:${config.schedulerId}` });
+  const timestamp = String(Date.now());
+  const nonce = randomBytes(16).toString('base64url');
+  const canonical = [
+    'cukies-economy-hmac-v1',
+    config.keyId,
+    'POST',
+    path,
+    timestamp,
+    nonce,
+    sha256(Buffer.from(body, 'utf8')),
+  ].join('\n');
+  const signature = createHmac('sha256', Buffer.from(config.secret, 'utf8'))
+    .update(canonical, 'utf8')
+    .digest('hex');
+  const response = await fetch(`${config.baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-economy-key-id': config.keyId,
+      'x-economy-timestamp': timestamp,
+      'x-economy-nonce': nonce,
+      'x-economy-signature': `v1=${signature}`,
+    },
+    body,
+    signal: AbortSignal.timeout(config.tickTimeoutMs),
+  });
+  if (!response.ok) throw new Error(`WEEKLY_RANKING_TICK_HTTP_${response.status}`);
+}
+
+if (client) await client.connect();
+
+while (true) {
+  if (config.enabled) {
+    try {
+      await heartbeat('running');
+      await tick();
+      await heartbeat('success');
+    } catch (error) {
+      const code = error instanceof Error ? error.message.slice(0, 120) : 'WEEKLY_RANKING_TICK_FAILED';
+      try {
+        await heartbeat('error', code);
+      } catch {
+        process.stderr.write(`${new Date().toISOString()} WEEKLY_RANKING_HEARTBEAT_FAILED\n`);
+      }
+      process.stderr.write(`${new Date().toISOString()} ${code}\n`);
+    }
+  }
+  await new Promise((resolve) => setTimeout(resolve, config.intervalMs));
+}

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -47,6 +47,10 @@ services:
       NEXT_PUBLIC_TWITTER_PROFILE_URL: ${NEXT_PUBLIC_TWITTER_PROFILE_URL:-}
       NEXT_PUBLIC_DISCORD_INVITE_URL: ${NEXT_PUBLIC_DISCORD_INVITE_URL:-}
       IFTTT_WEBHOOK_SECRET: ${IFTTT_WEBHOOK_SECRET:-}
+      ECONOMY_INTERNAL_HMAC_KEY_ID: ${ECONOMY_INTERNAL_HMAC_KEY_ID:-}
+      ECONOMY_INTERNAL_HMAC_SECRET: ${ECONOMY_INTERNAL_HMAC_SECRET:-}
+      ECONOMY_GAMES_HMAC_KEY_ID: ${ECONOMY_GAMES_HMAC_KEY_ID:-}
+      ECONOMY_GAMES_HMAC_SECRET: ${ECONOMY_GAMES_HMAC_SECRET:-}
       GAME_SYBILSLASH: ${GAME_SYBILSLASH:-}
       TREASURE_HUNT_MULTIPLAYER_ENABLED: ${TREASURE_HUNT_MULTIPLAYER_ENABLED:-false}
       TREASURE_HUNT_COMPETITION_ENABLED: ${TREASURE_HUNT_COMPETITION_ENABLED:-false}
@@ -126,6 +130,197 @@ services:
       TRONGRID_API_KEY: ${TRONGRID_API_KEY:-}
       CHAIN_INDEXER_POLL_INTERVAL_MS: ${CHAIN_INDEXER_POLL_INTERVAL_MS:-60000}
     restart: unless-stopped
+
+  cukie-master-scheduler:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        CUKIES_SERVICE: dapp
+    command:
+      - sh
+      - -c
+      - node scripts/assert-staging-only.mjs --scope economy-scheduler && exec node dapp/scripts/cukie-master-scheduler.mjs
+    environment:
+      NODE_ENV: production
+      APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
+      STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      DATABASE_URL: ${DATABASE_URL}
+      CHAIN_INDEXER_MONGO_URL: ${CHAIN_INDEXER_MONGO_URL:-${DATABASE_URL}}
+      CHAIN_INDEXER_DB_NAME: ${CHAIN_INDEXER_DB_NAME:-cukieshub-new}
+      CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID: ${CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID:-56}
+      CHAIN_INDEXER_CUKIE_MASTER_ENABLED: ${CHAIN_INDEXER_CUKIE_MASTER_ENABLED:-false}
+      CUKIE_MASTER_DAPP_INTERNAL_URL: http://dapp:3000
+      CUKIE_MASTER_SCHEDULER_INTERVAL_MS: ${CUKIE_MASTER_SCHEDULER_INTERVAL_MS:-60000}
+      CUKIE_MASTER_TICK_TIMEOUT_MS: ${CUKIE_MASTER_TICK_TIMEOUT_MS:-300000}
+      CUKIE_MASTER_QUEUE_LIMIT: ${CUKIE_MASTER_QUEUE_LIMIT:-100}
+      CUKIE_MASTER_SCHEDULER_ID: ${CUKIE_MASTER_SCHEDULER_ID:-coolify-staging-primary}
+      ECONOMY_INTERNAL_HMAC_KEY_ID: ${ECONOMY_INTERNAL_HMAC_KEY_ID:-}
+      ECONOMY_INTERNAL_HMAC_SECRET: ${ECONOMY_INTERNAL_HMAC_SECRET:-}
+    depends_on:
+      dapp:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://dapp:3000/api/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
+    networks:
+      - coolify
+
+  competition-credit-scheduler:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        CUKIES_SERVICE: dapp
+    command:
+      - sh
+      - -c
+      - node scripts/assert-staging-only.mjs --scope economy-scheduler && exec node dapp/scripts/competition-credit-scheduler.mjs
+    environment:
+      NODE_ENV: production
+      APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
+      STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      DATABASE_URL: ${DATABASE_URL}
+      CHAIN_INDEXER_MONGO_URL: ${CHAIN_INDEXER_MONGO_URL:-${DATABASE_URL}}
+      CHAIN_INDEXER_DB_NAME: ${CHAIN_INDEXER_DB_NAME:-cukieshub-new}
+      CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID: ${CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID:-56}
+      COMPETITION_CREDITS_SCHEDULER_ENABLED: ${COMPETITION_CREDITS_RUNTIME_ENABLED:-false}
+      COMPETITION_CREDITS_SCHEDULER_BASE_URL: http://dapp:3000
+      COMPETITION_CREDITS_SCHEDULER_INTERVAL_MS: ${COMPETITION_CREDITS_SCHEDULER_INTERVAL_MS:-30000}
+      COMPETITION_CREDITS_TICK_TIMEOUT_MS: ${COMPETITION_CREDITS_TICK_TIMEOUT_MS:-240000}
+      COMPETITION_CREDITS_SCHEDULER_ID: ${COMPETITION_CREDITS_SCHEDULER_ID:-coolify-staging-primary}
+      ECONOMY_INTERNAL_HMAC_KEY_ID: ${ECONOMY_INTERNAL_HMAC_KEY_ID:-}
+      ECONOMY_INTERNAL_HMAC_SECRET: ${ECONOMY_INTERNAL_HMAC_SECRET:-}
+    depends_on:
+      dapp:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://dapp:3000/api/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
+    networks:
+      - coolify
+
+  game-economy-scheduler:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        CUKIES_SERVICE: dapp
+    command:
+      - sh
+      - -c
+      - node scripts/assert-staging-only.mjs --scope economy-scheduler && exec node dapp/scripts/game-economy-scheduler.mjs
+    environment:
+      NODE_ENV: production
+      APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
+      STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      DATABASE_URL: ${DATABASE_URL}
+      CHAIN_INDEXER_MONGO_URL: ${CHAIN_INDEXER_MONGO_URL:-${DATABASE_URL}}
+      CHAIN_INDEXER_DB_NAME: ${CHAIN_INDEXER_DB_NAME:-cukieshub-new}
+      CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID: ${CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID:-56}
+      GAME_ECONOMY_RUNTIME_ENABLED: ${GAME_ECONOMY_RUNTIME_ENABLED:-false}
+      GAME_ECONOMY_DAPP_INTERNAL_URL: http://dapp:3000
+      GAME_ECONOMY_SCHEDULER_INTERVAL_MS: ${GAME_ECONOMY_SCHEDULER_INTERVAL_MS:-30000}
+      GAME_ECONOMY_TICK_TIMEOUT_MS: ${GAME_ECONOMY_TICK_TIMEOUT_MS:-240000}
+      GAME_ECONOMY_SCHEDULER_ID: ${GAME_ECONOMY_SCHEDULER_ID:-coolify-staging-primary}
+      ECONOMY_INTERNAL_HMAC_KEY_ID: ${ECONOMY_INTERNAL_HMAC_KEY_ID:-}
+      ECONOMY_INTERNAL_HMAC_SECRET: ${ECONOMY_INTERNAL_HMAC_SECRET:-}
+    depends_on:
+      dapp:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://dapp:3000/api/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
+    networks:
+      - coolify
+
+  cukie-pool-scheduler:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        CUKIES_SERVICE: dapp
+    command:
+      - sh
+      - -c
+      - node scripts/assert-staging-only.mjs --scope economy-scheduler && exec node dapp/scripts/cukie-pool-scheduler.mjs
+    environment:
+      NODE_ENV: production
+      APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
+      STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      DATABASE_URL: ${DATABASE_URL}
+      CHAIN_INDEXER_MONGO_URL: ${CHAIN_INDEXER_MONGO_URL:-${DATABASE_URL}}
+      CHAIN_INDEXER_DB_NAME: ${CHAIN_INDEXER_DB_NAME:-cukieshub-new}
+      CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID: ${CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID:-56}
+      CUKIE_POOL_RUNTIME_ENABLED: ${CUKIE_POOL_RUNTIME_ENABLED:-false}
+      CUKIE_POOL_DAPP_INTERNAL_URL: http://dapp:3000
+      CUKIE_POOL_SCHEDULER_INTERVAL_MS: ${CUKIE_POOL_SCHEDULER_INTERVAL_MS:-30000}
+      CUKIE_POOL_TICK_TIMEOUT_MS: ${CUKIE_POOL_TICK_TIMEOUT_MS:-240000}
+      CUKIE_POOL_SCHEDULER_ID: ${CUKIE_POOL_SCHEDULER_ID:-coolify-staging-primary}
+      ECONOMY_INTERNAL_HMAC_KEY_ID: ${ECONOMY_INTERNAL_HMAC_KEY_ID:-}
+      ECONOMY_INTERNAL_HMAC_SECRET: ${ECONOMY_INTERNAL_HMAC_SECRET:-}
+    depends_on:
+      dapp:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://dapp:3000/api/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
+    networks:
+      - coolify
+
+  weekly-ranking-scheduler:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        CUKIES_SERVICE: dapp
+    command:
+      - sh
+      - -c
+      - node scripts/assert-staging-only.mjs --scope economy-scheduler && exec node dapp/scripts/weekly-ranking-scheduler.mjs
+    environment:
+      NODE_ENV: production
+      APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
+      STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      DATABASE_URL: ${DATABASE_URL}
+      CHAIN_INDEXER_MONGO_URL: ${CHAIN_INDEXER_MONGO_URL:-${DATABASE_URL}}
+      CHAIN_INDEXER_DB_NAME: ${CHAIN_INDEXER_DB_NAME:-cukieshub-new}
+      CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID: ${CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID:-56}
+      WEEKLY_RANKING_RUNTIME_ENABLED: ${WEEKLY_RANKING_RUNTIME_ENABLED:-false}
+      WEEKLY_RANKING_DAPP_INTERNAL_URL: http://dapp:3000
+      WEEKLY_RANKING_SCHEDULER_INTERVAL_MS: ${WEEKLY_RANKING_SCHEDULER_INTERVAL_MS:-21600000}
+      WEEKLY_RANKING_TICK_TIMEOUT_MS: ${WEEKLY_RANKING_TICK_TIMEOUT_MS:-240000}
+      WEEKLY_RANKING_SCHEDULER_ID: ${WEEKLY_RANKING_SCHEDULER_ID:-coolify-staging-primary}
+      ECONOMY_INTERNAL_HMAC_KEY_ID: ${ECONOMY_INTERNAL_HMAC_KEY_ID:-}
+      ECONOMY_INTERNAL_HMAC_SECRET: ${ECONOMY_INTERNAL_HMAC_SECRET:-}
+    depends_on:
+      dapp:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://dapp:3000/api/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
+    networks:
+      - coolify
 
   cuki-card-worker:
     profiles:

--- a/scripts/assert-staging-only.mjs
+++ b/scripts/assert-staging-only.mjs
@@ -84,12 +84,19 @@ function requireStagingAuthUrl(environment, failures) {
 
 export function validateStagingEnvironment(environment = process.env, scope = 'full') {
   const failures = [];
-  const supportedScopes = new Set(['full', 'dapp', 'chain-indexer', 'cuki-card-worker']);
+  const supportedScopes = new Set([
+    'full',
+    'dapp',
+    'chain-indexer',
+    'cuki-card-worker',
+    'economy-scheduler',
+  ]);
   if (!supportedScopes.has(scope)) {
     throw new StagingGuardError([`unsupported guard scope ${scope}`]);
   }
 
   const appEnv = requireExact(environment, 'APP_ENV', STAGING_TARGET.appEnv, failures);
+  requireExact(environment, 'STAGING_ONLY_GUARD', 'true', failures);
   const gitBranch = requireQuotedOrExact(
     environment,
     'COOLIFY_BRANCH',
@@ -113,7 +120,9 @@ export function validateStagingEnvironment(environment = process.env, scope = 'f
   );
   let legacyDatabaseName = null;
   let indexerDatabaseName = null;
+  let indexerMongoDatabaseName = null;
   let cardWorkerDatabaseName = null;
+  let cardWorkerMongoDatabaseName = null;
   let authHost = null;
 
   if (scope === 'full' || scope === 'dapp') {
@@ -135,10 +144,16 @@ export function validateStagingEnvironment(environment = process.env, scope = 'f
       STAGING_TARGET.indexerDatabaseName,
       failures,
     );
+    indexerMongoDatabaseName = requireMongoDatabase(
+      environment,
+      'CHAIN_INDEXER_MONGO_URL',
+      STAGING_TARGET.indexerDatabaseName,
+      failures,
+    );
     authHost = requireStagingAuthUrl(environment, failures);
   }
 
-  if (scope === 'full' || scope === 'chain-indexer') {
+  if (scope === 'full' || scope === 'chain-indexer' || scope === 'economy-scheduler') {
     indexerChainId = requireExact(
       environment,
       'CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID',
@@ -151,12 +166,24 @@ export function validateStagingEnvironment(environment = process.env, scope = 'f
       STAGING_TARGET.indexerDatabaseName,
       failures,
     );
+    indexerMongoDatabaseName ??= requireMongoDatabase(
+      environment,
+      'CHAIN_INDEXER_MONGO_URL',
+      STAGING_TARGET.indexerDatabaseName,
+      failures,
+    );
   }
 
   if (scope === 'full' || scope === 'cuki-card-worker') {
     cardWorkerDatabaseName = requireExact(
       environment,
       'CARD_WORKER_DB_NAME',
+      STAGING_TARGET.indexerDatabaseName,
+      failures,
+    );
+    cardWorkerMongoDatabaseName = requireMongoDatabase(
+      environment,
+      'CARD_WORKER_MONGO_URL',
       STAGING_TARGET.indexerDatabaseName,
       failures,
     );
@@ -177,7 +204,9 @@ export function validateStagingEnvironment(environment = process.env, scope = 'f
     databaseName,
     legacyDatabaseName,
     indexerDatabaseName,
+    indexerMongoDatabaseName,
     cardWorkerDatabaseName,
+    cardWorkerMongoDatabaseName,
     authHost,
   };
 }

--- a/scripts/assert-staging-only.test.mjs
+++ b/scripts/assert-staging-only.test.mjs
@@ -9,6 +9,7 @@ import {
 function stagingEnvironment(overrides = {}) {
   return {
     APP_ENV: 'staging',
+    STAGING_ONLY_GUARD: 'true',
     COOLIFY_BRANCH: '"staging"',
     COOLIFY_RESOURCE_UUID: 'u4s804o4wwcckowgk0woo4wg',
     NEXT_PUBLIC_UKI_CHAIN_ID: '97',
@@ -16,7 +17,11 @@ function stagingEnvironment(overrides = {}) {
     DATABASE_URL: 'mongodb://staging-user:redacted@mongo:27017/cukies-hub-staging?authSource=admin',
     CUKIES_DATABASE_URL:
       'mongodb://staging-legacy:redacted@mongo:27017/cukies-legacy-staging?authSource=admin',
+    CHAIN_INDEXER_MONGO_URL:
+      'mongodb://staging-economy:redacted@mongo:27017/cukieshub-new-staging?authSource=cukieshub-new-staging',
     CHAIN_INDEXER_DB_NAME: 'cukieshub-new-staging',
+    CARD_WORKER_MONGO_URL:
+      'mongodb://staging-card:redacted@mongo:27017/cukieshub-new-staging?authSource=cukieshub-new-staging',
     CARD_WORKER_DB_NAME: 'cukieshub-new-staging',
     NEXTAUTH_URL: 'https://cukieshub.eurekand.com',
     ...overrides,
@@ -32,10 +37,12 @@ test('accepts only the exact staging application, chain and database perimeter',
   assert.equal(result.databaseName, 'cukies-hub-staging');
   assert.equal(result.legacyDatabaseName, 'cukies-legacy-staging');
   assert.equal(result.indexerDatabaseName, 'cukieshub-new-staging');
+  assert.equal(result.indexerMongoDatabaseName, 'cukieshub-new-staging');
 });
 
 for (const [name, override, expectedMessage] of [
   ['production app env', { APP_ENV: 'production' }, 'APP_ENV must equal staging'],
+  ['disabled staging guard', { STAGING_ONLY_GUARD: 'false' }, 'STAGING_ONLY_GUARD must equal true'],
   ['main branch', { COOLIFY_BRANCH: '"main"' }, 'must equal staging'],
   ['production Coolify UUID', { COOLIFY_RESOURCE_UUID: 'jookw8ow8woks088s44404ok' }, 'must equal u4s804'],
   ['BSC mainnet public chain', { NEXT_PUBLIC_UKI_CHAIN_ID: '56' }, 'must equal 97'],
@@ -47,6 +54,11 @@ for (const [name, override, expectedMessage] of [
     'cukies-legacy-staging',
   ],
   ['production indexer database', { CHAIN_INDEXER_DB_NAME: 'cukieshub-new' }, 'cukieshub-new-staging'],
+  [
+    'production indexer Mongo URL',
+    { CHAIN_INDEXER_MONGO_URL: 'mongodb://mongo:27017/cukieshub-new' },
+    'CHAIN_INDEXER_MONGO_URL must target database cukieshub-new-staging',
+  ],
   ['production auth URL', { NEXTAUTH_URL: 'https://cukies.world' }, 'approved staging HTTPS'],
 ]) {
   test(`rejects ${name}`, () => {
@@ -70,6 +82,7 @@ test('never includes Mongo credentials in a rejection message', () => {
 test('uses service scopes without requiring unrelated credentials', () => {
   const common = {
     APP_ENV: 'staging',
+    STAGING_ONLY_GUARD: 'true',
     COOLIFY_BRANCH: 'staging',
     COOLIFY_RESOURCE_UUID: 'u4s804o4wwcckowgk0woo4wg',
   };
@@ -77,6 +90,7 @@ test('uses service scopes without requiring unrelated credentials', () => {
   assert.equal(validateStagingEnvironment({
     ...common,
     DATABASE_URL: 'mongodb://mongo:27017/cukies-hub-staging',
+    CHAIN_INDEXER_MONGO_URL: 'mongodb://mongo:27017/cukieshub-new-staging',
     CHAIN_INDEXER_DB_NAME: 'cukieshub-new-staging',
     CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID: '97',
   }, 'chain-indexer').scope, 'chain-indexer');
@@ -84,8 +98,17 @@ test('uses service scopes without requiring unrelated credentials', () => {
   assert.equal(validateStagingEnvironment({
     ...common,
     DATABASE_URL: 'mongodb://mongo:27017/cukies-hub-staging',
+    CARD_WORKER_MONGO_URL: 'mongodb://mongo:27017/cukieshub-new-staging',
     CARD_WORKER_DB_NAME: 'cukieshub-new-staging',
   }, 'cuki-card-worker').scope, 'cuki-card-worker');
+
+  assert.equal(validateStagingEnvironment({
+    ...common,
+    DATABASE_URL: 'mongodb://mongo:27017/cukies-hub-staging',
+    CHAIN_INDEXER_MONGO_URL: 'mongodb://mongo:27017/cukieshub-new-staging',
+    CHAIN_INDEXER_DB_NAME: 'cukieshub-new-staging',
+    CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID: '97',
+  }, 'economy-scheduler').scope, 'economy-scheduler');
 });
 
 test('rejects unknown service scopes', () => {


### PR DESCRIPTION
Refs #166

## Resumen
- incorpora los cinco schedulers de economía como procesos inertes por defecto
- ejecuta el guard staging-only antes de cada scheduler y valida el Mongo de economía por URL y nombre
- mantiene todos los gates en `false`
- pasa HMAC privados al runtime sin exponerlos
- permite `cukieshub-new-staging` en la política de créditos

## Validación
- `pnpm guard:staging:test` — 15/15 OK
- `pnpm --filter dapp test:schedulers` — 16/16 OK
- smoke local de los cinco procesos desactivados — todos permanecen vivos e inertes
- `docker compose config --services` — dapp, indexer y cinco schedulers; card worker excluido
- `pnpm dapp lint` — OK
- `pnpm dapp typecheck` — OK
- `pnpm dapp build` — OK

## Seguridad operativa
- base: `staging`
- no toca `main`, Coolify app 12, mainnet, contratos ni bases de producción
- los schedulers no escriben heartbeats ni ejecutan ticks mientras sus gates sigan apagados