### PR TITLE
fix: make card image URLs immutable

### DIFF
--- a/docs/coolify-deployment.md
+++ b/docs/coolify-deployment.md
@@ -162,7 +162,7 @@ AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 ```
 
-En staging, mantener `CARD_WORKER_UPLOAD=false` hasta disponer de bucket/prefijo propios. No activar `true` con el destino compartido de produccion.
+En staging, el destino exclusivo es el bucket MinIO `cukies-cards-staging`. Mantener `CARD_WORKER_UPLOAD=false` y el profile `card-worker` desactivado hasta desplegar las URLs inmutables de #216 y repetir el smoke; despues, activar ambos valores solo en la app Coolify 28. No usar nunca el destino compartido de produccion.
 
 ## Validacion post deploy
 

--- a/docs/deployment-environments.md
+++ b/docs/deployment-environments.md
@@ -224,14 +224,14 @@ No se migra ningun namespace de produccion. Si falta el marcador, el bootstrap s
 
 ### Card worker en staging
 
-`cuki-card-worker` queda fuera del arranque por defecto mediante el profile Compose `card-worker`. Mientras staging no tenga bucket, prefijo, URL publica y credenciales S3 propios, no se debe definir `COMPOSE_PROFILES=card-worker` en la app 28. Esto elimina el bucle de reinicios causado por `CARD_WORKER_UPLOAD=false` sin fingir que el renderer/uploader esta operativo.
+`cuki-card-worker` queda fuera del arranque por defecto mediante el profile Compose `card-worker`. Staging dispone del bucket MinIO exclusivo `cukies-cards-staging`, hostname publico, prefijo y credenciales limitadas; el upload real y su limpieza se validaron el 6 de agosto de 2026. No se debe definir `COMPOSE_PROFILES=card-worker` ni cambiar `CARD_WORKER_UPLOAD=true` en la app 28 hasta desplegar y validar las URLs inmutables de #216. Esto evita tanto el bucle de reinicios como servir una card anterior desde la cache de Cloudflare despues de una regeneracion.
 
 Para habilitarlo en el futuro:
 
-1. crear destino S3 exclusivo de staging;
-2. configurar `CARD_WORKER_S3_*`, `CARD_WORKER_PUBLIC_BASE_URL` y credenciales limitadas a ese prefijo; para MinIO u otro destino compatible tambien son obligatorios su endpoint y `CARD_WORKER_S3_FORCE_PATH_STYLE=true`;
-3. validar `pnpm staging:cards:setup` y una generacion de prueba;
-4. definir `COMPOSE_PROFILES=card-worker` solo en la app 28 y redesplegar.
+1. desplegar #216 en `staging` y validar que cada URL incluye el SHA-256 del PNG;
+2. repetir `pnpm staging:cards:setup` y una generacion con fixture aislado, comprobando `Cache-Control: public, max-age=31536000, immutable`;
+3. eliminar el fixture, su job, el PNG local y el objeto S3 de prueba;
+4. definir `CARD_WORKER_UPLOAD=true` y `COMPOSE_PROFILES=card-worker` solo en la app 28, redesplegar y verificar que el noveno contenedor queda sano.
 
 ## Gates para staging
 
@@ -263,12 +263,14 @@ Antes de considerar staging valido:
 - [ ] Aprobar y cargar en staging los valores de `programStartsAt`, frontera/gracia UTC, maximo diario y techo acumulado irreversible del `RewardRule`.
 - [ ] Cargar reglas aprobadas de creditos, juegos, pools y ranking.
 - [x] Desplegar los cinco schedulers con gates desactivados y verificar guardas, credencial limitada y ausencia de heartbeats/runs.
-- [x] Retirar el card worker del arranque por defecto de staging mediante el profile `card-worker`; sigue desactivado hasta disponer de S3 propio.
+- [x] Retirar el card worker del arranque por defecto de staging mediante el profile `card-worker`.
+- [x] Provisionar bucket MinIO, hostname publico, prefijo y credenciales exclusivos de staging; validar setup, upload/render real y limpieza completa del fixture.
+- [ ] Desplegar URLs de card inmutables (#216), repetir el smoke y activar el profile `card-worker` solo en la app 28.
 - [x] Vaciar OAuth social, Pusher, Resend, Telegram e IFTTT en staging; quedan deshabilitados hasta tener destinos exclusivos.
 - [x] Completar smoke E2E con una segunda wallet desde la UI: login firmado, cookie segura, BSC Testnet `97`, transacciones bloqueadas, APIs de competicion `200`, registro `1/1` en Mongo staging y `0/0` en la base productiva.
-- [ ] Rotar preventivamente `STAGING_MONGO_REPLICA_KEY` en una ventana controlada antes de habilitar workers, reiniciar solo la replica staging y repetir health/transacciones; no reutilizar ni cambiar ninguna credencial de produccion.
+- [x] Rotar preventivamente `STAGING_MONGO_REPLICA_KEY` en una ventana controlada, reiniciar solo la replica staging y repetir health/transacciones sin reutilizar ni cambiar credenciales de produccion.
 
-El siguiente bloque recomendado es aprobar la interpretacion de `500,000 UKI/dia`, el techo acumulado del pool de `450,000,000 UKI`, el inicio/frontera/gracia del ledger y si el limite de Cukie Master es 5 cupos totales o 5 por ruta. Despues se cargan rulesets versionados con todos los gates apagados, se prueban fencing e idempotencia mediante ticks manuales y se habilita como maximo un scheduler cada vez. El mirror secundario de source en BscScan, un S3 exclusivo para tarjetas y las integraciones externas propias de staging siguen siendo ampliaciones separadas; no bloquean la version de prueba base.
+El siguiente bloque recomendado es desplegar #216, repetir el smoke aislado del card worker y activar solo ese worker en la app 28. En paralelo siguen pendientes decisiones de producto: aprobar la interpretacion de `500,000 UKI/dia`, el techo acumulado del pool de `450,000,000 UKI`, el inicio/frontera/gracia del ledger y si el limite de Cukie Master es 5 cupos totales o 5 por ruta. Despues se cargan rulesets versionados con todos los gates apagados, se prueban fencing e idempotencia mediante ticks manuales y se habilita como maximo un scheduler cada vez. El mirror secundario de source en BscScan y las integraciones externas propias de staging siguen siendo ampliaciones separadas; no bloquean la version de prueba base.
 
 ## Gates para produccion
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "cards:process": "pnpm --filter @cukies/cuki-card-worker run process:once",
     "cards:render": "pnpm --filter @cukies/cuki-card-worker run render",
     "cards:generate": "pnpm --filter @cukies/cuki-card-worker run generate",
+    "test:cards": "pnpm --filter @cukies/cuki-card-worker run test",
     "build:cards": "pnpm --filter @cukies/cuki-card-worker run build",
     "start:cards": "pnpm --filter @cukies/cuki-card-worker run start",
     "build:dapp": "pnpm --filter dapp build",

--- a/packages/cuki-card-worker/README.md
+++ b/packages/cuki-card-worker/README.md
@@ -33,7 +33,10 @@ pnpm cards:dev
 - `CARD_WORKER_S3_PREFIX`: prefijo S3. Default: `png/tokens/v2/TVkQDrxQgX7ZQmeeXj2RbPQa93qJrYQYGe`.
 - `CARD_WORKER_S3_ENDPOINT`: opcional para S3-compatible.
 - `CARD_WORKER_S3_FORCE_PATH_STYLE`: `true` para endpoints compatibles.
+- `CARD_WORKER_S3_ACL`: ACL opcional del objeto; en staging se usa `private` y el bucket concede solo lectura publica.
 - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`: credenciales S3.
+
+Cada PNG se publica bajo una clave inmutable `<prefix>/<tokenId-base64url>/<sha256>.png` y con `Cache-Control: public, max-age=31536000, immutable`. Una regeneracion con contenido distinto cambia la URL antes de actualizar Mongo, por lo que CDN y clientes no pueden mezclar la card nueva con una version cacheada anterior.
 
 ## Seleccion de pendientes
 

--- a/packages/cuki-card-worker/package.json
+++ b/packages/cuki-card-worker/package.json
@@ -16,6 +16,7 @@
     "process:once": "tsx src/cli.ts process-once",
     "render": "tsx src/cli.ts render-token",
     "generate": "tsx src/cli.ts generate-token",
+    "test": "node --import tsx --test src/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/cuki-card-worker/src/s3.test.ts
+++ b/packages/cuki-card-worker/src/s3.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  buildCardObjectUpload,
+  cardContentSha256,
+  cardS3Key,
+  IMMUTABLE_CARD_CACHE_CONTROL,
+} from './s3.js';
+import type { CardWorkerConfig, RenderResult } from './types.js';
+
+const config: CardWorkerConfig = {
+  mongoUrl: 'mongodb://staging.invalid',
+  dbName: 'cukieshub-new-staging',
+  assetsDir: '/tmp/assets',
+  outputDir: '/tmp/cards',
+  pollIntervalMs: 5_000,
+  maxAttempts: 5,
+  staleLockMs: 900_000,
+  upload: true,
+  publicBaseUrl: 'https://cards.staging.invalid/staging-bucket',
+  s3Bucket: 'staging-bucket',
+  s3Region: 'us-east-1',
+  s3Prefix: 'png/staging/tokens/v2/test-collection',
+  s3Endpoint: 'http://minio.staging.invalid:9000',
+  s3ForcePathStyle: true,
+  s3Acl: 'private',
+};
+
+const renderResult: RenderResult = {
+  tokenId: '42',
+  outputPath: '/tmp/cards/42.png',
+  width: 752,
+  height: 1152,
+};
+
+describe('immutable card uploads', () => {
+  it('uses a deterministic SHA-256 content address', () => {
+    const firstBody = Buffer.from('first png');
+    const secondBody = Buffer.from('second png');
+
+    const first = buildCardObjectUpload(config, renderResult, firstBody);
+    const firstReplay = buildCardObjectUpload(config, renderResult, firstBody);
+    const second = buildCardObjectUpload(config, renderResult, secondBody);
+
+    assert.equal(first.key, firstReplay.key);
+    assert.equal(first.imageUrl, firstReplay.imageUrl);
+    assert.notEqual(first.key, second.key);
+    assert.equal(first.contentSha256, cardContentSha256(firstBody));
+    assert.match(
+      first.key,
+      /^png\/staging\/tokens\/v2\/test-collection\/[A-Za-z0-9_-]+\/[a-f0-9]{64}\.png$/,
+    );
+  });
+
+  it('encodes arbitrary token ids into a single safe path segment', () => {
+    const unsafeTokenId = '../../Cukie 42/ñ';
+    const hash = cardContentSha256(Buffer.from('png'));
+    const key = cardS3Key(config, unsafeTokenId, hash);
+    const tokenSegment = key.split('/').at(-2);
+
+    assert.ok(tokenSegment);
+    assert.match(tokenSegment, /^[A-Za-z0-9_-]+$/);
+    assert.equal(Buffer.from(tokenSegment, 'base64url').toString('utf8'), unsafeTokenId);
+    assert.equal(key.includes('../'), false);
+  });
+
+  it('publishes immutable PNG metadata and the exact versioned URL', () => {
+    const body = Buffer.from('png bytes');
+    const upload = buildCardObjectUpload(config, renderResult, body);
+
+    assert.equal(upload.putObjectInput.Bucket, config.s3Bucket);
+    assert.equal(upload.putObjectInput.Key, upload.key);
+    assert.equal(upload.putObjectInput.Body, body);
+    assert.equal(upload.putObjectInput.ContentType, 'image/png');
+    assert.equal(upload.putObjectInput.CacheControl, IMMUTABLE_CARD_CACHE_CONTROL);
+    assert.equal(upload.putObjectInput.ACL, 'private');
+    assert.equal(upload.imageUrl, `${config.publicBaseUrl}/${upload.key}`);
+  });
+
+  it('rejects empty token ids and malformed content hashes', () => {
+    assert.throws(() => cardS3Key(config, '', '0'.repeat(64)), /tokenId/);
+    assert.throws(() => cardS3Key(config, '42', 'ABC'), /SHA-256/);
+  });
+});

--- a/packages/cuki-card-worker/src/s3.ts
+++ b/packages/cuki-card-worker/src/s3.ts
@@ -1,9 +1,12 @@
+import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 
 import { HeadBucketCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import type { ObjectCannedACL } from '@aws-sdk/client-s3';
+import type { ObjectCannedACL, PutObjectCommandInput } from '@aws-sdk/client-s3';
 
 import type { CardWorkerConfig, GenerationResult, RenderResult } from './types.js';
+
+export const IMMUTABLE_CARD_CACHE_CONTROL = 'public, max-age=31536000, immutable';
 
 export function assertS3UploadConfig(config: CardWorkerConfig) {
   if (!config.s3Bucket) {
@@ -34,8 +37,50 @@ export async function verifyS3UploadAccess(config: CardWorkerConfig) {
   await client.send(new HeadBucketCommand({ Bucket: config.s3Bucket ?? undefined }));
 }
 
-export function cardS3Key(config: CardWorkerConfig, tokenId: string) {
-  return `${config.s3Prefix}/${tokenId}.png`;
+export function cardContentSha256(body: Uint8Array) {
+  return createHash('sha256').update(body).digest('hex');
+}
+
+function cardTokenPathSegment(tokenId: string) {
+  if (!tokenId) {
+    throw new Error('El tokenId de la card no puede estar vacio.');
+  }
+
+  return Buffer.from(tokenId, 'utf8').toString('base64url');
+}
+
+export function cardS3Key(config: CardWorkerConfig, tokenId: string, contentSha256: string) {
+  if (!/^[a-f0-9]{64}$/.test(contentSha256)) {
+    throw new Error('El SHA-256 de la card debe ser hexadecimal en minusculas y tener 64 caracteres.');
+  }
+
+  return `${config.s3Prefix}/${cardTokenPathSegment(tokenId)}/${contentSha256}.png`;
+}
+
+export function buildCardObjectUpload(
+  config: CardWorkerConfig,
+  renderResult: RenderResult,
+  body: Uint8Array,
+) {
+  assertS3UploadConfig(config);
+
+  const contentSha256 = cardContentSha256(body);
+  const key = cardS3Key(config, renderResult.tokenId, contentSha256);
+  const putObjectInput: PutObjectCommandInput = {
+    Bucket: config.s3Bucket ?? undefined,
+    Key: key,
+    Body: body,
+    ContentType: 'image/png',
+    CacheControl: IMMUTABLE_CARD_CACHE_CONTROL,
+    ACL: (config.s3Acl as ObjectCannedACL | null) ?? undefined,
+  };
+
+  return {
+    contentSha256,
+    imageUrl: `${config.publicBaseUrl}/${key}`,
+    key,
+    putObjectInput,
+  };
 }
 
 export async function uploadRenderedCard(
@@ -45,22 +90,14 @@ export async function uploadRenderedCard(
   assertS3UploadConfig(config);
 
   const client = createS3Client(config);
-  const key = cardS3Key(config, renderResult.tokenId);
   const body = await fs.readFile(renderResult.outputPath);
+  const upload = buildCardObjectUpload(config, renderResult, body);
 
-  await client.send(
-    new PutObjectCommand({
-      Bucket: config.s3Bucket ?? undefined,
-      Key: key,
-      Body: body,
-      ContentType: 'image/png',
-      ACL: (config.s3Acl as ObjectCannedACL | null) ?? undefined,
-    }),
-  );
+  await client.send(new PutObjectCommand(upload.putObjectInput));
 
   return {
     ...renderResult,
-    imageUrl: `${config.publicBaseUrl}/${key}`,
-    s3Key: key,
+    imageUrl: upload.imageUrl,
+    s3Key: upload.key,
   };
 }


### PR DESCRIPTION
Closes #216

## Resumen

- direcciona cada card por SHA-256 del PNG bajo un segmento seguro de token;
- añade `Cache-Control: public, max-age=31536000, immutable` al upload;
- cubre determinismo, cambios de contenido, token ids inseguros y metadatos con tests;
- actualiza el checklist con el MinIO staging ya provisionado y la rotación Mongo completada.

## Validación local

- `pnpm test:cards` — OK (4 tests)
- `pnpm card-worker typecheck` — OK
- `pnpm build:cards` — OK
- `git diff --check` — OK

## Despliegue y seguridad

La PR tiene base `staging`. Tras revisión se desplegará exclusivamente en Coolify app 28 y se repetirá el smoke contra BSC Testnet 97, Mongo staging y `cukies-cards-staging`. No se modifica `main`, app 12, BSC mainnet ni datos de producción.
