### PR TITLE
fix: remove legacy Mongo database fallbacks

### DIFF
--- a/dapp/scripts/inspect-databases.mjs
+++ b/dapp/scripts/inspect-databases.mjs
@@ -1,7 +1,21 @@
 import { MongoClient } from 'mongodb';
 
-const CUKIES_HUB_URL = 'mongodb://admin:changeme123@192.168.1.221:27017/cukies-hub?authSource=admin';
-const CUKIES_URL = 'mongodb://admin:changeme123@192.168.1.221:27017/cukies?authSource=admin';
+function requireDatabaseConfig(envName) {
+  const url = process.env[envName]?.trim();
+  if (!url) throw new Error(`${envName} es obligatoria.`);
+
+  const match = url.match(/^mongodb(?:\+srv)?:\/\/[^/]+\/([^?]*)/i);
+  if (!match || !match[1]) {
+    throw new Error(`${envName} debe incluir explicitamente el nombre de la base de datos.`);
+  }
+
+  const dbName = decodeURIComponent(match[1]);
+  if (dbName.length > 64 || /[\s/\\."$*<>:|?\u0000]/.test(dbName)) {
+    throw new Error(`${envName} contiene un nombre de base de datos invalido.`);
+  }
+
+  return { url, dbName };
+}
 
 async function inspectDatabase(url, dbName) {
   const client = new MongoClient(url);
@@ -28,10 +42,7 @@ async function inspectDatabase(url, dbName) {
         keys.forEach(key => {
           const value = sample[key];
           const type = Array.isArray(value) ? 'Array' : typeof value;
-          const preview = typeof value === 'object' && value !== null 
-            ? (Array.isArray(value) ? `[${value.length} items]` : '{...}')
-            : String(value).substring(0, 50);
-          console.log(`     - ${key}: ${type} ${preview.length > 0 ? `(${preview})` : ''}`);
+          console.log(`     - ${key}: ${type}`);
         });
       }
     }
@@ -45,12 +56,17 @@ async function inspectDatabase(url, dbName) {
 
 async function main() {
   console.log('🔍 Inspeccionando estructuras de bases de datos...\n');
-  
-  await inspectDatabase(CUKIES_HUB_URL, 'cukies-hub');
-  await inspectDatabase(CUKIES_URL, 'cukies');
+
+  const hub = requireDatabaseConfig('DATABASE_URL');
+  const legacy = requireDatabaseConfig('CUKIES_DATABASE_URL');
+
+  await inspectDatabase(hub.url, hub.dbName);
+  await inspectDatabase(legacy.url, legacy.dbName);
   
   console.log('\n✅ Inspección completada\n');
 }
 
-main().catch(console.error);
-
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/docs/uki-nft-data-quality-report.md
+++ b/docs/uki-nft-data-quality-report.md
@@ -73,7 +73,7 @@ Sin ejecutar muestreo live, el repo confirma:
 
 - `dapp/src/lib/mongodb-cukies.ts` expone helpers para `cukies`, `originals`, `wallets`, `tx_nfts` y `txMarketplace`.
 - `dapp/src/lib/user-sync.ts` confirma que existen wallets TRON (`T...`) y BSC/EVM (`0x...`) y que la normalizacion difiere por red.
-- `dapp/scripts/inspect-databases.mjs` demuestra que ya existia una inspeccion manual de bases, pero imprime muestras de documentos; no debe usarse para reportes compartidos sin sanitizar.
+- `dapp/scripts/inspect-databases.mjs` permite una inspeccion manual, exige `DATABASE_URL` y `CUKIES_DATABASE_URL` explicitas y limita la salida a nombres y tipos de campos; no incluye valores de documentos ni credenciales embebidas.
 - `cukies-hub` no contiene modelos NFT actuales en Prisma; los nuevos modelos deben depender de una capa normalizada y no copiar ownership completo sin motivo.
 
 ## Riesgos detectados antes del muestreo live
@@ -126,4 +126,3 @@ No publicar:
 - #22 debe diseñar `NftInventoryService` asumiendo que owner/listing/bridge pueden venir de varias colecciones.
 - #21 queda listo para cerrarse cuando el muestreo live sanitizado confirme porcentajes reales o documente que el acceso a Mongo queda pendiente de ops.
 - Si el muestreo descubre colecciones no inventariadas, actualizar `docs/uki-nft-data-inventory.md` antes de implementar.
-

--- a/packages/chain-indexer/src/cli.ts
+++ b/packages/chain-indexer/src/cli.ts
@@ -116,6 +116,7 @@ async function importLegacy() {
       legacyConfig.legacyMongoUrl,
       legacyConfig.limit,
       legacyConfig.networks,
+      legacyConfig.legacyDbName,
     );
     const endedAt = now();
 
@@ -146,6 +147,7 @@ async function importLegacyMetadata() {
       store,
       legacyConfig.legacyMongoUrl,
       legacyConfig.limit,
+      legacyConfig.legacyDbName,
     );
     const endedAt = now();
 

--- a/packages/chain-indexer/src/config/env.ts
+++ b/packages/chain-indexer/src/config/env.ts
@@ -91,6 +91,29 @@ function parseChains(value: string): ChainName[] {
   return valid.length > 0 ? valid : ['BSC', 'TRON'];
 }
 
+export function resolveMongoDatabaseNameFromUrl(databaseUrl: string, envName: string) {
+  const match = databaseUrl.match(/^mongodb(?:\+srv)?:\/\/[^/]+\/([^?]*)/i);
+  if (!match || !match[1]) {
+    throw new Error(`${envName} debe incluir explicitamente el nombre de la base de datos.`);
+  }
+
+  let databaseName: string;
+  try {
+    databaseName = decodeURIComponent(match[1]);
+  } catch {
+    throw new Error(`${envName} contiene un nombre de base de datos invalido.`);
+  }
+
+  if (
+    databaseName.length > 64
+    || /[\s/\\."$*<>:|?\u0000]/.test(databaseName)
+  ) {
+    throw new Error(`${envName} contiene un nombre de base de datos invalido.`);
+  }
+
+  return databaseName;
+}
+
 function parseContractAliases(value?: string): ContractAlias[] | undefined {
   if (!value) return undefined;
 
@@ -255,6 +278,10 @@ export function getLegacyImportConfig(): LegacyImportConfig {
 
   return {
     legacyMongoUrl: env.CUKIES_DATABASE_URL,
+    legacyDbName: resolveMongoDatabaseNameFromUrl(
+      env.CUKIES_DATABASE_URL,
+      'CUKIES_DATABASE_URL',
+    ),
     limit: env.CHAIN_INDEXER_IMPORT_LEGACY_LIMIT,
     networks: env.CHAIN_INDEXER_IMPORT_LEGACY_NETWORK
       ? parseChains(env.CHAIN_INDEXER_IMPORT_LEGACY_NETWORK)

--- a/packages/chain-indexer/src/legacy/importer.ts
+++ b/packages/chain-indexer/src/legacy/importer.ts
@@ -1,6 +1,7 @@
 import { MongoClient, type Document } from 'mongodb';
 
 import { getContractAliasByAddress } from '../config/contracts.js';
+import { resolveMongoDatabaseNameFromUrl } from '../config/env.js';
 import { normalizeDomainEvent } from '../normalize.js';
 import type { ChainEvent, ChainName, EventName } from '../types.js';
 import type { IndexerStore } from '../storage/index.js';
@@ -142,12 +143,15 @@ export async function importLegacyProcessedEvents(
   legacyMongoUrl: string,
   limit: number,
   networks?: ChainName[],
+  configuredLegacyDbName?: string,
 ) {
+  const legacyDbName = configuredLegacyDbName
+    ?? resolveMongoDatabaseNameFromUrl(legacyMongoUrl, 'CUKIES_DATABASE_URL');
   const client = new MongoClient(legacyMongoUrl);
   await client.connect();
 
   try {
-    const legacyDb = client.db('cukies');
+    const legacyDb = client.db(legacyDbName);
     const filter = networks?.length ? { network: { $in: networks } } : {};
     const cursor = legacyDb
       .collection<LegacyProcessedEvent & Document>('processedEvents')
@@ -263,12 +267,15 @@ export async function importLegacyCukiesMetadata(
   store: IndexerStore,
   legacyMongoUrl: string,
   limit: number,
+  configuredLegacyDbName?: string,
 ) {
+  const legacyDbName = configuredLegacyDbName
+    ?? resolveMongoDatabaseNameFromUrl(legacyMongoUrl, 'CUKIES_DATABASE_URL');
   const client = new MongoClient(legacyMongoUrl);
   await client.connect();
 
   try {
-    const legacyDb = client.db('cukies');
+    const legacyDb = client.db(legacyDbName);
     const cursor = legacyDb
       .collection<LegacyCukiDocument & Document>('cukies')
       .find({})

--- a/packages/chain-indexer/src/types.ts
+++ b/packages/chain-indexer/src/types.ts
@@ -118,6 +118,7 @@ export type IndexerConfig = {
 
 export type LegacyImportConfig = {
   legacyMongoUrl: string;
+  legacyDbName: string;
   limit: number;
   networks?: ChainName[];
 };

--- a/packages/chain-indexer/test/env.test.ts
+++ b/packages/chain-indexer/test/env.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { resolveBscRpcUrls } from '../src/config/env.js';
+import {
+  resolveBscRpcUrls,
+  resolveMongoDatabaseNameFromUrl,
+} from '../src/config/env.js';
 
 test('testnet ignores the legacy mainnet RPC and keeps only explicit URLs', () => {
   const urls = resolveBscRpcUrls({
@@ -30,5 +33,32 @@ test('mainnet preserves the legacy fallback', () => {
   assert.deepEqual(
     resolveBscRpcUrls({ expectedChainId: 56 }),
     ['https://bsc.rpc.blxrbdn.com'],
+  );
+});
+
+test('legacy imports select the database encoded in the runtime URL', () => {
+  assert.equal(
+    resolveMongoDatabaseNameFromUrl(
+      'mongodb://db.invalid:27017/cukies-legacy-staging?authSource=admin',
+      'CUKIES_DATABASE_URL',
+    ),
+    'cukies-legacy-staging',
+  );
+  assert.equal(
+    resolveMongoDatabaseNameFromUrl(
+      'mongodb://db.invalid:27017/cukies?authSource=admin',
+      'CUKIES_DATABASE_URL',
+    ),
+    'cukies',
+  );
+});
+
+test('legacy imports fail closed when the URL has no database', () => {
+  assert.throws(
+    () => resolveMongoDatabaseNameFromUrl(
+      'mongodb://db.invalid:27017',
+      'CUKIES_DATABASE_URL',
+    ),
+    /debe incluir explicitamente el nombre de la base de datos/,
   );
 });


### PR DESCRIPTION
## Resumen
- hace que los imports legacy usen la BBDD codificada en `CUKIES_DATABASE_URL`
- elimina URL, credenciales y nombres Mongo hardcodeados del script de inspección
- el script deja de imprimir valores de documentos y devuelve error si faltan URLs explícitas
- actualiza la documentación del inventario de datos

## Validación
- `pnpm --filter @cukies/chain-indexer test` (17/17)
- `pnpm --filter @cukies/chain-indexer typecheck`
- `pnpm --filter @cukies/chain-indexer build`
- `pnpm dapp lint`
- `node --check dapp/scripts/inspect-databases.mjs`
- ejecución sin `DATABASE_URL`/`CUKIES_DATABASE_URL` falla con exit code 1

## Alcance
- base exclusiva: `staging`
- no modifica `main`, producción, contratos ni chain IDs
- conserva los nombres productivos cuando están explícitos en sus URLs