### PR TITLE
feat: add fail-closed economy v2 core

### DIFF
--- a/dapp/__tests__/lib/indexer-db-economy-schema.test.ts
+++ b/dapp/__tests__/lib/indexer-db-economy-schema.test.ts
@@ -1,0 +1,70 @@
+jest.mock('mongodb', () => ({
+  MongoClient: jest.fn(),
+  ReadPreference: { primary: 'primary' },
+}));
+
+import {
+  ECONOMY_SCHEMA_METADATA_ID,
+  assertEconomySchema,
+} from '@/lib/indexer-db/mongodb';
+import { SchemaNotReadyError } from '@/lib/uki-economy/errors';
+import type { Db } from 'mongodb';
+
+const EXPECTED_DB = 'cukieshub-new-staging';
+
+function fakeDb(input: {
+  databaseName?: string;
+  metadata?: Record<string, unknown> | null;
+}) {
+  const findOne = jest.fn().mockResolvedValue(input.metadata ?? null);
+  const db = {
+    databaseName: input.databaseName ?? EXPECTED_DB,
+    collection: jest.fn(() => ({ findOne })),
+  } as unknown as Db;
+
+  return { db, findOne };
+}
+
+function validMetadata() {
+  return {
+    _id: ECONOMY_SCHEMA_METADATA_ID,
+    schemaVersion: 2,
+    dbName: EXPECTED_DB,
+    initializedAt: new Date('2026-08-05T20:00:00.000Z'),
+    updatedAt: new Date('2026-08-05T20:01:00.000Z'),
+    transactionVerifiedAt: new Date('2026-08-05T20:01:00.000Z'),
+  };
+}
+
+describe('dapp economy schema gate', () => {
+  it('accepts only the expected v2 sentinel with verified transactions', async () => {
+    const { db } = fakeDb({ metadata: validMetadata() });
+
+    await expect(assertEconomySchema(db, EXPECTED_DB)).resolves.toEqual(validMetadata());
+  });
+
+  it('rejects a different database before querying its sentinel', async () => {
+    const { db, findOne } = fakeDb({
+      databaseName: 'cukieshub-new',
+      metadata: validMetadata(),
+    });
+
+    await expect(assertEconomySchema(db, EXPECTED_DB)).rejects.toBeInstanceOf(
+      SchemaNotReadyError,
+    );
+    expect(findOne).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    null,
+    { ...validMetadata(), schemaVersion: 1 },
+    { ...validMetadata(), dbName: 'cukieshub-new' },
+    { ...validMetadata(), transactionVerifiedAt: undefined },
+  ])('fails closed for a missing or incompatible sentinel', async (metadata) => {
+    const { db } = fakeDb({ metadata });
+
+    await expect(assertEconomySchema(db, EXPECTED_DB)).rejects.toBeInstanceOf(
+      SchemaNotReadyError,
+    );
+  });
+});

--- a/dapp/__tests__/lib/indexer-db-name.test.ts
+++ b/dapp/__tests__/lib/indexer-db-name.test.ts
@@ -1,0 +1,19 @@
+import { resolveIndexerDbName } from '@/lib/indexer-db/name';
+
+describe('indexer DB name guard', () => {
+  it('defaults to the new hub database', () => {
+    expect(resolveIndexerDbName(undefined)).toBe('cukieshub-new');
+  });
+
+  it('trims configured names', () => {
+    expect(resolveIndexerDbName('  cukieshub-preview  ')).toBe('cukieshub-preview');
+  });
+
+  it('rejects empty database names', () => {
+    expect(() => resolveIndexerDbName('   ')).toThrow('no puede estar vacio');
+  });
+
+  it('rejects the legacy cukies database as operational indexer target', () => {
+    expect(() => resolveIndexerDbName('Cukies')).toThrow('base legacy `cukies`');
+  });
+});

--- a/dapp/__tests__/lib/uki-economy-internal-auth.test.ts
+++ b/dapp/__tests__/lib/uki-economy-internal-auth.test.ts
@@ -1,0 +1,272 @@
+import {
+  ECONOMY_INTERNAL_MAX_BODY_BYTES,
+  InternalEconomyAuthError,
+  buildInternalEconomyCanonicalRequest,
+  createMongoInternalEconomyNonceRepository,
+  loadGameEconomyAuthConfig,
+  loadInternalEconomyAuthConfig,
+  readLimitedInternalEconomyRequestBody,
+  signInternalEconomyRequest,
+  verifyAndConsumeInternalEconomyRequest,
+  type InternalEconomyNonceDocument,
+  type InternalEconomyNonceRepository,
+} from '@/lib/uki-economy/internal-auth';
+import type { Db } from 'mongodb';
+import { ReadableStream as NodeReadableStream } from 'node:stream/web';
+
+const NOW = new Date('2026-07-10T12:00:00.000Z');
+const STRONG_SECRET = 'B7!qL2@zN9#vR4$xC8%mK5&wT1*eY6+pD3=sH0_uF7-jS2.a';
+const TestReadableStream = NodeReadableStream as unknown as typeof globalThis.ReadableStream;
+
+function config() {
+  return loadInternalEconomyAuthConfig({
+    ECONOMY_INTERNAL_HMAC_KEY_ID: 'game-backend-2026-01',
+    ECONOMY_INTERNAL_HMAC_SECRET: STRONG_SECRET,
+    ECONOMY_INTERNAL_HMAC_MAX_SKEW_MS: '30000',
+    ECONOMY_INTERNAL_HMAC_NONCE_TTL_MS: '600000',
+  });
+}
+
+class MemoryNonces implements InternalEconomyNonceRepository {
+  readonly documents = new Map<string, InternalEconomyNonceDocument>();
+  failNext = false;
+
+  async consume(document: InternalEconomyNonceDocument) {
+    if (this.failNext) {
+      this.failNext = false;
+      throw new Error('mongo unavailable');
+    }
+    if (this.documents.has(document._id)) return false;
+    this.documents.set(document._id, document);
+    return true;
+  }
+}
+
+function unsigned(overrides: Partial<{
+  method: string;
+  path: string;
+  timestamp: string;
+  nonce: string;
+  keyId: string;
+  rawBody: string;
+}> = {}) {
+  return {
+    method: 'POST',
+    path: '/api/economy/v1/internal/credits/reservations?game=treasure-hunt',
+    timestamp: String(NOW.getTime()),
+    nonce: '0123456789abcdef0123456789abcdef',
+    keyId: 'game-backend-2026-01',
+    rawBody: '{"externalSessionId":"game-1","costCode":"treasure-hunt"}',
+    ...overrides,
+  };
+}
+
+function expectAuthError(error: unknown, code: InternalEconomyAuthError['code']) {
+  expect(error).toBeInstanceOf(InternalEconomyAuthError);
+  expect((error as InternalEconomyAuthError).code).toBe(code);
+}
+
+describe('economy internal HMAC auth', () => {
+  it('fails closed without an explicit strong server-side key', () => {
+    expect(() => loadInternalEconomyAuthConfig({})).toThrow(InternalEconomyAuthError);
+    expect(() => loadInternalEconomyAuthConfig({
+      ECONOMY_INTERNAL_HMAC_KEY_ID: 'key-1',
+      ECONOMY_INTERNAL_HMAC_SECRET: 'short',
+    })).toThrow('al menos 32 bytes');
+    expect(() => loadInternalEconomyAuthConfig({
+      ECONOMY_INTERNAL_HMAC_KEY_ID: 'key-1',
+      ECONOMY_INTERNAL_HMAC_SECRET: STRONG_SECRET,
+      NEXT_PUBLIC_OTHER_SECRET: `  ${STRONG_SECRET}  `,
+    })).toThrow('no puede reutilizar');
+    expect(() => loadInternalEconomyAuthConfig({
+      ECONOMY_INTERNAL_HMAC_KEY_ID: 'key-1',
+      ECONOMY_INTERNAL_HMAC_SECRET: 'a'.repeat(64),
+    })).toThrow('predecible');
+    expect(() => loadInternalEconomyAuthConfig({
+      ECONOMY_INTERNAL_HMAC_KEY_ID: 'key-1',
+      ECONOMY_INTERNAL_HMAC_SECRET: STRONG_SECRET,
+      ECONOMY_INTERNAL_HMAC_MAX_SKEW_MS: '30000',
+      ECONOMY_INTERNAL_HMAC_NONCE_TTL_MS: '60000',
+    })).toThrow('dos veces');
+  });
+
+  it('requires a dedicated game-server credential distinct from admin', () => {
+    expect(() => loadGameEconomyAuthConfig({
+      ECONOMY_GAMES_HMAC_KEY_ID: 'games-v1',
+      ECONOMY_GAMES_HMAC_SECRET: STRONG_SECRET,
+      ECONOMY_INTERNAL_HMAC_SECRET: STRONG_SECRET,
+    })).toThrow('distinta');
+    expect(loadGameEconomyAuthConfig({
+      ECONOMY_GAMES_HMAC_KEY_ID: 'games-v1',
+      ECONOMY_GAMES_HMAC_SECRET: `${STRONG_SECRET}-games`,
+      ECONOMY_INTERNAL_HMAC_SECRET: STRONG_SECRET,
+    }).keyId).toBe('games-v1');
+  });
+
+  it('builds a domain-separated deterministic canonical request', () => {
+    const request = unsigned();
+    const bodyHash = signInternalEconomyRequest(request, config()).bodyHash;
+    expect(buildInternalEconomyCanonicalRequest({ ...request, bodyHash })).toBe([
+      'cukies-economy-hmac-v1',
+      request.keyId,
+      request.method,
+      request.path,
+      request.timestamp,
+      request.nonce,
+      bodyHash,
+    ].join('\n'));
+  });
+
+  it('verifies the raw body and consumes a hashed nonce exactly once', async () => {
+    const request = unsigned();
+    const signed = signInternalEconomyRequest(request, config());
+    const nonces = new MemoryNonces();
+    const authenticated = await verifyAndConsumeInternalEconomyRequest({
+      request: { ...request, signature: signed.signature },
+      config: config(),
+      nonces,
+      now: NOW,
+    });
+
+    expect(authenticated.bodyHash).toBe(signed.bodyHash);
+    expect(authenticated.requestHash).toBe(signed.requestHash);
+    expect(authenticated.nonceHash).not.toContain(request.nonce);
+    expect(nonces.documents.size).toBe(1);
+
+    try {
+      await verifyAndConsumeInternalEconomyRequest({
+        request: { ...request, signature: signed.signature },
+        config: config(),
+        nonces,
+        now: NOW,
+      });
+      throw new Error('expected replay rejection');
+    } catch (error) {
+      expectAuthError(error, 'REPLAYED_REQUEST');
+    }
+  });
+
+  it('rejects body, path, method, key and signature tampering', async () => {
+    const request = unsigned();
+    const signed = signInternalEconomyRequest(request, config());
+    const tampered = [
+      { ...request, rawBody: '{}', signature: signed.signature },
+      { ...request, path: `${request.path}&admin=true`, signature: signed.signature },
+      { ...request, method: 'PUT', signature: signed.signature },
+      { ...request, keyId: 'other-key', signature: signed.signature },
+      { ...request, signature: `v1=${'0'.repeat(64)}` },
+    ];
+
+    for (const candidate of tampered) {
+      await expect(verifyAndConsumeInternalEconomyRequest({
+        request: candidate,
+        config: config(),
+        nonces: new MemoryNonces(),
+        now: NOW,
+      })).rejects.toBeInstanceOf(InternalEconomyAuthError);
+    }
+  });
+
+  it('rejects stale and future requests outside the symmetric clock window', async () => {
+    for (const timestamp of [NOW.getTime() - 30_001, NOW.getTime() + 30_001]) {
+      const request = unsigned({ timestamp: String(timestamp) });
+      const signed = signInternalEconomyRequest(request, config());
+      try {
+        await verifyAndConsumeInternalEconomyRequest({
+          request: { ...request, signature: signed.signature },
+          config: config(),
+          nonces: new MemoryNonces(),
+          now: NOW,
+        });
+        throw new Error('expected rejection');
+      } catch (error) {
+        expectAuthError(error, 'EXPIRED_REQUEST');
+      }
+    }
+  });
+
+  it('fails closed if nonce persistence is unavailable', async () => {
+    const request = unsigned();
+    const signed = signInternalEconomyRequest(request, config());
+    const nonces = new MemoryNonces();
+    nonces.failNext = true;
+
+    await expect(verifyAndConsumeInternalEconomyRequest({
+      request: { ...request, signature: signed.signature },
+      config: config(),
+      nonces,
+      now: NOW,
+    })).rejects.toThrow('mongo unavailable');
+  });
+
+  it('rejects oversized bodies, non-internal paths and malformed nonces', () => {
+    expect(() => signInternalEconomyRequest(
+      unsigned({ rawBody: 'x'.repeat(1024 * 1024 + 1) }),
+      config(),
+    )).toThrow('supera el limite');
+    expect(() => signInternalEconomyRequest(
+      unsigned({ path: '/api/games/end-session' }),
+      config(),
+    )).toThrow('Ruta interna invalida');
+    expect(() => signInternalEconomyRequest(
+      unsigned({ path: '/api/economy/v1/internal/credits/../admin' }),
+      config(),
+    )).toThrow('Ruta interna invalida');
+    expect(() => signInternalEconomyRequest(
+      unsigned({ nonce: 'short' }),
+      config(),
+    )).toThrow('Nonce base64url invalido');
+    expect(() => signInternalEconomyRequest(
+      unsigned({ nonce: '0123456789abcdef012345' }),
+      config(),
+    )).toThrow('128 bits');
+  });
+
+  it('enforces the body limit before materializing input and while streaming HTTP', async () => {
+    const oversized = new Uint8Array(ECONOMY_INTERNAL_MAX_BODY_BYTES + 1);
+    expect(() => signInternalEconomyRequest(
+      { ...unsigned(), rawBody: oversized },
+      config(),
+    )).toThrow('supera el limite');
+
+    const stream = new TestReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(ECONOMY_INTERNAL_MAX_BODY_BYTES));
+        controller.enqueue(new Uint8Array(1));
+        controller.close();
+      },
+    });
+    await expect(readLimitedInternalEconomyRequestBody({
+      headers: new Headers(),
+      body: stream as unknown as Pick<Request, 'body'>['body'],
+    })).rejects.toThrow('supera el limite');
+    await expect(readLimitedInternalEconomyRequestBody({
+      headers: new Headers({ 'content-length': String(ECONOMY_INTERNAL_MAX_BODY_BYTES + 1) }),
+      body: null,
+    })).rejects.toThrow('supera el limite');
+  });
+
+  it('persists nonce consumption with majority write concern', async () => {
+    let options: unknown;
+    const fakeDb = {
+      collection: () => ({
+        insertOne: async (_document: unknown, receivedOptions: unknown) => {
+          options = receivedOptions;
+        },
+      }),
+    } as unknown as Db;
+    const repository = createMongoInternalEconomyNonceRepository(fakeDb);
+    const document: InternalEconomyNonceDocument = {
+      _id: '1'.repeat(64),
+      keyId: 'key-1',
+      nonceHash: '1'.repeat(64),
+      requestHash: '2'.repeat(64),
+      bodyHash: '3'.repeat(64),
+      requestedAt: NOW,
+      consumedAt: NOW,
+      expiresAt: new Date(NOW.getTime() + 60_001),
+    };
+    await expect(repository.consume(document)).resolves.toBe(true);
+    expect(options).toEqual({ writeConcern: { w: 'majority' } });
+  });
+});

--- a/dapp/__tests__/lib/uki-economy-money.test.ts
+++ b/dapp/__tests__/lib/uki-economy-money.test.ts
@@ -1,0 +1,56 @@
+import {
+  UINT256_MAX,
+  addRawAmounts,
+  assertCreditAmount,
+  formatRawAmount,
+  mulDiv,
+  parseRawAmount,
+  subtractRawAmounts,
+  sumRawAmounts,
+} from '@/lib/uki-economy/money';
+
+describe('UKI raw money helpers', () => {
+  it('parses and formats minimum-unit amounts without Number coercion', () => {
+    const value = '123456789012345678901234567890';
+
+    expect(parseRawAmount(value)).toBe(BigInt('123456789012345678901234567890'));
+    expect(formatRawAmount(parseRawAmount(value))).toBe(value);
+    expect(parseRawAmount('0007')).toBe(BigInt('7'));
+  });
+
+  it.each(['', '-1', '+1', '1.0', '1e18', ' 1', '1 '])(
+    'rejects invalid raw amount %p',
+    (value) => {
+      expect(() => parseRawAmount(value)).toThrow();
+    },
+  );
+
+  it('enforces uint256 bounds', () => {
+    expect(parseRawAmount(UINT256_MAX.toString())).toBe(UINT256_MAX);
+    expect(() => parseRawAmount((UINT256_MAX + BigInt('1')).toString())).toThrow('uint256');
+    expect(() => formatRawAmount(BigInt('-1'))).toThrow('negativo');
+    expect(() => addRawAmounts(UINT256_MAX, BigInt('1'))).toThrow('uint256');
+  });
+
+  it('adds, sums, subtracts and rejects underflow', () => {
+    expect(addRawAmounts(BigInt('2'), BigInt('3'))).toBe(BigInt('5'));
+    expect(sumRawAmounts([BigInt('1'), BigInt('2'), BigInt('3')])).toBe(BigInt('6'));
+    expect(subtractRawAmounts(BigInt('5'), BigInt('3'))).toBe(BigInt('2'));
+    expect(() => subtractRawAmounts(BigInt('2'), BigInt('3'))).toThrow('no puede ser negativa');
+  });
+
+  it('calculates floor mulDiv and rejects zero divisors or invalid results', () => {
+    expect(mulDiv(BigInt('10'), BigInt('3'), BigInt('4'))).toBe(BigInt('7'));
+    expect(mulDiv(UINT256_MAX, UINT256_MAX, UINT256_MAX)).toBe(UINT256_MAX);
+    expect(() => mulDiv(BigInt('1'), BigInt('1'), BigInt('0'))).toThrow('cero');
+    expect(() => mulDiv(UINT256_MAX, BigInt('2'), BigInt('1'))).toThrow('uint256');
+  });
+
+  it('accepts only non-negative safe integer credits', () => {
+    expect(assertCreditAmount(0)).toBe(0);
+    expect(assertCreditAmount(Number.MAX_SAFE_INTEGER)).toBe(Number.MAX_SAFE_INTEGER);
+    expect(() => assertCreditAmount(-1)).toThrow();
+    expect(() => assertCreditAmount(1.5)).toThrow();
+    expect(() => assertCreditAmount(Number.MAX_SAFE_INTEGER + 1)).toThrow();
+  });
+});

--- a/dapp/__tests__/lib/uki-economy-periods.test.ts
+++ b/dapp/__tests__/lib/uki-economy-periods.test.ts
@@ -1,0 +1,47 @@
+import {
+  getDailyPeriod,
+  getIsoWeekPeriod,
+  getIsoWeekPeriodFromId,
+} from '@/lib/uki-economy/periods';
+
+describe('UTC economy periods', () => {
+  it('builds daily ids and exclusive UTC bounds across a leap day', () => {
+    expect(getDailyPeriod(new Date('2024-02-29T23:59:59.999Z'))).toEqual({
+      id: '2024-02-29',
+      start: new Date('2024-02-29T00:00:00.000Z'),
+      endExclusive: new Date('2024-03-01T00:00:00.000Z'),
+    });
+  });
+
+  it('uses the UTC date rather than the source offset', () => {
+    expect(getDailyPeriod(new Date('2026-01-01T00:30:00+02:00')).id).toBe('2025-12-31');
+  });
+
+  it.each([
+    ['2020-12-31T12:00:00Z', '2020-W53', '2020-12-28T00:00:00.000Z', '2021-01-04T00:00:00.000Z'],
+    ['2021-01-01T12:00:00Z', '2020-W53', '2020-12-28T00:00:00.000Z', '2021-01-04T00:00:00.000Z'],
+    ['2021-01-04T00:00:00Z', '2021-W01', '2021-01-04T00:00:00.000Z', '2021-01-11T00:00:00.000Z'],
+    ['2024-12-30T23:59:59Z', '2025-W01', '2024-12-30T00:00:00.000Z', '2025-01-06T00:00:00.000Z'],
+  ])('builds ISO week %s as %s', (date, id, start, endExclusive) => {
+    expect(getIsoWeekPeriod(new Date(date))).toEqual({
+      id,
+      start: new Date(start),
+      endExclusive: new Date(endExclusive),
+    });
+  });
+
+  it('rejects invalid dates', () => {
+    expect(() => getDailyPeriod(new Date('invalid'))).toThrow('fecha valida');
+    expect(() => getIsoWeekPeriod(new Date('invalid'))).toThrow('fecha valida');
+  });
+
+  it('resuelve bounds exactos desde un periodId ISO y rechaza W53 inexistente', () => {
+    expect(getIsoWeekPeriodFromId('2026-W28')).toEqual({
+      id: '2026-W28',
+      start: new Date('2026-07-06T00:00:00.000Z'),
+      endExclusive: new Date('2026-07-13T00:00:00.000Z'),
+    });
+    expect(() => getIsoWeekPeriodFromId('2021-W53')).toThrow(/no existe/);
+    expect(() => getIsoWeekPeriodFromId('2026-W1')).toThrow(/canonico/);
+  });
+});

--- a/dapp/src/lib/indexer-db/mongodb.ts
+++ b/dapp/src/lib/indexer-db/mongodb.ts
@@ -1,6 +1,23 @@
 import 'server-only';
 
-import { Db, MongoClient } from 'mongodb';
+import { type ClientSession, Db, MongoClient, ReadPreference } from 'mongodb';
+
+import { SchemaNotReadyError } from '@/lib/uki-economy/errors';
+
+import { getIndexerDbName } from './name';
+
+export const ECONOMY_SCHEMA_METADATA_COLLECTION = 'economy_schema_metadata';
+export const ECONOMY_SCHEMA_METADATA_ID = 'uki-economy';
+export const ECONOMY_SCHEMA_VERSION = 2;
+
+export type EconomySchemaMetadata = {
+  _id: typeof ECONOMY_SCHEMA_METADATA_ID;
+  schemaVersion: typeof ECONOMY_SCHEMA_VERSION;
+  dbName: string;
+  initializedAt: Date;
+  updatedAt: Date;
+  transactionVerifiedAt: Date;
+};
 
 declare global {
   // eslint-disable-next-line no-var
@@ -59,13 +76,80 @@ function getConnection() {
 async function ensureConnection() {
   const connection = getConnection();
   await connection.client.connect();
-  return connection.db;
+  return connection;
 }
 
 export async function getIndexerDb() {
-  return ensureConnection();
+  const connection = await ensureConnection();
+  return connection.db;
 }
 
-export function getIndexerDbName() {
-  return process.env.CHAIN_INDEXER_DB_NAME ?? 'cukieshub-new';
+export async function assertEconomySchema(
+  db: Db,
+  expectedDbName = getIndexerDbName(),
+  session?: ClientSession,
+) {
+  if (db.databaseName !== expectedDbName) {
+    throw new SchemaNotReadyError(
+      `La conexion apunta a ${db.databaseName}, no a la base de economia esperada ${expectedDbName}.`,
+    );
+  }
+
+  const metadata = await db
+    .collection<EconomySchemaMetadata>(ECONOMY_SCHEMA_METADATA_COLLECTION)
+    .findOne({ _id: ECONOMY_SCHEMA_METADATA_ID }, { session });
+
+  if (!metadata) {
+    throw new SchemaNotReadyError(
+      `La base ${expectedDbName} no tiene inicializado el schema de economia UKI.`,
+    );
+  }
+
+  if (
+    metadata.schemaVersion !== ECONOMY_SCHEMA_VERSION
+    || metadata.dbName !== expectedDbName
+    || !(metadata.initializedAt instanceof Date)
+    || !(metadata.updatedAt instanceof Date)
+    || !(metadata.transactionVerifiedAt instanceof Date)
+  ) {
+    throw new SchemaNotReadyError(
+      `El sentinel de economia de ${expectedDbName} es incompatible con schemaVersion ${ECONOMY_SCHEMA_VERSION} o no acredita transacciones.`,
+    );
+  }
+
+  return metadata;
 }
+
+export async function getEconomyDb() {
+  const connection = await ensureConnection();
+  await assertEconomySchema(connection.db);
+  return connection.db;
+}
+
+export type EconomyTransactionWork<T> = (
+  db: Db,
+  session: ClientSession,
+) => Promise<T>;
+
+export async function withEconomyTransaction<T>(work: EconomyTransactionWork<T>) {
+  const connection = await ensureConnection();
+  const session = connection.client.startSession();
+
+  try {
+    return await session.withTransaction(
+      async () => {
+        await assertEconomySchema(connection.db, getIndexerDbName(), session);
+        return work(connection.db, session);
+      },
+      {
+        readConcern: { level: 'snapshot' },
+        writeConcern: { w: 'majority' },
+        readPreference: ReadPreference.primary,
+      },
+    );
+  } finally {
+    await session.endSession();
+  }
+}
+
+export { getIndexerDbName } from './name';

--- a/dapp/src/lib/indexer-db/name.ts
+++ b/dapp/src/lib/indexer-db/name.ts
@@ -1,0 +1,20 @@
+const DEFAULT_INDEXER_DB_NAME = 'cukieshub-new';
+const LEGACY_CUKIES_DB_NAME = 'cukies';
+
+export function resolveIndexerDbName(value = process.env.CHAIN_INDEXER_DB_NAME) {
+  const dbName = (value ?? DEFAULT_INDEXER_DB_NAME).trim();
+
+  if (!dbName) {
+    throw new Error('CHAIN_INDEXER_DB_NAME no puede estar vacio.');
+  }
+
+  if (dbName.toLowerCase() === LEGACY_CUKIES_DB_NAME) {
+    throw new Error('CHAIN_INDEXER_DB_NAME no puede apuntar a la base legacy `cukies`.');
+  }
+
+  return dbName;
+}
+
+export function getIndexerDbName() {
+  return resolveIndexerDbName();
+}

--- a/dapp/src/lib/uki-economy/errors.ts
+++ b/dapp/src/lib/uki-economy/errors.ts
@@ -1,0 +1,64 @@
+export type UkiEconomyErrorCode =
+  | 'VALIDATION'
+  | 'CONFLICT'
+  | 'NOT_FOUND'
+  | 'STALE_FENCE'
+  | 'SCHEMA_NOT_READY';
+
+export class UkiEconomyError extends Error {
+  readonly code: UkiEconomyErrorCode;
+  readonly details?: Record<string, unknown>;
+
+  constructor(
+    code: UkiEconomyErrorCode,
+    message: string,
+    details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'UkiEconomyError';
+    this.code = code;
+    this.details = details;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class DomainValidationError extends UkiEconomyError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('VALIDATION', message, details);
+    this.name = 'DomainValidationError';
+  }
+}
+
+export class DomainConflictError extends UkiEconomyError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('CONFLICT', message, details);
+    this.name = 'DomainConflictError';
+  }
+}
+
+export class DomainNotFoundError extends UkiEconomyError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('NOT_FOUND', message, details);
+    this.name = 'DomainNotFoundError';
+  }
+}
+
+export class StaleFenceError extends UkiEconomyError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('STALE_FENCE', message, details);
+    this.name = 'StaleFenceError';
+  }
+}
+
+export class SchemaNotReadyError extends UkiEconomyError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('SCHEMA_NOT_READY', message, details);
+    this.name = 'SchemaNotReadyError';
+  }
+}
+
+export { DomainConflictError as DomainConflict };
+export { DomainNotFoundError as DomainNotFound };
+export { DomainValidationError as DomainValidation };
+export { SchemaNotReadyError as SchemaNotReady };
+export { StaleFenceError as DomainStaleFence };

--- a/dapp/src/lib/uki-economy/internal-auth.ts
+++ b/dapp/src/lib/uki-economy/internal-auth.ts
@@ -1,0 +1,486 @@
+import 'server-only';
+
+import {
+  createHash,
+  createHmac,
+  timingSafeEqual,
+  type BinaryLike,
+} from 'node:crypto';
+
+import type { Db, MongoServerError } from 'mongodb';
+
+const INTERNAL_PATH_PREFIX = '/api/economy/v1/internal/';
+const SIGNATURE_PREFIX = 'v1=';
+const DEFAULT_MAX_CLOCK_SKEW_MS = 30_000;
+const DEFAULT_NONCE_TTL_MS = 10 * 60_000;
+export const ECONOMY_INTERNAL_MAX_BODY_BYTES = 1024 * 1024;
+
+export const ECONOMY_INTERNAL_NONCES_COLLECTION = 'economy_internal_nonces';
+
+export type InternalEconomyAuthErrorCode =
+  | 'CONFIGURATION'
+  | 'INVALID_REQUEST'
+  | 'INVALID_KEY'
+  | 'INVALID_SIGNATURE'
+  | 'EXPIRED_REQUEST'
+  | 'REPLAYED_REQUEST';
+
+export class InternalEconomyAuthError extends Error {
+  readonly code: InternalEconomyAuthErrorCode;
+
+  constructor(code: InternalEconomyAuthErrorCode, message: string) {
+    super(message);
+    this.name = 'InternalEconomyAuthError';
+    this.code = code;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export type InternalEconomyAuthConfig = {
+  keyId: string;
+  secret: Buffer;
+  maxClockSkewMs: number;
+  nonceTtlMs: number;
+};
+
+export type InternalEconomyAuthInput = {
+  method: string;
+  path: string;
+  timestamp: string;
+  nonce: string;
+  keyId: string;
+  signature: string;
+  rawBody: string | Buffer | Uint8Array;
+};
+
+export type InternalEconomyNonceDocument = {
+  _id: string;
+  keyId: string;
+  nonceHash: string;
+  requestHash: string;
+  bodyHash: string;
+  requestedAt: Date;
+  consumedAt: Date;
+  expiresAt: Date;
+};
+
+export interface InternalEconomyNonceRepository {
+  consume(document: InternalEconomyNonceDocument): Promise<boolean>;
+}
+
+type InternalEconomyAuthEnvironment = Record<string, string | undefined>;
+
+function requiredEnvironmentValue(
+  environment: InternalEconomyAuthEnvironment,
+  name: string,
+) {
+  const value = environment[name];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new InternalEconomyAuthError(
+      'CONFIGURATION',
+      `${name} es obligatorio para autenticar rutas internas de economia.`,
+    );
+  }
+  return value.trim();
+}
+
+function positiveBoundedInteger(
+  value: string | undefined,
+  fallback: number,
+  label: string,
+  maximum: number,
+) {
+  if (value === undefined || value.trim().length === 0) return fallback;
+  if (!/^\d+$/.test(value.trim())) {
+    throw new InternalEconomyAuthError('CONFIGURATION', `${label} debe ser un entero positivo.`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > maximum) {
+    throw new InternalEconomyAuthError(
+      'CONFIGURATION',
+      `${label} debe estar entre 1 y ${maximum}.`,
+    );
+  }
+  return parsed;
+}
+
+export function loadInternalEconomyAuthConfig(
+  environment: InternalEconomyAuthEnvironment = process.env,
+): InternalEconomyAuthConfig {
+  const keyId = requiredEnvironmentValue(environment, 'ECONOMY_INTERNAL_HMAC_KEY_ID');
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(keyId)) {
+    throw new InternalEconomyAuthError(
+      'CONFIGURATION',
+      'ECONOMY_INTERNAL_HMAC_KEY_ID tiene un formato invalido.',
+    );
+  }
+
+  const secretText = requiredEnvironmentValue(environment, 'ECONOMY_INTERNAL_HMAC_SECRET');
+  const publicSecretReuse = Object.entries(environment).some(([name, value]) => (
+    name.startsWith('NEXT_PUBLIC_')
+    && typeof value === 'string'
+    && value.trim().length > 0
+    && secretText === value.trim()
+  ));
+  if (publicSecretReuse) {
+    throw new InternalEconomyAuthError(
+      'CONFIGURATION',
+      'La clave interna de economia no puede reutilizar una variable NEXT_PUBLIC.',
+    );
+  }
+  const secret = Buffer.from(secretText, 'utf8');
+  if (secret.byteLength < 32) {
+    throw new InternalEconomyAuthError(
+      'CONFIGURATION',
+      'ECONOMY_INTERNAL_HMAC_SECRET debe tener al menos 32 bytes.',
+    );
+  }
+  const normalizedSecret = secretText.toLowerCase();
+  const uniqueCharacters = new Set(secretText).size;
+  if (
+    uniqueCharacters < 10
+    || /^(.)\1+$/.test(secretText)
+    || /(change[-_ ]?me|example|placeholder|default|secret123|password)/i.test(normalizedSecret)
+  ) {
+    throw new InternalEconomyAuthError(
+      'CONFIGURATION',
+      'ECONOMY_INTERNAL_HMAC_SECRET parece predecible o de ejemplo.',
+    );
+  }
+
+  const maxClockSkewMs = positiveBoundedInteger(
+    environment.ECONOMY_INTERNAL_HMAC_MAX_SKEW_MS,
+    DEFAULT_MAX_CLOCK_SKEW_MS,
+    'ECONOMY_INTERNAL_HMAC_MAX_SKEW_MS',
+    5 * 60_000,
+  );
+  const nonceTtlMs = positiveBoundedInteger(
+    environment.ECONOMY_INTERNAL_HMAC_NONCE_TTL_MS,
+    DEFAULT_NONCE_TTL_MS,
+    'ECONOMY_INTERNAL_HMAC_NONCE_TTL_MS',
+    24 * 60 * 60_000,
+  );
+  if (nonceTtlMs <= maxClockSkewMs * 2) {
+    throw new InternalEconomyAuthError(
+      'CONFIGURATION',
+      'La retencion de nonces debe cubrir al menos dos veces la ventana de reloj.',
+    );
+  }
+
+  return { keyId, secret, maxClockSkewMs, nonceTtlMs };
+}
+
+/**
+ * Credencial de alcance exclusivo para el game server. No concede acceso a
+ * rewards, reglas, migraciones ni ticks administrativos.
+ */
+export function loadGameEconomyAuthConfig(
+  environment: InternalEconomyAuthEnvironment = process.env,
+): InternalEconomyAuthConfig {
+  const gameKeyId = environment.ECONOMY_GAMES_HMAC_KEY_ID;
+  const gameSecret = environment.ECONOMY_GAMES_HMAC_SECRET;
+  if (
+    typeof gameSecret === 'string'
+    && gameSecret.trim().length > 0
+    && typeof environment.ECONOMY_INTERNAL_HMAC_SECRET === 'string'
+    && gameSecret.trim() === environment.ECONOMY_INTERNAL_HMAC_SECRET.trim()
+  ) {
+    throw new InternalEconomyAuthError(
+      'CONFIGURATION',
+      'ECONOMY_GAMES_HMAC_SECRET debe ser distinta de la credencial administrativa.',
+    );
+  }
+  return loadInternalEconomyAuthConfig({
+    ...environment,
+    ECONOMY_INTERNAL_HMAC_KEY_ID: gameKeyId,
+    ECONOMY_INTERNAL_HMAC_SECRET: gameSecret,
+  });
+}
+
+function requestBodyBytes(value: InternalEconomyAuthInput['rawBody']) {
+  const byteLength = typeof value === 'string' ? Buffer.byteLength(value, 'utf8') : value.byteLength;
+  if (byteLength > ECONOMY_INTERNAL_MAX_BODY_BYTES) {
+    throw new InternalEconomyAuthError(
+      'INVALID_REQUEST',
+      `El cuerpo firmado supera el limite de ${ECONOMY_INTERNAL_MAX_BODY_BYTES} bytes.`,
+    );
+  }
+  if (Buffer.isBuffer(value)) return value;
+  return typeof value === 'string' ? Buffer.from(value, 'utf8') : Buffer.from(value);
+}
+
+export async function readLimitedInternalEconomyRequestBody(
+  request: Pick<Request, 'headers' | 'body'>,
+) {
+  const rawContentLength = request.headers.get('content-length');
+  if (rawContentLength !== null) {
+    if (!/^\d+$/.test(rawContentLength)) {
+      throw new InternalEconomyAuthError('INVALID_REQUEST', 'Content-Length invalido.');
+    }
+    const contentLength = Number(rawContentLength);
+    if (
+      !Number.isSafeInteger(contentLength)
+      || contentLength > ECONOMY_INTERNAL_MAX_BODY_BYTES
+    ) {
+      throw new InternalEconomyAuthError(
+        'INVALID_REQUEST',
+        `El cuerpo firmado supera el limite de ${ECONOMY_INTERNAL_MAX_BODY_BYTES} bytes.`,
+      );
+    }
+  }
+
+  if (!request.body) return Buffer.alloc(0);
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > ECONOMY_INTERNAL_MAX_BODY_BYTES) {
+        await reader.cancel('economy internal body limit exceeded');
+        throw new InternalEconomyAuthError(
+          'INVALID_REQUEST',
+          `El cuerpo firmado supera el limite de ${ECONOMY_INTERNAL_MAX_BODY_BYTES} bytes.`,
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, totalBytes);
+}
+
+function normalizedMethod(value: string) {
+  if (typeof value !== 'string' || !/^[A-Za-z]{3,12}$/.test(value)) {
+    throw new InternalEconomyAuthError('INVALID_REQUEST', 'Metodo HTTP invalido.');
+  }
+  return value.toUpperCase();
+}
+
+function validInternalPath(value: string) {
+  const pathname = typeof value === 'string' ? value.split('?', 1)[0] : '';
+  const lowerPathname = pathname.toLowerCase();
+  if (
+    typeof value !== 'string'
+    || value.length > 2048
+    || !value.startsWith(INTERNAL_PATH_PREFIX)
+    || value.includes('#')
+    || /[\r\n]/.test(value)
+    || pathname.includes('\\')
+    || pathname.includes('//')
+    || pathname.split('/').includes('..')
+    || lowerPathname.includes('%2e')
+    || lowerPathname.includes('%2f')
+    || lowerPathname.includes('%5c')
+  ) {
+    throw new InternalEconomyAuthError('INVALID_REQUEST', 'Ruta interna invalida.');
+  }
+  return value;
+}
+
+function validTimestamp(value: string) {
+  if (typeof value !== 'string' || !/^\d{13}$/.test(value)) {
+    throw new InternalEconomyAuthError(
+      'INVALID_REQUEST',
+      'El timestamp debe ser Unix epoch en milisegundos.',
+    );
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new InternalEconomyAuthError('INVALID_REQUEST', 'Timestamp fuera de rango.');
+  }
+  return parsed;
+}
+
+function validNonce(value: string) {
+  if (typeof value !== 'string' || value.length > 128) {
+    throw new InternalEconomyAuthError(
+      'INVALID_REQUEST',
+      'Nonce invalido; se requieren al menos 128 bits en base64url o hexadecimal.',
+    );
+  }
+  if (/^[0-9a-fA-F]+$/.test(value)) {
+    if (value.length < 32 || value.length % 2 !== 0) {
+      throw new InternalEconomyAuthError(
+        'INVALID_REQUEST',
+        'Nonce hexadecimal invalido; se requieren al menos 128 bits.',
+      );
+    }
+    return value;
+  }
+  if (!/^[A-Za-z0-9_-]{22,128}$/.test(value)) {
+    throw new InternalEconomyAuthError(
+      'INVALID_REQUEST',
+      'Nonce base64url invalido; se requieren al menos 128 bits.',
+    );
+  }
+  const decoded = Buffer.from(value, 'base64url');
+  if (decoded.byteLength < 16 || decoded.toString('base64url') !== value) {
+    throw new InternalEconomyAuthError(
+      'INVALID_REQUEST',
+      'Nonce base64url invalido; se requieren al menos 128 bits.',
+    );
+  }
+  return value;
+}
+
+function validSignature(value: string) {
+  if (
+    typeof value !== 'string'
+    || !new RegExp(`^${SIGNATURE_PREFIX}[0-9a-fA-F]{64}$`).test(value)
+  ) {
+    throw new InternalEconomyAuthError('INVALID_SIGNATURE', 'Firma HMAC invalida.');
+  }
+  return value.slice(SIGNATURE_PREFIX.length).toLowerCase();
+}
+
+function sha256(value: BinaryLike) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function buildInternalEconomyCanonicalRequest(input: {
+  method: string;
+  path: string;
+  timestamp: string;
+  nonce: string;
+  keyId: string;
+  bodyHash: string;
+}) {
+  const method = normalizedMethod(input.method);
+  const path = validInternalPath(input.path);
+  validTimestamp(input.timestamp);
+  const nonce = validNonce(input.nonce);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(input.keyId)) {
+    throw new InternalEconomyAuthError('INVALID_KEY', 'Identificador de clave invalido.');
+  }
+  if (!/^[0-9a-f]{64}$/.test(input.bodyHash)) {
+    throw new InternalEconomyAuthError('INVALID_REQUEST', 'Hash de cuerpo invalido.');
+  }
+  return [
+    'cukies-economy-hmac-v1',
+    input.keyId,
+    method,
+    path,
+    input.timestamp,
+    nonce,
+    input.bodyHash,
+  ].join('\n');
+}
+
+export function signInternalEconomyRequest(
+  input: Omit<InternalEconomyAuthInput, 'signature'>,
+  config: InternalEconomyAuthConfig,
+) {
+  if (input.keyId !== config.keyId) {
+    throw new InternalEconomyAuthError('INVALID_KEY', 'La clave solicitada no esta activa.');
+  }
+  const bodyHash = sha256(requestBodyBytes(input.rawBody));
+  const canonicalRequest = buildInternalEconomyCanonicalRequest({ ...input, bodyHash });
+  const signature = createHmac('sha256', config.secret)
+    .update(canonicalRequest, 'utf8')
+    .digest('hex');
+  return {
+    signature: `${SIGNATURE_PREFIX}${signature}`,
+    bodyHash,
+    canonicalRequest,
+    requestHash: sha256(canonicalRequest),
+  };
+}
+
+function signaturesMatch(actualHex: string, expectedHeader: string) {
+  const expectedHex = validSignature(expectedHeader);
+  const actual = Buffer.from(actualHex, 'hex');
+  const expected = Buffer.from(expectedHex, 'hex');
+  return actual.byteLength === expected.byteLength && timingSafeEqual(actual, expected);
+}
+
+export async function verifyAndConsumeInternalEconomyRequest(input: {
+  request: InternalEconomyAuthInput;
+  config: InternalEconomyAuthConfig;
+  nonces: InternalEconomyNonceRepository;
+  now?: Date;
+}) {
+  const now = input.now ?? new Date();
+  if (!(now instanceof Date) || Number.isNaN(now.getTime())) {
+    throw new InternalEconomyAuthError('INVALID_REQUEST', 'Fecha de verificacion invalida.');
+  }
+  if (input.request.keyId !== input.config.keyId) {
+    throw new InternalEconomyAuthError('INVALID_KEY', 'La clave solicitada no esta activa.');
+  }
+
+  const requestedAtMs = validTimestamp(input.request.timestamp);
+  if (Math.abs(now.getTime() - requestedAtMs) > input.config.maxClockSkewMs) {
+    throw new InternalEconomyAuthError('EXPIRED_REQUEST', 'La solicitud interna esta fuera de ventana.');
+  }
+
+  const signed = signInternalEconomyRequest(
+    {
+      method: input.request.method,
+      path: input.request.path,
+      timestamp: input.request.timestamp,
+      nonce: input.request.nonce,
+      keyId: input.request.keyId,
+      rawBody: input.request.rawBody,
+    },
+    input.config,
+  );
+  if (!signaturesMatch(signed.signature.slice(SIGNATURE_PREFIX.length), input.request.signature)) {
+    throw new InternalEconomyAuthError('INVALID_SIGNATURE', 'Firma HMAC invalida.');
+  }
+
+  const nonce = validNonce(input.request.nonce);
+  const nonceHash = sha256(`${input.config.keyId}:${nonce}`);
+  const consumed = await input.nonces.consume({
+    _id: nonceHash,
+    keyId: input.config.keyId,
+    nonceHash,
+    requestHash: signed.requestHash,
+    bodyHash: signed.bodyHash,
+    requestedAt: new Date(requestedAtMs),
+    consumedAt: new Date(now.getTime()),
+    expiresAt: new Date(now.getTime() + input.config.nonceTtlMs),
+  });
+  if (!consumed) {
+    throw new InternalEconomyAuthError('REPLAYED_REQUEST', 'Nonce interno ya consumido.');
+  }
+
+  return {
+    keyId: input.config.keyId,
+    nonceHash,
+    bodyHash: signed.bodyHash,
+    requestHash: signed.requestHash,
+    requestedAt: new Date(requestedAtMs),
+    verifiedAt: new Date(now.getTime()),
+  };
+}
+
+function isMongoDuplicateKey(error: unknown) {
+  return Boolean(
+    error
+    && typeof error === 'object'
+    && 'code' in error
+    && Number((error as MongoServerError).code) === 11000,
+  );
+}
+
+export function createMongoInternalEconomyNonceRepository(
+  db: Db,
+): InternalEconomyNonceRepository {
+  const collection = db.collection<InternalEconomyNonceDocument>(
+    ECONOMY_INTERNAL_NONCES_COLLECTION,
+  );
+  return {
+    async consume(document) {
+      try {
+        await collection.insertOne(document, { writeConcern: { w: 'majority' } });
+        return true;
+      } catch (error) {
+        if (isMongoDuplicateKey(error)) return false;
+        throw error;
+      }
+    },
+  };
+}

--- a/dapp/src/lib/uki-economy/money.ts
+++ b/dapp/src/lib/uki-economy/money.ts
@@ -1,0 +1,78 @@
+const RAW_ZERO = BigInt('0');
+const RAW_ONE = BigInt('1');
+const UINT256_BITS = BigInt('256');
+
+export const UINT256_MAX = (RAW_ONE << UINT256_BITS) - RAW_ONE;
+
+function assertRawBigInt(value: bigint, label: string) {
+  if (typeof value !== 'bigint') {
+    throw new TypeError(`${label} debe ser bigint.`);
+  }
+
+  if (value < RAW_ZERO) {
+    throw new RangeError(`${label} no puede ser negativo.`);
+  }
+
+  if (value > UINT256_MAX) {
+    throw new RangeError(`${label} excede uint256.`);
+  }
+
+  return value;
+}
+
+export function parseRawAmount(value: string) {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+    throw new TypeError('El monto raw debe ser una cadena decimal entera sin signo.');
+  }
+
+  return assertRawBigInt(BigInt(value), 'El monto raw');
+}
+
+export function formatRawAmount(value: bigint) {
+  return assertRawBigInt(value, 'El monto raw').toString(10);
+}
+
+export function addRawAmounts(left: bigint, right: bigint) {
+  const result = assertRawBigInt(left, 'El sumando izquierdo')
+    + assertRawBigInt(right, 'El sumando derecho');
+
+  return assertRawBigInt(result, 'El resultado de la suma');
+}
+
+export function sumRawAmounts(values: readonly bigint[]) {
+  return values.reduce((total, value) => addRawAmounts(total, value), RAW_ZERO);
+}
+
+export function subtractRawAmounts(left: bigint, right: bigint) {
+  const minuend = assertRawBigInt(left, 'El minuendo');
+  const subtrahend = assertRawBigInt(right, 'El sustraendo');
+
+  if (subtrahend > minuend) {
+    throw new RangeError('La resta de montos raw no puede ser negativa.');
+  }
+
+  return minuend - subtrahend;
+}
+
+export function mulDiv(value: bigint, multiplier: bigint, divisor: bigint) {
+  const checkedValue = assertRawBigInt(value, 'El valor');
+  const checkedMultiplier = assertRawBigInt(multiplier, 'El multiplicador');
+  const checkedDivisor = assertRawBigInt(divisor, 'El divisor');
+
+  if (checkedDivisor === RAW_ZERO) {
+    throw new RangeError('El divisor no puede ser cero.');
+  }
+
+  const result = (checkedValue * checkedMultiplier) / checkedDivisor;
+  return assertRawBigInt(result, 'El resultado de mulDiv');
+}
+
+export const multiplyDivideRawAmount = mulDiv;
+
+export function assertCreditAmount(value: number) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError('El monto de creditos debe ser un entero seguro no negativo.');
+  }
+
+  return value;
+}

--- a/dapp/src/lib/uki-economy/periods.ts
+++ b/dapp/src/lib/uki-economy/periods.ts
@@ -1,0 +1,101 @@
+export type UtcPeriod = {
+  id: string;
+  start: Date;
+  endExclusive: Date;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function assertValidDate(value: Date) {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new TypeError('Se requiere una fecha valida.');
+  }
+
+  return value;
+}
+
+function utcMidnight(value: Date) {
+  const date = assertValidDate(value);
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+export function getDailyPeriodId(value: Date) {
+  return utcMidnight(value).toISOString().slice(0, 10);
+}
+
+export function getDailyPeriodBounds(value: Date) {
+  const start = utcMidnight(value);
+  return {
+    start,
+    endExclusive: new Date(start.getTime() + DAY_MS),
+  };
+}
+
+export function getDailyPeriod(value: Date): UtcPeriod {
+  const bounds = getDailyPeriodBounds(value);
+  return {
+    id: getDailyPeriodId(value),
+    ...bounds,
+  };
+}
+
+function isoWeekParts(value: Date) {
+  const midnight = utcMidnight(value);
+  const isoDay = midnight.getUTCDay() || 7;
+  const thursday = new Date(midnight.getTime() + (4 - isoDay) * DAY_MS);
+  const year = thursday.getUTCFullYear();
+  const yearStart = new Date(Date.UTC(year, 0, 1));
+  const week = Math.ceil(((thursday.getTime() - yearStart.getTime()) / DAY_MS + 1) / 7);
+
+  return { midnight, isoDay, year, week };
+}
+
+export function getIsoWeekPeriodId(value: Date) {
+  const { year, week } = isoWeekParts(value);
+  return `${year}-W${String(week).padStart(2, '0')}`;
+}
+
+export function getIsoWeekPeriodBounds(value: Date) {
+  const { midnight, isoDay } = isoWeekParts(value);
+  const start = new Date(midnight.getTime() - (isoDay - 1) * DAY_MS);
+
+  return {
+    start,
+    endExclusive: new Date(start.getTime() + 7 * DAY_MS),
+  };
+}
+
+export function getIsoWeekPeriod(value: Date): UtcPeriod {
+  const bounds = getIsoWeekPeriodBounds(value);
+  return {
+    id: getIsoWeekPeriodId(value),
+    ...bounds,
+  };
+}
+
+export function getIsoWeekPeriodFromId(periodId: string): UtcPeriod {
+  const match = /^(\d{4})-W(\d{2})$/.exec(periodId);
+  if (!match) throw new TypeError('Se requiere un periodo ISO semanal canonico.');
+  const year = Number(match[1]);
+  const week = Number(match[2]);
+  if (week < 1 || week > 53) {
+    throw new TypeError('La semana ISO esta fuera de rango.');
+  }
+  const januaryFourth = new Date(Date.UTC(year, 0, 4));
+  const isoDay = januaryFourth.getUTCDay() || 7;
+  const weekOneStart = new Date(
+    januaryFourth.getTime() - (isoDay - 1) * DAY_MS,
+  );
+  const start = new Date(weekOneStart.getTime() + (week - 1) * 7 * DAY_MS);
+  if (getIsoWeekPeriodId(start) !== periodId) {
+    throw new TypeError('El periodo ISO semanal no existe.');
+  }
+  return {
+    id: periodId,
+    start,
+    endExclusive: new Date(start.getTime() + 7 * DAY_MS),
+  };
+}
+
+export const dailyPeriodId = getDailyPeriodId;
+export const isoWeekPeriodId = getIsoWeekPeriodId;


### PR DESCRIPTION
Refs #166

## Resumen
- añade el núcleo neutral de economía v2 sin cargar reglas ni cifras de producto
- autentica rutas internas con HMAC separado para administración y game servers
- limita el cuerpo firmado, valida reloj y consume nonces con write concern majority
- añade acceso Mongo transaccional con sentinel v2 fail-closed
- exige que el sentinel acredite `transactionVerifiedAt`
- mantiene el lector genérico del indexer separado del acceso de escritura de economía

## Validación
- 5 suites / 40 tests focalizados — OK
- `pnpm dapp lint` — OK
- `pnpm dapp typecheck` — OK
- `pnpm dapp build` — OK

## Seguridad operativa
- no incluye rutas HTTP ni reglas de producto todavía
- no activa schedulers ni realiza escrituras al desplegarse
- base `staging`; no modifica `main`, mainnet ni producción