### PR TITLE
fix: restore full dapp regression suite

### DIFF
--- a/dapp/__tests__/api/auth.test.ts
+++ b/dapp/__tests__/api/auth.test.ts
@@ -1,267 +1,212 @@
-import { NextRequest } from 'next/server'
-import { POST } from '@/app/api/auth/login/route'
-
-// Mock Prisma module
-const mockFindUnique = jest.fn()
-const mockCreate = jest.fn()
+const mockFindUnique = jest.fn();
+const mockReadWalletSession = jest.fn();
+const mockReadWalletChallenge = jest.fn();
+const mockVerifyWalletSignature = jest.fn();
+const mockSetWalletSessionCookie = jest.fn();
+const mockClearWalletChallengeCookie = jest.fn();
+const mockFindOrSyncUserFromCukies = jest.fn();
+const mockCreateUserDirectly = jest.fn();
+const mockEnsureHubWalletForLogin = jest.fn();
 
 jest.mock('@/lib/prisma', () => ({
   prisma: {
     user: {
-      findUnique: mockFindUnique,
-      create: mockCreate,
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
     },
   },
-}))
+}));
+
+jest.mock('@/lib/wallet-auth', () => ({
+  clearWalletChallengeCookie: (...args: unknown[]) => mockClearWalletChallengeCookie(...args),
+  evmWalletSessionMatchesSignedAddress: jest.fn(() => false),
+  isValidEvmWalletAddress: (walletAddress: string) => (
+    /^0x[a-f0-9]{40}$/i.test(walletAddress)
+    && walletAddress.toLowerCase() !== '0x0000000000000000000000000000000000000000'
+  ),
+  readWalletChallenge: (...args: unknown[]) => mockReadWalletChallenge(...args),
+  readWalletSession: (...args: unknown[]) => mockReadWalletSession(...args),
+  resolveWalletType: (walletAddress: string, walletType?: string) => (
+    walletType === 'tron' || walletAddress.startsWith('T') ? 'tron' : 'evm'
+  ),
+  setWalletSessionCookie: (...args: unknown[]) => mockSetWalletSessionCookie(...args),
+  verifyWalletSignature: (...args: unknown[]) => mockVerifyWalletSignature(...args),
+  walletSessionMatchesAddress: jest.fn(() => false),
+}));
+
+jest.mock('@/lib/user-sync', () => ({
+  findOrSyncUserFromCukies: (...args: unknown[]) => mockFindOrSyncUserFromCukies(...args),
+}));
+
+jest.mock('@/lib/mongodb-hub', () => ({
+  createUserDirectly: (...args: unknown[]) => mockCreateUserDirectly(...args),
+}));
+
+jest.mock('@/lib/user-wallets', () => ({
+  ensureHubWalletForLogin: (...args: unknown[]) => mockEnsureHubWalletForLogin(...args),
+}));
+
+import { POST } from '@/app/api/auth/login/route';
+
+const walletAddress = '0x1111111111111111111111111111111111111111';
+const message = 'Cukies wallet login challenge';
+const signature = '0xsigned';
+const user = {
+  id: 'user-1',
+  walletAddress,
+  username: walletAddress,
+  completedQuests: [],
+};
+
+function request(body: unknown) {
+  return new Request('https://hub.test/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+function signedBody(overrides: Record<string, unknown> = {}) {
+  return {
+    walletAddress,
+    walletType: 'evm',
+    message,
+    signature,
+    ...overrides,
+  };
+}
 
 describe('API /auth/login', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
-  })
+    jest.clearAllMocks();
+    mockReadWalletSession.mockResolvedValue(null);
+    mockReadWalletChallenge.mockResolvedValue({
+      walletAddress,
+      walletType: 'evm',
+      message,
+    });
+    mockVerifyWalletSignature.mockResolvedValue(true);
+    mockSetWalletSessionCookie.mockResolvedValue(undefined);
+    mockClearWalletChallengeCookie.mockResolvedValue(undefined);
+    mockFindOrSyncUserFromCukies.mockResolvedValue(null);
+    mockCreateUserDirectly.mockResolvedValue('user-1');
+    mockEnsureHubWalletForLogin.mockResolvedValue(undefined);
+  });
 
-  const mockUser = {
-    id: '1',
-    walletAddress: '0x123456789abcdef',
-    username: 'user_0x1234',
-    email: null,
-    profilePictureUrl: null,
-    xp: 0,
-    twitterHandle: null,
-    discordUsername: null,
-    telegramUsername: null,
-    referralCode: null,
-    referredById: null,
-    referralRewards: 0,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    lastCheckIn: null,
-    completedQuests: [],
-  }
+  it('devuelve el usuario existente tras validar la firma', async () => {
+    mockFindUnique.mockResolvedValue(user);
 
-  it('should return existing user when wallet address exists', async () => {
-    const walletAddress = '0x123456789ABCDEF'
-    
-    mockFindUnique.mockResolvedValue(mockUser)
+    const response = await POST(request(signedBody()));
 
-    const request = new NextRequest('http://localhost/api/auth/login', {
-      method: 'POST',
-      body: JSON.stringify({ walletAddress }),
-    })
-
-    const response = await POST(request)
-    const data = await response.json()
-
-    expect(response.status).toBe(200)
-    expect(data).toEqual(mockUser)
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(user);
     expect(mockFindUnique).toHaveBeenCalledWith({
-      where: {
-        walletAddress: walletAddress.toLowerCase(),
-      },
+      where: { walletAddress },
       include: {
         lastCheckIn: true,
-        completedQuests: {
-          include: {
-            quest: true,
-          },
-        },
+        completedQuests: { include: { quest: true } },
       },
-    })
-  })
+    });
+    expect(mockVerifyWalletSignature).toHaveBeenCalledWith({
+      walletAddress,
+      walletType: 'evm',
+      message,
+      signature,
+    });
+    expect(mockEnsureHubWalletForLogin).toHaveBeenCalledWith(user.id, walletAddress, 'evm');
+    expect(mockSetWalletSessionCookie).toHaveBeenCalledWith({
+      userId: user.id,
+      walletAddress,
+      signedWalletAddress: walletAddress,
+      walletType: 'evm',
+    });
+    expect(mockClearWalletChallengeCookie).toHaveBeenCalled();
+  });
 
-  it('should create new user when wallet address does not exist', async () => {
-    const walletAddress = '0x123456789ABCDEF'
-    const newUser = {
-      id: '2',
-      walletAddress: walletAddress.toLowerCase(),
-      username: `user_${walletAddress.toLowerCase().slice(0, 6)}`,
-    }
+  it('reutiliza un usuario sincronizado desde la base Cukies', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    mockFindOrSyncUserFromCukies.mockResolvedValue(user);
 
-    // First call returns null (user doesn't exist)
-    // Second call returns the created user with includes
+    const response = await POST(request(signedBody()));
+
+    expect(response.status).toBe(200);
+    expect(mockFindOrSyncUserFromCukies).toHaveBeenCalledWith(walletAddress);
+    expect(mockCreateUserDirectly).not.toHaveBeenCalled();
+    expect(mockEnsureHubWalletForLogin).toHaveBeenCalledWith(user.id, walletAddress, 'evm');
+  });
+
+  it('crea directamente un usuario nuevo y lo vuelve a leer con relaciones', async () => {
     mockFindUnique
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(mockUser)
-    
-    mockCreate.mockResolvedValue(newUser as any)
+      .mockResolvedValueOnce(user);
 
-    const request = new NextRequest('http://localhost/api/auth/login', {
-      method: 'POST',
-      body: JSON.stringify({ walletAddress }),
-    })
+    const response = await POST(request(signedBody()));
 
-    const response = await POST(request)
-    const data = await response.json()
-
-    expect(response.status).toBe(200)
-    expect(data).toEqual(mockUser)
-    expect(mockCreate).toHaveBeenCalledWith({
-      data: {
-        walletAddress: walletAddress.toLowerCase(),
-        username: `user_${walletAddress.toLowerCase().slice(0, 6)}`,
-      },
-    })
-  })
-
-  it('should convert wallet address to lowercase', async () => {
-    const walletAddress = '0X123456789ABCDEF'
-    
-    mockFindUnique.mockResolvedValue(mockUser)
-
-    const request = new NextRequest('http://localhost/api/auth/login', {
-      method: 'POST',
-      body: JSON.stringify({ walletAddress }),
-    })
-
-    await POST(request)
-
-    expect(mockFindUnique).toHaveBeenCalledWith({
-      where: {
-        walletAddress: walletAddress.toLowerCase(),
-      },
-      include: {
-        lastCheckIn: true,
-        completedQuests: {
-          include: {
-            quest: true,
-          },
-        },
-      },
-    })
-  })
-
-  it('should return 400 when wallet address is missing', async () => {
-    const request = new NextRequest('http://localhost/api/auth/login', {
-      method: 'POST',
-      body: JSON.stringify({}),
-    })
-
-    const response = await POST(request)
-    const data = await response.json()
-
-    expect(response.status).toBe(400)
-    expect(data.error).toBe('Wallet address is required')
-  })
-
-  it('should return 400 when wallet address is not a string', async () => {
-    const request = new NextRequest('http://localhost/api/auth/login', {
-      method: 'POST',
-      body: JSON.stringify({ walletAddress: 123 }),
-    })
-
-    const response = await POST(request)
-    const data = await response.json()
-
-    expect(response.status).toBe(400)
-    expect(data.error).toBe('Wallet address is required')
-  })
-
-  it('should return 400 when wallet address is empty string', async () => {
-    const request = new NextRequest('http://localhost/api/auth/login', {
-      method: 'POST',
-      body: JSON.stringify({ walletAddress: '' }),
-    })
-
-    const response = await POST(request)
-    const data = await response.json()
-
-    expect(response.status).toBe(400)
-    expect(data.error).toBe('Wallet address is required')
-  })
-
-  it('should return 500 when database error occurs', async () => {
-    const walletAddress = '0x123456789ABCDEF'
-    
-    mockFindUnique.mockRejectedValue(new Error('Database error'))
-
-    const request = new NextRequest('http://localhost/api/auth/login', {
-      method: 'POST',
-      body: JSON.stringify({ walletAddress }),
-    })
-
-    const response = await POST(request)
-    const data = await response.json()
-
-    expect(response.status).toBe(500)
-    expect(data.error).toBe('Internal Server Error')
-  })
-
-  it('should handle JSON parsing errors', async () => {
-    const request = new NextRequest('http://localhost/api/auth/login', {
-      method: 'POST',
-      body: 'invalid json',
-    })
-
-    const response = await POST(request)
-    const data = await response.json()
-
-    expect(response.status).toBe(500)
-    expect(data.error).toBe('Internal Server Error')
-  })
-
-  it('should include correct relations when fetching existing user', async () => {
-    const walletAddress = '0x123456789ABCDEF'
-    
-    mockFindUnique.mockResolvedValue(mockUser)
-
-    const request = new NextRequest('http://localhost/api/auth/login', {
-      method: 'POST',
-      body: JSON.stringify({ walletAddress }),
-    })
-
-    await POST(request)
-
-    expect(mockFindUnique).toHaveBeenCalledWith({
-      where: {
-        walletAddress: walletAddress.toLowerCase(),
-      },
-      include: {
-        lastCheckIn: true,
-        completedQuests: {
-          include: {
-            quest: true,
-          },
-        },
-      },
-    })
-  })
-
-  it('should include correct relations when fetching newly created user', async () => {
-    const walletAddress = '0x123456789ABCDEF'
-    const newUser = {
-      id: '2',
-      walletAddress: walletAddress.toLowerCase(),
-      username: `user_${walletAddress.toLowerCase().slice(0, 6)}`,
-    }
-
-    mockFindUnique
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(mockUser)
-    
-    mockCreate.mockResolvedValue(newUser as any)
-
-    const request = new NextRequest('http://localhost/api/auth/login', {
-      method: 'POST',
-      body: JSON.stringify({ walletAddress }),
-    })
-
-    await POST(request)
-
-    // Should call findUnique twice: once to check if user exists, once to fetch with includes
-    expect(mockFindUnique).toHaveBeenCalledTimes(2)
-    
-    // Second call should include relations
+    expect(response.status).toBe(200);
+    expect(mockCreateUserDirectly).toHaveBeenCalledWith({
+      walletAddress,
+      username: walletAddress,
+    });
     expect(mockFindUnique).toHaveBeenLastCalledWith({
-      where: {
-        id: newUser.id,
-      },
+      where: { id: user.id },
       include: {
         lastCheckIn: true,
-        completedQuests: {
-          include: {
-            quest: true,
-          },
-        },
+        completedQuests: { include: { quest: true } },
       },
-    })
-  })
-})
+    });
+  });
+
+  it.each([
+    [{}, 'missing'],
+    [{ walletAddress: 123 }, 'non-string'],
+    [{ walletAddress: '' }, 'empty'],
+  ])('rechaza walletAddress invalida (%s)', async (body, _caseName) => {
+    const response = await POST(request(body));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Wallet address is required' });
+    expect(mockReadWalletSession).not.toHaveBeenCalled();
+  });
+
+  it('exige firma cuando no hay una sesion reutilizable', async () => {
+    const response = await POST(request({ walletAddress }));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: 'Wallet signature is required',
+      requiresSignature: true,
+    });
+  });
+
+  it('rechaza un challenge que no coincide con la wallet', async () => {
+    mockReadWalletChallenge.mockResolvedValue({
+      walletAddress: '0x2222222222222222222222222222222222222222',
+      walletType: 'evm',
+      message,
+    });
+
+    const response = await POST(request(signedBody()));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: 'Invalid or expired wallet challenge',
+      requiresSignature: true,
+    });
+    expect(mockVerifyWalletSignature).not.toHaveBeenCalled();
+  });
+
+  it('devuelve 500 sin filtrar detalles ante un error de base de datos', async () => {
+    mockFindUnique.mockRejectedValue(new Error('Database error'));
+
+    const response = await POST(request(signedBody()));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Internal Server Error' });
+  });
+
+  it('devuelve 500 ante JSON malformado', async () => {
+    const response = await POST(request('invalid json'));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Internal Server Error' });
+  });
+});

--- a/dapp/__tests__/components/stats-cards.test.tsx
+++ b/dapp/__tests__/components/stats-cards.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import StatsCards from '@/components/home/stats-cards'
 import { useAuth } from '@/providers/auth-provider'
 import { User } from '@/types'
@@ -88,18 +88,20 @@ describe('components/home/StatsCards', () => {
 
   it('should display placeholder when user is not available', () => {
     mockUseAuth.mockReturnValue(mockAuthValue(null))
+    ;(global.fetch as jest.Mock).mockReturnValue(new Promise(() => {}))
 
     render(<StatsCards />)
 
-    expect(screen.getByText('--')).toBeInTheDocument()
+    expect(screen.getAllByText('--')).toHaveLength(4)
   })
 
-  it('should display placeholder when user is loading', () => {
+  it('should display placeholders while platform stats are loading', () => {
     mockUseAuth.mockReturnValue(mockAuthValue(null, true))
+    ;(global.fetch as jest.Mock).mockReturnValue(new Promise(() => {}))
 
     render(<StatsCards />)
 
-    expect(screen.getByText('--')).toBeInTheDocument()
+    expect(screen.getAllByText('--')).toHaveLength(4)
   })
 
   it('should render correct icons', () => {
@@ -113,7 +115,7 @@ describe('components/home/StatsCards', () => {
     expect(screen.getByTestId('coins-icon')).toBeInTheDocument()
   })
 
-  it('should format XP with commas', () => {
+  it('should format XP with commas', async () => {
     const userWithHighXP = {
       ...mockUser,
       xp: 1234567,
@@ -123,10 +125,14 @@ describe('components/home/StatsCards', () => {
 
     render(<StatsCards />)
 
-    expect(screen.getByText('1,234,567')).toBeInTheDocument()
+    await waitFor(() => {
+      const myXpCard = screen.getByRole('heading', { name: 'My XP' }).closest('.rounded-lg')
+      expect(myXpCard).not.toBeNull()
+      expect(within(myXpCard as HTMLElement).getByText('1,234,567')).toBeInTheDocument()
+    })
   })
 
-  it('should handle zero XP', () => {
+  it('should handle zero XP', async () => {
     const userWithZeroXP = {
       ...mockUser,
       xp: 0,
@@ -136,7 +142,9 @@ describe('components/home/StatsCards', () => {
 
     render(<StatsCards />)
 
-    expect(screen.getByText('0')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('0')).toBeInTheDocument()
+    })
   })
 
   it('should render dynamic values for rank, total players, and total XP', async () => {
@@ -157,7 +165,7 @@ describe('components/home/StatsCards', () => {
     const { container } = render(<StatsCards />)
     const gridContainer = container.firstChild
 
-    expect(gridContainer).toHaveClass('grid', 'gap-4', 'md:grid-cols-2', 'lg:grid-cols-4')
+    expect(gridContainer).toHaveClass('grid', 'gap-6', 'md:grid-cols-2', 'lg:grid-cols-4')
   })
 
   it('should render card structure correctly', async () => {
@@ -167,10 +175,10 @@ describe('components/home/StatsCards', () => {
 
     // Check that each stat has both title and value
     await waitFor(() => {
-      const myXpCard = screen.getByText('My XP').closest('div')
+      const myXpCard = screen.getByRole('heading', { name: 'My XP' }).closest('.rounded-lg')
       expect(myXpCard).toContainElement(screen.getByText('1,500'))
 
-      const myRankCard = screen.getByText('My Rank').closest('div')
+      const myRankCard = screen.getByRole('heading', { name: 'My Rank' }).closest('.rounded-lg')
       expect(myRankCard).toContainElement(screen.getByText('#1,234'))
     })
   })

--- a/dapp/jest.config.js
+++ b/dapp/jest.config.js
@@ -7,7 +7,11 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
-  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
+  testPathIgnorePatterns: [
+    '<rootDir>/.next/',
+    '<rootDir>/node_modules/',
+    '<rootDir>/scripts/',
+  ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/dapp/src/components/ui/card.tsx
+++ b/dapp/src/components/ui/card.tsx
@@ -30,10 +30,10 @@ const CardHeader = React.forwardRef<
 CardHeader.displayName = "CardHeader"
 
 const CardTitle = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
-  <div
+  <h3
     ref={ref}
     className={cn(
       "text-2xl font-semibold leading-none tracking-tight",
@@ -45,10 +45,10 @@ const CardTitle = React.forwardRef<
 CardTitle.displayName = "CardTitle"
 
 const CardDescription = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
-  <div
+  <p
     ref={ref}
     className={cn("text-sm text-muted-foreground", className)}
     {...props}


### PR DESCRIPTION
## Resumen

- Separa correctamente las pruebas Node de políticas de schedulers de la suite Jest del dapp.
- Actualiza las pruebas de autenticación al flujo actual de login de wallet con firma y challenge.
- Estabiliza las expectativas asíncronas de las tarjetas de estadísticas.
- Recupera semántica HTML en `CardTitle` y `CardDescription` sin cambios visuales.

## Causa

La suite completa mezclaba runners incompatibles y conservaba expectativas de flujos antiguos, por lo que fallaba aunque las pruebas específicas de Economy v2 pasaban.

## Impacto

La suite de regresión completa vuelve a quedar verde y cubre el flujo actual de autenticación. El cambio se dirige exclusivamente a `staging`.

## Validación

- `pnpm dapp test -- --runInBand`: 122 suites / 1004 tests OK
- `pnpm dapp test:schedulers`: 16 tests OK
- `pnpm dapp lint`: OK
- `pnpm dapp typecheck`: OK
- `NEXT_PUBLIC_UKI_CHAIN_ID=97 CHAIN_INDEXER_BSC_EXPECTED_CHAIN_ID=97 pnpm dapp build`: OK
- `git diff --check origin/staging...HEAD`: OK

## Seguridad de entorno

- Base del PR: `staging`
- No modifica configuración de producción ni mainnet.
- No incluye secretos ni cambios de datos.