### PR TITLE
feat: isolate staging Mongo runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
+FROM mongo:4.4 AS staging-mongo
+
+COPY infrastructure/staging-mongo/entrypoint.sh /usr/local/bin/cukies-staging-mongo-entrypoint
+COPY infrastructure/staging-mongo/resync.sh /usr/local/bin/cukies-staging-mongo-resync
+
+RUN chmod 0755 \
+  /usr/local/bin/cukies-staging-mongo-entrypoint \
+  /usr/local/bin/cukies-staging-mongo-resync
+
+ENTRYPOINT ["/usr/local/bin/cukies-staging-mongo-entrypoint"]
+
 FROM node:22-bookworm-slim AS app
 
 ARG CUKIES_SERVICE=dapp

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -1,4 +1,45 @@
 services:
+  staging-mongo:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: staging-mongo
+    environment:
+      APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
+      STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      COOLIFY_RESOURCE_UUID: ${COOLIFY_RESOURCE_UUID:?Set the exact staging Coolify resource UUID}
+      MONGO_INITDB_ROOT_USERNAME: ${STAGING_MONGO_ROOT_USERNAME:?Set the staging-only Mongo root username}
+      MONGO_INITDB_ROOT_PASSWORD: ${STAGING_MONGO_ROOT_PASSWORD:?Set the staging-only Mongo root password}
+      STAGING_MONGO_REPLICA_KEY: ${STAGING_MONGO_REPLICA_KEY:?Set the staging-only Mongo replica key}
+      STAGING_MONGO_SOURCE_HUB_URL: ${DATABASE_URL}
+      STAGING_MONGO_SOURCE_LEGACY_URL: ${CUKIES_DATABASE_URL}
+      STAGING_MONGO_SOURCE_ECONOMY_URL: ${CHAIN_INDEXER_MONGO_URL}
+      STAGING_MONGO_SOURCE_CARD_URL: ${CARD_WORKER_MONGO_URL}
+    volumes:
+      - staging-mongo-data:/data/db
+      - staging-mongo-config:/data/configdb
+    mem_limit: 2g
+    cpus: 1.5
+    restart: unless-stopped
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          mongo --quiet --host 127.0.0.1 --port 27017
+          --username "$$MONGO_INITDB_ROOT_USERNAME"
+          --password "$$MONGO_INITDB_ROOT_PASSWORD"
+          --authenticationDatabase admin
+          cukies_staging_mongo_admin
+          --eval 'quit(db.isMaster().ismaster === true && db.bootstrap_state.countDocuments({_id:"logical-staging-v1"}) === 1 ? 0 : 1)'
+      interval: 15s
+      timeout: 10s
+      retries: 20
+      start_period: 180s
+    networks:
+      coolify:
+        aliases:
+          - cukies-hub-staging-mongo-u4s804o4wwcckowgk0woo4wg
+
   dapp:
     build:
       context: .
@@ -352,3 +393,9 @@ services:
 networks:
   coolify:
     external: true
+
+volumes:
+  staging-mongo-data:
+    name: ${STAGING_MONGO_DATA_VOLUME:?Set the staging-only Mongo data volume name}
+  staging-mongo-config:
+    name: ${STAGING_MONGO_CONFIG_VOLUME:?Set the staging-only Mongo config volume name}

--- a/docs/deployment-environments.md
+++ b/docs/deployment-environments.md
@@ -28,7 +28,7 @@ Las ramas `release/staging-YYYY-MM-DD` son opcionales y se usan solo cuando `sta
 - Staging usa BSC Testnet (`97`) y la preventa `0xC0d7b04AC4DFCCc28790FD492FCB3CB16AcDfcdA`.
 - Staging usa `UKIStaking` `0x551bd243eE4C5d68BA53A27fd9aE09339d5C2205` (bloque `123359165`) y `RewardsDistributor` `0xc2252D797Da294D16b84282d213604b4Bcf6EE09` (bloque `123359171`). Ambos apuntan al UKI testnet existente.
 - El smoke `STAGING_SMOKE_C31176A_2026_08_05` movio temporalmente `1 UKI` por contrato y termino con staking, reservas y balance del distribuidor a cero. No representa una cifra de producto.
-- Staging usa `cukies-hub-staging`, `cukies-legacy-staging` y `cukieshub-new-staging` sobre Mongo replica set `rs0`.
+- Staging usa las bases logicas `cukies-hub-staging`, `cukies-legacy-staging` y `cukieshub-new-staging`. El cutover a la instancia fisica exclusiva `cukies-staging-rs0` se prepara en dos despliegues para no apuntar la aplicacion a una replica a medio inicializar.
 - Produccion conserva BSC mainnet y sus bases de produccion; no se han reapuntado durante esta separacion.
 - La VM Coolify/Traefik observada es `1001` (`192.168.1.201`) y publica Traefik en `80/443`.
 - Cloudflare Tunnel ya tiene ruta para `cukieshub.eurekand.com` hacia `https://192.168.1.201:443`.
@@ -86,9 +86,9 @@ El proveedor activo observado es Coolify. `cukieshub.eurekand.com` sigue `stagin
 
 Trabajo pendiente en Coolify:
 
-- completar usuarios/credenciales Mongo limitados a las tres bases staging antes de QA externa,
-- separar OAuth, Pusher, Resend y Telegram,
-- desplegar los contratos de economia pendientes y mantener schedulers desactivados hasta completar sus gates,
+- completar el cutover desde las bases logicas staging del host compartido a `cukies-staging-rs0`, sin leer ni escribir las bases live,
+- sustituir las integraciones externas deshabilitadas por credenciales realmente exclusivas cuando QA las necesite,
+- mantener los cinco schedulers desplegados pero desactivados hasta aprobar y cargar sus reglas,
 - documentar rollback por commit y por variables para cada promocion a `main`.
 
 Nada de esto debe usar secrets en el repo.
@@ -134,6 +134,21 @@ El schema de economia se inicializa de forma deliberada, no durante el arranque 
 5. mantener todos los schedulers desactivados hasta cargar reglas y probar leases/idempotencia.
 
 Ambos comandos vuelven a ejecutar el guard staging-only antes de crear indices, escribir el sentinel o abrir la transaccion de prueba.
+
+### Mongo fisico exclusivo de staging
+
+El servicio `staging-mongo` del compose crea un replica set de un solo nodo llamado `cukies-staging-rs0`, sin puerto publico y con volumenes exclusivos de la app Coolify `28`. Su entrypoint falla cerrado salvo que coincidan `APP_ENV=staging`, `STAGING_ONLY_GUARD=true` y el UUID `u4s804o4wwcckowgk0woo4wg`.
+
+El cutover se hace siempre en dos despliegues:
+
+1. desplegar `staging-mongo` manteniendo las cuatro URLs de aplicacion en el origen actual;
+2. el bootstrap valida que solo lee los tres namespaces `*-staging`, los copia a la replica exclusiva, conserva los cuatro usuarios limitados y escribe el marcador `logical-staging-v1`;
+3. verificar replica PRIMARY, conteos, indices, sentinel v2, usuarios/roles y transacciones;
+4. detener temporalmente solo los contenedores de la app `28` y ejecutar `cukies-staging-mongo-resync` dentro del nuevo Mongo para cerrar el delta con las tres fuentes staging ya quietas;
+5. cambiar solo las URLs de la app `28` al alias interno `cukies-hub-staging-mongo-u4s804o4wwcckowgk0woo4wg:27017`, con `replicaSet=cukies-staging-rs0`;
+6. redesplegar y repetir health, schema setup y comprobaciones de no escritura de los schedulers.
+
+No se migra ningun namespace de produccion. Si falta el marcador, el bootstrap solo acepta como origen el host `192.168.1.221:27017`, los cuatro usuarios de staging conocidos y los tres nombres de base exactos; cualquier otra combinacion aborta el contenedor.
 
 ## Matriz de envs
 
@@ -233,21 +248,22 @@ Antes de considerar staging valido:
 - [x] Integrar el guardarrail de RPC/chain id de BSC Testnet en `staging` (PR #188, merge `290cc643`).
 - [x] Anadir preflight staging-only fail-closed para rama, recurso Coolify, chain, bases y URL de autenticacion antes de arrancar o ejecutar setups.
 - [x] Reapuntar el recurso Coolify staging a la rama `staging`.
-- [x] Separar las tres bases staging y habilitar transacciones mediante Mongo replica set `rs0`.
+- [x] Separar los tres namespaces y los cuatro usuarios staging sin reapuntar ninguna base live.
+- [ ] Completar el cutover de esos namespaces a la instancia fisica exclusiva `cukies-staging-rs0` y validar transacciones tras el cambio de URLs.
 - [x] Desplegar y financiar un nuevo `VestingVault` y `Presale` en BSC Testnet.
 - [x] Ejecutar una compra on-chain smoke de `5 tASM -> 500 UKI` y validar pago, venta y vesting.
 - [x] Migrar la verificacion del explorer a Etherscan API V2 y verificar el source de Vault/Presale.
-- [ ] Crear usuarios Mongo con minimo privilegio y habilitar `security.authorization` tras validar los consumidores legacy.
+- [x] Crear cuatro usuarios Mongo staging con roles `readWrite` + `dbAdmin` limitados a su unica base.
 - [x] Desplegar `UKIStaking` y `RewardsDistributor`, configurar sus cinco cursores y proyectar un smoke completo en Mongo staging (PR #192, merge `c31176ab`).
 - [ ] Publicar el source de ambos contratos en BscScan cuando haya `ETHERSCAN_API_KEY`/`BSCSCAN_API_KEY`; el entorno actual no conserva ninguna.
-- [ ] Configurar HMAC exclusivos de staging y ejecutar el setup de economia v2.
+- [x] Configurar HMAC distintas para administracion y juegos en staging y ejecutar dos veces el setup idempotente de economia v2.
 - [ ] Cargar reglas aprobadas de creditos, juegos, pools y ranking.
-- [ ] Desplegar los cinco schedulers con gates desactivados; activarlos uno a uno tras validar heartbeats, leases e idempotencia.
+- [x] Desplegar los cinco schedulers con gates desactivados y verificar guardas, credencial limitada y ausencia de heartbeats/runs.
 - [x] Retirar el card worker del arranque por defecto de staging mediante el profile `card-worker`; sigue desactivado hasta disponer de S3 propio.
-- [ ] Separar OAuth, Pusher, Resend y Telegram antes de QA externa.
+- [x] Vaciar OAuth social, Pusher, Resend, Telegram e IFTTT en staging; quedan deshabilitados hasta tener destinos exclusivos.
 - [ ] Completar smoke E2E con una segunda wallet desde la UI y conservar evidencia de APIs, Mongo e indexer.
 
-El siguiente bloque recomendado es configurar HMAC exclusivos de staging y ejecutar el setup transaccional de economia v2. Despues deben cargarse reglas aprobadas y validarse APIs/leases antes de habilitar ningun scheduler.
+El siguiente bloque recomendado es completar el cutover al Mongo fisico exclusivo y repetir el setup transaccional. Despues se debe ejecutar el E2E con dos wallets y cargar solo las reglas numericas que producto haya aprobado; ningun scheduler se habilita antes.
 
 ## Gates para produccion
 

--- a/infrastructure/staging-mongo/entrypoint.sh
+++ b/infrastructure/staging-mongo/entrypoint.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly expected_resource_uuid='u4s804o4wwcckowgk0woo4wg'
+readonly replica_set='cukies-staging-rs0'
+readonly replica_host='cukies-hub-staging-mongo-u4s804o4wwcckowgk0woo4wg:27017'
+readonly source_host='192.168.1.221:27017'
+readonly bootstrap_database='cukies_staging_mongo_admin'
+readonly bootstrap_id='logical-staging-v1'
+readonly keyfile='/tmp/cukies-staging-mongo-keyfile'
+
+fail() {
+  printf 'STAGING_MONGO_GUARD_FAILED: %s\n' "$1" >&2
+  exit 64
+}
+
+require_value() {
+  local name="$1"
+  [[ -n "${!name:-}" ]] || fail "falta ${name}"
+}
+
+[[ "${STAGING_ONLY_GUARD:-}" == 'true' ]] || fail 'STAGING_ONLY_GUARD debe ser true'
+[[ "${APP_ENV:-}" == 'staging' ]] || fail 'APP_ENV debe ser staging'
+[[ "${COOLIFY_RESOURCE_UUID:-}" == "$expected_resource_uuid" ]] \
+  || fail 'COOLIFY_RESOURCE_UUID no corresponde a staging'
+
+require_value MONGO_INITDB_ROOT_USERNAME
+require_value MONGO_INITDB_ROOT_PASSWORD
+require_value STAGING_MONGO_REPLICA_KEY
+
+[[ "${#STAGING_MONGO_REPLICA_KEY}" -ge 32 ]] \
+  || fail 'STAGING_MONGO_REPLICA_KEY es demasiado corta'
+[[ "${#STAGING_MONGO_REPLICA_KEY}" -le 1024 ]] \
+  || fail 'STAGING_MONGO_REPLICA_KEY supera el limite de MongoDB'
+[[ "$STAGING_MONGO_REPLICA_KEY" =~ ^[A-Za-z0-9+/=]+$ ]] \
+  || fail 'STAGING_MONGO_REPLICA_KEY contiene caracteres no permitidos'
+[[ "$MONGO_INITDB_ROOT_USERNAME" == 'cukies_staging_root' ]] \
+  || fail 'MONGO_INITDB_ROOT_USERNAME inesperado'
+[[ "${#MONGO_INITDB_ROOT_PASSWORD}" -ge 48 ]] \
+  || fail 'MONGO_INITDB_ROOT_PASSWORD es demasiado corta'
+
+install -m 0600 /dev/null "$keyfile"
+printf '%s' "$STAGING_MONGO_REPLICA_KEY" > "$keyfile"
+chown mongodb:mongodb "$keyfile"
+chmod 0400 "$keyfile"
+
+/usr/local/bin/docker-entrypoint.sh mongod \
+  --bind_ip_all \
+  --replSet "$replica_set" \
+  --keyFile "$keyfile" \
+  --wiredTigerCacheSizeGB 0.5 &
+mongod_pid=$!
+
+terminate() {
+  if kill -0 "$mongod_pid" 2>/dev/null; then
+    kill -TERM "$mongod_pid"
+  fi
+  wait "$mongod_pid" || true
+}
+trap terminate TERM INT
+
+mongo_admin=(
+  mongo
+  --quiet
+  --host 127.0.0.1
+  --port 27017
+  --username "$MONGO_INITDB_ROOT_USERNAME"
+  --password "$MONGO_INITDB_ROOT_PASSWORD"
+  --authenticationDatabase admin
+)
+
+for _ in $(seq 1 90); do
+  if "${mongo_admin[@]}" admin --eval 'db.adminCommand({ ping: 1 }).ok' >/dev/null 2>&1; then
+    break
+  fi
+  kill -0 "$mongod_pid" 2>/dev/null || fail 'mongod termino durante el arranque'
+  sleep 2
+done
+"${mongo_admin[@]}" admin --eval 'db.adminCommand({ ping: 1 }).ok' >/dev/null \
+  || fail 'mongod no responde con autenticacion root'
+
+replica_status="$("${mongo_admin[@]}" admin --eval '
+  try {
+    const status = rs.status();
+    if (status.ok === 1) print("ready");
+    else if (status.code === 94 || status.codeName === "NotYetInitialized") print("not-initialized");
+    else print("not-ready");
+  } catch (error) {
+    if (error.code === 94 || error.codeName === "NotYetInitialized") print("not-initialized");
+    else throw error;
+  }
+' | tail -n 1)"
+
+if [[ "$replica_status" == 'not-initialized' ]]; then
+  "${mongo_admin[@]}" admin --eval "
+    const result = rs.initiate({
+      _id: '$replica_set',
+      members: [{ _id: 0, host: '$replica_host' }],
+    });
+    if (result.ok !== 1) throw new Error('rs.initiate fallo');
+  " >/dev/null
+elif [[ "$replica_status" != 'ready' ]]; then
+  fail 'estado inesperado del replica set'
+fi
+
+for _ in $(seq 1 90); do
+  if "${mongo_admin[@]}" admin --eval 'quit(db.isMaster().ismaster === true ? 0 : 1)' \
+    >/dev/null 2>&1; then
+    break
+  fi
+  kill -0 "$mongod_pid" 2>/dev/null || fail 'mongod termino antes de ser primary'
+  sleep 2
+done
+"${mongo_admin[@]}" admin --eval 'quit(db.isMaster().ismaster === true ? 0 : 1)' \
+  >/dev/null || fail 'el replica set no alcanzo PRIMARY'
+
+marker_count="$("${mongo_admin[@]}" "$bootstrap_database" --eval \
+  "print(db.bootstrap_state.countDocuments({ _id: '$bootstrap_id' }))" | tail -n 1)"
+
+validate_source_url() {
+  local name="$1"
+  local expected_user="$2"
+  local expected_database="$3"
+  local value="${!name:-}"
+
+  require_value "$name"
+  [[ "$value" =~ ^mongodb://${expected_user}:[^@]+@192\.168\.1\.221:27017/${expected_database}(\?.*)?$ ]] \
+    || fail "${name} no apunta al usuario, host y DB de staging esperados"
+}
+
+if [[ "$marker_count" == '0' ]]; then
+  validate_source_url STAGING_MONGO_SOURCE_HUB_URL 'cukies_hub_staging_app' 'cukies-hub-staging'
+  validate_source_url STAGING_MONGO_SOURCE_LEGACY_URL 'cukies_legacy_staging_app' 'cukies-legacy-staging'
+  validate_source_url STAGING_MONGO_SOURCE_ECONOMY_URL 'cukies_economy_staging_app' 'cukieshub-new-staging'
+  validate_source_url STAGING_MONGO_SOURCE_CARD_URL 'cukies_card_staging_worker' 'cukieshub-new-staging'
+
+  root_uri="mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@127.0.0.1:27017/?authSource=admin&replicaSet=${replica_set}&directConnection=true"
+
+  migrate_database() {
+    local source_url="$1"
+    local database="$2"
+    printf 'Migrando DB logica de staging: %s\n' "$database"
+    mongodump --quiet --uri "$source_url" --archive \
+      | mongorestore --quiet --uri "$root_uri" --archive --drop --nsInclude "${database}.*"
+  }
+
+  migrate_database "$STAGING_MONGO_SOURCE_HUB_URL" 'cukies-hub-staging'
+  migrate_database "$STAGING_MONGO_SOURCE_LEGACY_URL" 'cukies-legacy-staging'
+  migrate_database "$STAGING_MONGO_SOURCE_ECONOMY_URL" 'cukieshub-new-staging'
+
+  "${mongo_admin[@]}" admin --eval '
+    function parseScopedUrl(environmentName, expectedUser, expectedDatabase) {
+      const value = _getEnv(environmentName);
+      const match = /^mongodb:\/\/([^:]+):([^@]+)@([^/]+)\/([^?]+)(?:\?.*)?$/.exec(value);
+      if (!match) throw new Error(environmentName + " tiene formato invalido");
+      const user = decodeURIComponent(match[1]);
+      const password = decodeURIComponent(match[2]);
+      const databaseName = decodeURIComponent(match[4]);
+      if (user !== expectedUser || databaseName !== expectedDatabase) {
+        throw new Error(environmentName + " no coincide con la identidad staging esperada");
+      }
+      return { user: user, password: password, databaseName: databaseName };
+    }
+
+    const specs = [
+      parseScopedUrl("STAGING_MONGO_SOURCE_HUB_URL", "cukies_hub_staging_app", "cukies-hub-staging"),
+      parseScopedUrl("STAGING_MONGO_SOURCE_LEGACY_URL", "cukies_legacy_staging_app", "cukies-legacy-staging"),
+      parseScopedUrl("STAGING_MONGO_SOURCE_ECONOMY_URL", "cukies_economy_staging_app", "cukieshub-new-staging"),
+      parseScopedUrl("STAGING_MONGO_SOURCE_CARD_URL", "cukies_card_staging_worker", "cukieshub-new-staging"),
+    ];
+
+    specs.forEach(function (spec) {
+      const target = db.getSiblingDB(spec.databaseName);
+      const roles = [
+        { role: "readWrite", db: spec.databaseName },
+        { role: "dbAdmin", db: spec.databaseName },
+      ];
+      const existing = target.runCommand({ usersInfo: spec.user }).users;
+      if (existing.length === 0) target.createUser({ user: spec.user, pwd: spec.password, roles: roles });
+      else target.updateUser(spec.user, { pwd: spec.password, roles: roles });
+    });
+  ' >/dev/null
+
+  "${mongo_admin[@]}" "$bootstrap_database" --eval "
+    db.bootstrap_state.updateOne(
+      { _id: '$bootstrap_id' },
+      {
+        \$setOnInsert: {
+          _id: '$bootstrap_id',
+          completedAt: new Date(),
+          sourceHost: '$source_host',
+          replicaSet: '$replica_set',
+          databases: ['cukies-hub-staging', 'cukies-legacy-staging', 'cukieshub-new-staging'],
+        },
+      },
+      { upsert: true },
+    );
+  " >/dev/null
+elif [[ "$marker_count" != '1' ]]; then
+  fail 'estado inesperado del marcador de bootstrap'
+fi
+
+printf 'STAGING_MONGO_READY replicaSet=%s resource=%s\n' "$replica_set" "$expected_resource_uuid"
+wait "$mongod_pid"

--- a/infrastructure/staging-mongo/resync.sh
+++ b/infrastructure/staging-mongo/resync.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly expected_resource_uuid='u4s804o4wwcckowgk0woo4wg'
+readonly replica_set='cukies-staging-rs0'
+readonly bootstrap_database='cukies_staging_mongo_admin'
+readonly bootstrap_id='logical-staging-v1'
+
+fail() {
+  printf 'STAGING_MONGO_RESYNC_GUARD_FAILED: %s\n' "$1" >&2
+  exit 64
+}
+
+require_value() {
+  local name="$1"
+  [[ -n "${!name:-}" ]] || fail "falta ${name}"
+}
+
+[[ "${STAGING_ONLY_GUARD:-}" == 'true' ]] || fail 'STAGING_ONLY_GUARD debe ser true'
+[[ "${APP_ENV:-}" == 'staging' ]] || fail 'APP_ENV debe ser staging'
+[[ "${COOLIFY_RESOURCE_UUID:-}" == "$expected_resource_uuid" ]] \
+  || fail 'COOLIFY_RESOURCE_UUID no corresponde a staging'
+
+require_value MONGO_INITDB_ROOT_USERNAME
+require_value MONGO_INITDB_ROOT_PASSWORD
+[[ "$MONGO_INITDB_ROOT_USERNAME" == 'cukies_staging_root' ]] \
+  || fail 'MONGO_INITDB_ROOT_USERNAME inesperado'
+
+validate_source_url() {
+  local name="$1"
+  local expected_user="$2"
+  local expected_database="$3"
+  local value="${!name:-}"
+
+  require_value "$name"
+  [[ "$value" =~ ^mongodb://${expected_user}:[^@]+@192\.168\.1\.221:27017/${expected_database}(\?.*)?$ ]] \
+    || fail "${name} no apunta al usuario, host y DB de staging esperados"
+}
+
+validate_source_url STAGING_MONGO_SOURCE_HUB_URL 'cukies_hub_staging_app' 'cukies-hub-staging'
+validate_source_url STAGING_MONGO_SOURCE_LEGACY_URL 'cukies_legacy_staging_app' 'cukies-legacy-staging'
+validate_source_url STAGING_MONGO_SOURCE_ECONOMY_URL 'cukies_economy_staging_app' 'cukieshub-new-staging'
+validate_source_url STAGING_MONGO_SOURCE_CARD_URL 'cukies_card_staging_worker' 'cukieshub-new-staging'
+
+mongo_admin=(
+  mongo
+  --quiet
+  --host 127.0.0.1
+  --port 27017
+  --username "$MONGO_INITDB_ROOT_USERNAME"
+  --password "$MONGO_INITDB_ROOT_PASSWORD"
+  --authenticationDatabase admin
+)
+
+"${mongo_admin[@]}" admin --eval 'quit(db.isMaster().ismaster === true ? 0 : 1)' \
+  >/dev/null || fail 'la replica staging no esta PRIMARY'
+
+marker_count="$("${mongo_admin[@]}" "$bootstrap_database" --eval \
+  "print(db.bootstrap_state.countDocuments({ _id: '$bootstrap_id' }))" | tail -n 1)"
+[[ "$marker_count" == '1' ]] || fail 'falta el marcador de bootstrap inicial'
+
+root_uri="mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@127.0.0.1:27017/?authSource=admin&replicaSet=${replica_set}&directConnection=true"
+
+resync_database() {
+  local source_url="$1"
+  local database="$2"
+  printf 'Resincronizando DB logica de staging: %s\n' "$database"
+  mongodump --quiet --uri "$source_url" --archive \
+    | mongorestore --quiet --uri "$root_uri" --archive --drop --nsInclude "${database}.*"
+}
+
+resync_database "$STAGING_MONGO_SOURCE_HUB_URL" 'cukies-hub-staging'
+resync_database "$STAGING_MONGO_SOURCE_LEGACY_URL" 'cukies-legacy-staging'
+resync_database "$STAGING_MONGO_SOURCE_ECONOMY_URL" 'cukieshub-new-staging'
+
+"${mongo_admin[@]}" "$bootstrap_database" --eval "
+  const now = new Date();
+  const result = db.bootstrap_state.updateOne(
+    { _id: '$bootstrap_id' },
+    {
+      \$set: { lastResyncedAt: now, updatedAt: now },
+      \$inc: { resyncCount: 1 },
+    },
+  );
+  if (result.matchedCount !== 1) throw new Error('no se actualizo el marcador de resync');
+" >/dev/null
+
+"${mongo_admin[@]}" admin --eval '
+  const names = ["cukies-hub-staging", "cukies-legacy-staging", "cukieshub-new-staging"];
+  const result = {};
+  names.forEach(function (name) {
+    const stats = db.getSiblingDB(name).stats();
+    result[name] = { collections: stats.collections, objects: stats.objects, indexes: stats.indexes };
+  });
+  print(JSON.stringify({ ok: true, databases: result }));
+'


### PR DESCRIPTION
## Resumen
- añade un Mongo 4.4 replica-set de un nodo exclusivo de la app Coolify staging 28
- protege el arranque con identidad exacta de staging y secretos/volúmenes exclusivos
- copia únicamente los tres namespaces staging y conserva cuatro usuarios con mínimo privilegio
- añade resync final para cerrar el delta con los contenedores staging detenidos antes del cutover
- no cambia aún ninguna URL de aplicación ni toca producción/mainnet

## Validación
- `bash -n infrastructure/staging-mongo/entrypoint.sh` OK
- `bash -n infrastructure/staging-mongo/resync.sh` OK
- `docker compose -f docker-compose.coolify.yml config --quiet` OK
- `pnpm guard:staging:test` OK (15/15)
- build remoto `--target staging-mongo` OK
- integración efímera con copia 5/41/88 colecciones OK
- replica `cukies-staging-rs0` PRIMARY y marcador `logical-staging-v1` OK
- cuatro usuarios limitados a sus DB y transacción abortada sin escritura OK
- reinicio idempotente y resync final bajo límite 2 GiB OK

## Despliegue en dos fases
1. merge/deploy manteniendo las URLs actuales; verificar la copia persistente
2. detener sólo app 28, ejecutar resync, cambiar sólo sus cuatro URLs y redesplegar

## Seguridad
Producción permanece en `main`, app 12, BSC 56 y sus URLs Mongo actuales. El compose falla cerrado fuera del UUID `u4s804o4wwcckowgk0woo4wg`.