### PR TITLE
fix: connect staging workers to Mongo network

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -36,9 +36,6 @@ services:
       retries: 20
       start_period: 180s
     networks:
-      default:
-        aliases:
-          - cukies-hub-staging-mongo-u4s804o4wwcckowgk0woo4wg
       coolify:
         aliases:
           - cukies-hub-staging-mongo-u4s804o4wwcckowgk0woo4wg
@@ -174,6 +171,8 @@ services:
       TRONGRID_API_KEY: ${TRONGRID_API_KEY:-}
       CHAIN_INDEXER_POLL_INTERVAL_MS: ${CHAIN_INDEXER_POLL_INTERVAL_MS:-60000}
     restart: unless-stopped
+    networks:
+      - coolify
 
   cukie-master-scheduler:
     build:
@@ -392,9 +391,10 @@ services:
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       AWS_REGION: ${AWS_REGION:-${CARD_WORKER_S3_REGION}}
     restart: unless-stopped
+    networks:
+      - coolify
 
 networks:
-  default: {}
   coolify:
     external: true
 


### PR DESCRIPTION
## Resumen
- conecta explícitamente `chain-indexer` a la red `coolify`, donde vive el alias estable del Mongo dedicado
- prepara el mismo acceso para `cuki-card-worker` sin activar su profile, puertos ni dominios
- elimina la red `default` que Coolify no usa para el indexer
- no modifica `main`, producción ni mainnet

## Validación
- `git diff --check`
- `docker compose -f docker-compose.coolify.yml config --no-interpolate --quiet`
- config renderizada: Mongo, indexer y card worker comparten `coolify`
- prueba temporal app 28: DNS OK y restart count estable en 4 tras 20 segundos

## Riesgo
- limitado a conectividad interna de servicios sin puertos públicos ni labels Traefik