### PR TITLE
docs: reconcile final staging readiness

### DIFF
--- a/docs/deployment-environments.md
+++ b/docs/deployment-environments.md
@@ -249,7 +249,7 @@ Antes de considerar staging valido:
 - [x] Anadir preflight staging-only fail-closed para rama, recurso Coolify, chain, bases y URL de autenticacion antes de arrancar o ejecutar setups.
 - [x] Reapuntar el recurso Coolify staging a la rama `staging`.
 - [x] Separar los tres namespaces y los cuatro usuarios staging sin reapuntar ninguna base live.
-- [ ] Completar el cutover de esos namespaces a la instancia fisica exclusiva `cukies-staging-rs0` y validar transacciones tras el cambio de URLs.
+- [x] Completar el cutover de esos namespaces a la instancia fisica exclusiva `cukies-staging-rs0` y validar replica PRIMARY, aislamiento de usuarios y transacciones Economy v2 tras el cambio de URLs.
 - [x] Desplegar y financiar un nuevo `VestingVault` y `Presale` en BSC Testnet.
 - [x] Ejecutar una compra on-chain smoke de `5 tASM -> 500 UKI` y validar pago, venta y vesting.
 - [x] Migrar la verificacion del explorer a Etherscan API V2 y verificar el source de Vault/Presale.
@@ -261,9 +261,9 @@ Antes de considerar staging valido:
 - [x] Desplegar los cinco schedulers con gates desactivados y verificar guardas, credencial limitada y ausencia de heartbeats/runs.
 - [x] Retirar el card worker del arranque por defecto de staging mediante el profile `card-worker`; sigue desactivado hasta disponer de S3 propio.
 - [x] Vaciar OAuth social, Pusher, Resend, Telegram e IFTTT en staging; quedan deshabilitados hasta tener destinos exclusivos.
-- [ ] Completar smoke E2E con una segunda wallet desde la UI y conservar evidencia de APIs, Mongo e indexer.
+- [x] Completar smoke E2E con una segunda wallet desde la UI: login firmado, cookie segura, BSC Testnet `97`, transacciones bloqueadas, APIs de competicion `200`, registro `1/1` en Mongo staging y `0/0` en la base productiva.
 
-El siguiente bloque recomendado es completar el cutover al Mongo fisico exclusivo y repetir el setup transaccional. Despues se debe ejecutar el E2E con dos wallets y cargar solo las reglas numericas que producto haya aprobado; ningun scheduler se habilita antes.
+El siguiente bloque recomendado es resolver la contradiccion de emision `500,000 UKI/dia` frente al pool de `450,000,000 UKI` durante 6 anos y decidir si el limite de Cukie Master es 5 cupos totales o 5 por ruta. Despues se cargan rulesets versionados con todos los gates apagados, se prueban leases e idempotencia mediante ticks manuales y se habilita como maximo un scheduler cada vez. La verificacion de source de `UKIStaking`/`RewardsDistributor`, un S3 exclusivo para tarjetas y las integraciones externas propias de staging siguen siendo ampliaciones separadas; no bloquean la version de prueba base.
 
 ## Gates para produccion
 

--- a/docs/uki-current-operating-rules.md
+++ b/docs/uki-current-operating-rules.md
@@ -1,10 +1,28 @@
 # UKI current operating rules
 
-Estado: fuente operativa vigente para especificacion tecnica.
-Fecha de sincronizacion: 2026-05-17.
-Fuentes: `/Users/fgomezserna/Downloads/Funcionamiento.docx` y `/Users/fgomezserna/Downloads/UKI/Preventa UKI.docx`.
+Estado: fuente operativa vigente para especificacion tecnica, con reconciliacion de producto pendiente.
+Fecha de sincronizacion de reglas aprobadas: 2026-05-17.
+Fecha de revision de la fuente mas reciente: 2026-08-06.
+Fuentes consolidadas: `/Users/fgomezserna/Downloads/Funcionamiento.docx` y `/Users/fgomezserna/Downloads/UKI/Preventa UKI.docx`.
+Fuente posterior revisada pero no consolidada: `/Users/fgomezserna/Downloads/Token UKI.docx`.
 
 Este documento sustituye como referencia de producto a los documentos antiguos de `Funcionamiento`, `dudas` y `para comentar`. Si una issue o documento anterior contradice estas reglas, estas reglas prevalecen hasta que producto apruebe una version nueva.
+
+## Reconciliacion pendiente con `Token UKI.docx`
+
+`Token UKI.docx` es el ultimo documento recibido y la fuente mas reciente revisada. Las cifras operativas que repite coinciden en lo esencial con estas reglas: 500 cupos iniciales por ruta; requisitos iniciales de 3 puntos NFT o 20,000 UKI; tabla de puntos por rareza; ventana de ajuste de 48 horas; espera minima de 24 horas; y 100 creditos diarios por cupo. El documento no vuelve a fijar el supply, el reparto 45%/25%/18%/12%, el precio de preventa, el listing, la compra minima ni los vestings; para esos puntos siguen vigentes las fuentes consolidadas anteriores.
+
+No se adopta todavia como nueva fuente operativa porque quedan dos contradicciones que cambian el modelo economico:
+
+1. **Reserva diaria frente a duracion del pool.** `Token UKI.docx` mantiene 500,000 UKI diarios. Las reglas consolidadas anteriores asignan 450,000,000 UKI al programa durante 6 anos. Tomadas conjuntamente, una emision constante de 500,000 UKI durante 6 anos consumiria aproximadamente 1,095,000,000 UKI. El pool de 450,000,000 UKI solo cubre 900 dias a ese ritmo. Para durar 6 anos, el promedio nominal seria de aproximadamente 205,479 UKI diarios. Hasta que producto decida, 500,000 UKI no debe cargarse como emision diaria garantizada. La opcion tecnica recomendada es tratarlo como capacidad maxima diaria, con techo acumulado de 450,000,000 UKI y reglas explicitas para UKI no distribuidos.
+2. **Limite de cupos Cukie Master.** La regla consolidada limita a 5 cupos totales por wallet sumando las rutas NFT y UKI. `Token UKI.docx` describe un maximo de 5 cupos por cada tipo, lo que permitiria hasta 10 por wallet. No se debe activar la regla de capacidad hasta elegir una de las dos interpretaciones.
+
+Tambien aparecen dos matices que no cambian cifras congeladas por ahora:
+
+- La preventa podria ampliarse despues de los 30 dias si no alcanza 3,000 ASM. El contrato soporta que el owner actualice la ventana con `setSaleWindow`, pero falta aprobar el criterio, la autoridad y el limite de extension antes de convertirlo en regla operativa.
+- El desbloqueo progresivo de claim 20%/40%/60%/80%/100% aparece como propuesta a valorar, no como decision aprobada ni comportamiento implementado.
+
+Mientras estos puntos sigan abiertos, los rulesets economicos y sus schedulers deben permanecer desactivados en staging.
 
 ## Preventa UKI
 


### PR DESCRIPTION
## Resumen
- marca como completados el cutover Mongo fisico y el E2E con segunda wallet
- registra `Token UKI.docx` como ultimo documento recibido, revisado pero aun no consolidado
- separa cifras repetidas, cifras no restatadas y dos contradicciones bloqueantes
- documenta la aritmetica 500k/dia vs 450M/6 anos y el limite 5 total vs 5 por ruta
- mantiene todos los gates economicos apagados

## Validacion
- extraccion directa de `/Users/fgomezserna/Downloads/Token UKI.docx`
- aritmetica verificada: 1.095B a 500k/dia durante 6 anos; 900 dias para consumir 450M; ~205.479/dia de promedio nominal
- `git diff --check` OK

## Perimetro
- PR dirigido exclusivamente a `staging`
- sin cambios de codigo, contratos, entornos, mainnet ni produccion