### PR TITLE
fix: expose staging Mongo alias to workers

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -36,6 +36,9 @@ services:
       retries: 20
       start_period: 180s
     networks:
+      default:
+        aliases:
+          - cukies-hub-staging-mongo-u4s804o4wwcckowgk0woo4wg
       coolify:
         aliases:
           - cukies-hub-staging-mongo-u4s804o4wwcckowgk0woo4wg
@@ -391,6 +394,7 @@ services:
     restart: unless-stopped
 
 networks:
+  default: {}
   coolify:
     external: true
 


### PR DESCRIPTION
## Resumen
- publica el alias estable del Mongo dedicado también en la red interna del compose
- mantiene el mismo alias en la red externa de Coolify para dapp y schedulers
- no modifica `main`, producción ni configuración mainnet

## Validación
- `git diff --check`
- `docker compose -f docker-compose.coolify.yml config --no-interpolate --quiet`
- prueba temporal en app Coolify 28: `chain-indexer` resolvió el alias y quedó `running`

## Riesgo
- limitado a la topología de red del servicio `staging-mongo` en la rama `staging`