### PR TITLE
fix: select staging Mongo databases from runtime URLs

### DIFF
--- a/dapp/__tests__/lib/mongodb-environment-selection.test.ts
+++ b/dapp/__tests__/lib/mongodb-environment-selection.test.ts
@@ -1,0 +1,98 @@
+const originalDatabaseUrl = process.env.DATABASE_URL;
+const originalCukiesDatabaseUrl = process.env.CUKIES_DATABASE_URL;
+const mockMongoClient = jest.fn();
+
+jest.mock('mongodb', () => ({
+  MongoClient: mockMongoClient,
+  ObjectId: jest.fn(),
+}));
+
+function clearCachedMongoConnections() {
+  const globals = globalThis as typeof globalThis & Record<string, unknown>;
+  delete globals.mongoCukiesClient;
+  delete globals.mongoCukiesDb;
+  delete globals.mongoHubClient;
+  delete globals.mongoHubDb;
+}
+
+describe('environment-specific MongoDB selection', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockMongoClient.mockReset();
+    clearCachedMongoConnections();
+    delete process.env.DATABASE_URL;
+    delete process.env.CUKIES_DATABASE_URL;
+  });
+
+  afterAll(() => {
+    if (originalDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = originalDatabaseUrl;
+    if (originalCukiesDatabaseUrl === undefined) delete process.env.CUKIES_DATABASE_URL;
+    else process.env.CUKIES_DATABASE_URL = originalCukiesDatabaseUrl;
+    clearCachedMongoConnections();
+  });
+
+  it('fails closed without the required connection URL', async () => {
+    const cukies = await import('@/lib/mongodb-cukies');
+    const hub = await import('@/lib/mongodb-hub');
+
+    expect(() => cukies.requireCukiesDatabaseConfig({})).toThrow(
+      'CUKIES_DATABASE_URL is required',
+    );
+    expect(() => hub.requireHubDatabaseConfig({})).toThrow('DATABASE_URL is required');
+    await expect(cukies.getCukiesDb()).rejects.toThrow('CUKIES_DATABASE_URL is required');
+    await expect(hub.getHubDb()).rejects.toThrow('DATABASE_URL is required');
+    expect(mockMongoClient).not.toHaveBeenCalled();
+  });
+
+  it('uses the database encoded in each environment URL', async () => {
+    const cukies = await import('@/lib/mongodb-cukies');
+    const hub = await import('@/lib/mongodb-hub');
+
+    expect(cukies.requireCukiesDatabaseConfig({
+      CUKIES_DATABASE_URL: 'mongodb://db.invalid:27017/cukies-legacy-staging?authSource=admin',
+    }).databaseName).toBe('cukies-legacy-staging');
+    expect(hub.requireHubDatabaseConfig({
+      DATABASE_URL: 'mongodb://db.invalid:27017/cukies-hub-staging?authSource=admin',
+    }).databaseName).toBe('cukies-hub-staging');
+
+    // The same rule preserves the current production database names without a special case.
+    expect(cukies.requireCukiesDatabaseConfig({
+      CUKIES_DATABASE_URL: 'mongodb://db.invalid:27017/cukies?authSource=admin',
+    }).databaseName).toBe('cukies');
+    expect(hub.requireHubDatabaseConfig({
+      DATABASE_URL: 'mongodb://db.invalid:27017/cukies-hub?authSource=admin',
+    }).databaseName).toBe('cukies-hub');
+  });
+
+  it('rejects URLs without an explicit database name', async () => {
+    const cukies = await import('@/lib/mongodb-cukies');
+    const hub = await import('@/lib/mongodb-hub');
+
+    expect(() => cukies.requireCukiesDatabaseConfig({
+      CUKIES_DATABASE_URL: 'mongodb://db.invalid:27017',
+    })).toThrow('database name is required');
+    expect(() => hub.requireHubDatabaseConfig({
+      DATABASE_URL: 'mongodb://db.invalid:27017',
+    })).toThrow('database name is required');
+  });
+
+  it('passes the URL-selected name to MongoClient.db', async () => {
+    const ping = jest.fn().mockResolvedValue({ ok: 1 });
+    const db = { databaseName: 'cukies-legacy-staging', admin: () => ({ ping }) };
+    const client = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      db: jest.fn(() => db),
+    };
+    mockMongoClient.mockImplementation(() => client);
+    process.env.CUKIES_DATABASE_URL =
+      'mongodb://db.invalid:27017/cukies-legacy-staging?authSource=admin';
+
+    const cukies = await import('@/lib/mongodb-cukies');
+    await cukies.getCukiesDb();
+
+    expect(client.db).toHaveBeenCalledWith('cukies-legacy-staging');
+    expect(client.connect).toHaveBeenCalledTimes(1);
+    expect(ping).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dapp/src/lib/mongodb-cukies.ts
+++ b/dapp/src/lib/mongodb-cukies.ts
@@ -1,8 +1,4 @@
-import { MongoClient, Db } from 'mongodb';
-
-// Connection URL for cukies database
-const CUKIES_DATABASE_URL = process.env.CUKIES_DATABASE_URL || 
-  'mongodb://admin:changeme123@192.168.1.221:27017/cukies?authSource=admin';
+import { Db, MongoClient } from 'mongodb';
 
 declare global {
   // allow global `var` declarations
@@ -12,32 +8,76 @@ declare global {
   var mongoCukiesDb: Db | undefined;
 }
 
-let mongoCukiesClient: MongoClient;
-let mongoCukiesDb: Db;
+let mongoCukiesClient: MongoClient | undefined;
+let mongoCukiesDb: Db | undefined;
 
-if (process.env.NODE_ENV === 'production') {
-  mongoCukiesClient = new MongoClient(CUKIES_DATABASE_URL);
-  mongoCukiesDb = mongoCukiesClient.db('cukies');
-} else {
-  // In development, use a global variable to prevent multiple connections
-  if (!global.mongoCukiesClient) {
-    global.mongoCukiesClient = new MongoClient(CUKIES_DATABASE_URL);
-    global.mongoCukiesDb = global.mongoCukiesClient.db('cukies');
+function databaseNameFromMongoUrl(databaseUrl: string) {
+  const match = databaseUrl.match(/^mongodb(?:\+srv)?:\/\/[^/]+\/([^?]*)/i);
+  if (!match || !match[1]) return null;
+
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    throw new Error('CUKIES_DATABASE_URL contains an invalid database name.');
   }
-  mongoCukiesClient = global.mongoCukiesClient;
-  mongoCukiesDb = global.mongoCukiesDb!; // Safe to use ! here as we check above
 }
 
-// Ensure connection is established
-async function ensureConnection() {
-  try {
-    // Try to ping the database to check connection
-    await mongoCukiesDb.admin().ping();
-  } catch {
-    // If ping fails, connect
-    await mongoCukiesClient.connect();
+function validDatabaseName(value: string) {
+  return value.length > 0 && value.length <= 64 && !/[\s/\\."$*<>:|?\u0000]/.test(value);
+}
+
+export function requireCukiesDatabaseConfig(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+) {
+  const databaseUrl = env.CUKIES_DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error('CUKIES_DATABASE_URL is required to access the legacy Cukies database.');
   }
-  return mongoCukiesDb;
+
+  const databaseName = databaseNameFromMongoUrl(databaseUrl);
+  if (!databaseName || !validDatabaseName(databaseName)) {
+    throw new Error('Legacy Cukies database name is required in CUKIES_DATABASE_URL.');
+  }
+
+  return { databaseUrl, databaseName };
+}
+
+function getOrCreateCukiesConnection() {
+  const config = requireCukiesDatabaseConfig();
+
+  if (mongoCukiesClient && mongoCukiesDb) {
+    if (mongoCukiesDb.databaseName !== config.databaseName) {
+      throw new Error('Cached legacy database does not match CUKIES_DATABASE_URL.');
+    }
+    return { client: mongoCukiesClient, db: mongoCukiesDb };
+  }
+
+  if (process.env.NODE_ENV !== 'production' && global.mongoCukiesClient) {
+    mongoCukiesClient = global.mongoCukiesClient;
+    if (global.mongoCukiesDb && global.mongoCukiesDb.databaseName !== config.databaseName) {
+      throw new Error('Cached legacy database does not match CUKIES_DATABASE_URL.');
+    }
+    mongoCukiesDb = global.mongoCukiesDb ?? mongoCukiesClient.db(config.databaseName);
+    global.mongoCukiesDb = mongoCukiesDb;
+    return { client: mongoCukiesClient, db: mongoCukiesDb };
+  }
+
+  mongoCukiesClient = new MongoClient(config.databaseUrl);
+  mongoCukiesDb = mongoCukiesClient.db(config.databaseName);
+
+  if (process.env.NODE_ENV !== 'production') {
+    global.mongoCukiesClient = mongoCukiesClient;
+    global.mongoCukiesDb = mongoCukiesDb;
+  }
+
+  return { client: mongoCukiesClient, db: mongoCukiesDb };
+}
+
+async function ensureConnection() {
+  const { client, db } = getOrCreateCukiesConnection();
+  await client.connect();
+  await db.admin().ping();
+  return db;
 }
 
 export async function getCukiesDb(): Promise<Db> {
@@ -85,5 +125,10 @@ export async function closeCukiesConnection() {
   if (mongoCukiesClient) {
     await mongoCukiesClient.close();
   }
+  if (global.mongoCukiesClient === mongoCukiesClient) {
+    global.mongoCukiesClient = undefined;
+    global.mongoCukiesDb = undefined;
+  }
+  mongoCukiesClient = undefined;
+  mongoCukiesDb = undefined;
 }
-

--- a/dapp/src/lib/mongodb-hub.ts
+++ b/dapp/src/lib/mongodb-hub.ts
@@ -1,8 +1,4 @@
-import { MongoClient, Db, ObjectId } from 'mongodb';
-
-// Connection URL for cukies-hub database
-const HUB_DATABASE_URL = process.env.DATABASE_URL || 
-  'mongodb://admin:changeme123@192.168.1.221:27017/cukies-hub?authSource=admin';
+import { Db, MongoClient, ObjectId } from 'mongodb';
 
 declare global {
   // allow global `var` declarations
@@ -12,32 +8,76 @@ declare global {
   var mongoHubDb: Db | undefined;
 }
 
-let mongoHubClient: MongoClient;
-let mongoHubDb: Db;
+let mongoHubClient: MongoClient | undefined;
+let mongoHubDb: Db | undefined;
 
-if (process.env.NODE_ENV === 'production') {
-  mongoHubClient = new MongoClient(HUB_DATABASE_URL);
-  mongoHubDb = mongoHubClient.db('cukies-hub');
-} else {
-  // In development, use a global variable to prevent multiple connections
-  if (!global.mongoHubClient) {
-    global.mongoHubClient = new MongoClient(HUB_DATABASE_URL);
-    global.mongoHubDb = global.mongoHubClient.db('cukies-hub');
+function databaseNameFromMongoUrl(databaseUrl: string) {
+  const match = databaseUrl.match(/^mongodb(?:\+srv)?:\/\/[^/]+\/([^?]*)/i);
+  if (!match || !match[1]) return null;
+
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    throw new Error('DATABASE_URL contains an invalid database name.');
   }
-  mongoHubClient = global.mongoHubClient;
-  mongoHubDb = global.mongoHubDb!; // Safe to use ! here as we check above
 }
 
-// Ensure connection is established
-async function ensureConnection() {
-  try {
-    // Try to ping the database to check connection
-    await mongoHubDb.admin().ping();
-  } catch {
-    // If ping fails, connect
-    await mongoHubClient.connect();
+function validDatabaseName(value: string) {
+  return value.length > 0 && value.length <= 64 && !/[\s/\\."$*<>:|?\u0000]/.test(value);
+}
+
+export function requireHubDatabaseConfig(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+) {
+  const databaseUrl = env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required to access the Cukies Hub database.');
   }
-  return mongoHubDb;
+
+  const databaseName = databaseNameFromMongoUrl(databaseUrl);
+  if (!databaseName || !validDatabaseName(databaseName)) {
+    throw new Error('Hub database name is required in DATABASE_URL.');
+  }
+
+  return { databaseUrl, databaseName };
+}
+
+function getOrCreateHubConnection() {
+  const config = requireHubDatabaseConfig();
+
+  if (mongoHubClient && mongoHubDb) {
+    if (mongoHubDb.databaseName !== config.databaseName) {
+      throw new Error('Cached hub database does not match DATABASE_URL.');
+    }
+    return { client: mongoHubClient, db: mongoHubDb };
+  }
+
+  if (process.env.NODE_ENV !== 'production' && global.mongoHubClient) {
+    mongoHubClient = global.mongoHubClient;
+    if (global.mongoHubDb && global.mongoHubDb.databaseName !== config.databaseName) {
+      throw new Error('Cached hub database does not match DATABASE_URL.');
+    }
+    mongoHubDb = global.mongoHubDb ?? mongoHubClient.db(config.databaseName);
+    global.mongoHubDb = mongoHubDb;
+    return { client: mongoHubClient, db: mongoHubDb };
+  }
+
+  mongoHubClient = new MongoClient(config.databaseUrl);
+  mongoHubDb = mongoHubClient.db(config.databaseName);
+
+  if (process.env.NODE_ENV !== 'production') {
+    global.mongoHubClient = mongoHubClient;
+    global.mongoHubDb = mongoHubDb;
+  }
+
+  return { client: mongoHubClient, db: mongoHubDb };
+}
+
+async function ensureConnection() {
+  const { client, db } = getOrCreateHubConnection();
+  await client.connect();
+  await db.admin().ping();
+  return db;
 }
 
 export async function getHubDb(): Promise<Db> {
@@ -92,5 +132,10 @@ export async function closeHubConnection() {
   if (mongoHubClient) {
     await mongoHubClient.close();
   }
+  if (global.mongoHubClient === mongoHubClient) {
+    global.mongoHubClient = undefined;
+    global.mongoHubDb = undefined;
+  }
+  mongoHubClient = undefined;
+  mongoHubDb = undefined;
 }
-


### PR DESCRIPTION
## Resumen
- elimina los nombres y credenciales Mongo de fallback hardcodeados
- selecciona `cukies-hub-staging` y `cukies-legacy-staging` desde las URLs runtime
- falla cerrado si falta URL o nombre de base de datos
- conserva los nombres actuales de producción mediante la misma regla, sin cambiar `main`

## Validación
- `pnpm --filter dapp test -- --runInBand __tests__/lib/mongodb-environment-selection.test.ts`
- `pnpm --filter dapp test -- --runInBand __tests__/api/auth-login-signed-wallet-mode.test.ts`
- `pnpm dapp lint`
- `pnpm dapp typecheck`
- `pnpm dapp build`

## Riesgo y despliegue
- base exclusiva: `staging`
- no modifica contratos, chain ID, mainnet, `main` ni producción
- se validará con una wallet efímera firmada y sin transacciones tras desplegar