### PR TITLE
docs: record staging card worker activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,21 +140,26 @@ Required environment variables in `dapp/.env.local`:
 
 The active integration deployment is Coolify on VM1001 (`192.168.1.201`) through Traefik/Cloudflare.
 
-- Live integration app:
+- Staging/integration app:
+  - Coolify resource: `game-hub-staging`
+  - Application ID: `28`
+  - UUID: `u4s804o4wwcckowgk0woo4wg`
+  - Branch: `staging`
+  - Public URL: `https://cukieshub.eurekand.com`
+  - Chain/data: BSC Testnet (`97`), `cukies-hub-staging`, `cukies-legacy-staging`, `cukieshub-new-staging`.
+- Production app:
   - Coolify resource: `game-hub`
+  - Application ID: `12`
   - UUID: `jookw8ow8woks088s44404ok`
   - Branch: `main`
-  - Public URL: `https://cukieshub.eurekand.com`
-- Production placeholder:
-  - Coolify resource: `game-hub-production`
-  - UUID: `u4s804o4wwcckowgk0woo4wg`
-  - Branch: `production`
+  - Public URL: `https://cukies.world`
 
 Use `docker-compose.coolify.yml` for the new hub deployment. It defines:
 
 - `dapp`: public Next.js app on port `3000`.
 - `chain-indexer`: internal blockchain indexer worker.
-- `cuki-card-worker`: internal NFT card renderer/uploader worker.
+- `cukie-master-scheduler`, `competition-credit-scheduler`, `game-economy-scheduler`, `cukie-pool-scheduler`, `weekly-ranking-scheduler`: internal economy schedulers, disabled until their runtime gates and HMAC credentials are approved.
+- `cuki-card-worker`: internal NFT card renderer/uploader worker. It is active in app 28 against the isolated staging Mongo/MinIO destination; generated URLs are content-addressed and immutable.
 
 Operational rules:
 
@@ -162,7 +167,8 @@ Operational rules:
 - Store runtime secrets in Coolify environment variables. Local worker secrets can live only in ignored `.env.local` files.
 - Before saying a worker is deployed, verify the actual Coolify resource is using `docker-compose.coolify.yml`, not a single Nixpacks app.
 - Workers do not need public domains or Traefik labels; only `dapp` should be proxied.
-- Required shared variables for Coolify include `DATABASE_URL`, `CUKIES_DATABASE_URL`, `CHAIN_INDEXER_MONGO_URL`, `CHAIN_INDEXER_DB_NAME=cukieshub-new`, `CARD_WORKER_MONGO_URL`, `CARD_WORKER_DB_NAME=cukieshub-new`, `CARD_WORKER_UPLOAD=true`, S3 bucket/region/prefix/public base URL and AWS credentials.
+- Staging must use `DATABASE_URL` -> `cukies-hub-staging`, `CUKIES_DATABASE_URL` -> `cukies-legacy-staging`, and `CHAIN_INDEXER_DB_NAME`/`CARD_WORKER_DB_NAME` -> `cukieshub-new-staging`.
+- In app 28, `CARD_WORKER_UPLOAD=true` and `COMPOSE_PROFILES=card-worker` are allowed only with the exclusive `cukies-cards-staging` bucket, staging-only credentials and the guard validated. Do not copy those values or credentials to another resource.
 - Validate post-deploy with `/api/health`, `/indexer?collection=chain_indexer_runs`, `/indexer?collection=card_generation_jobs`, and worker logs for `chain-indexer` and `cuki-card-worker`.
 - Use the `coolify-cloudflare` skill when changing Coolify, Traefik labels, domains, tunnels or deployment topology.
 

--- a/docs/coolify-deployment.md
+++ b/docs/coolify-deployment.md
@@ -162,7 +162,7 @@ AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 ```
 
-En staging, el destino exclusivo es el bucket MinIO `cukies-cards-staging`. Mantener `CARD_WORKER_UPLOAD=false` y el profile `card-worker` desactivado hasta desplegar las URLs inmutables de #216 y repetir el smoke; despues, activar ambos valores solo en la app Coolify 28. No usar nunca el destino compartido de produccion.
+En staging, el destino exclusivo es el bucket MinIO `cukies-cards-staging`. Las URLs inmutables de #216 y el smoke real quedaron validados, por lo que `CARD_WORKER_UPLOAD=true` y `COMPOSE_PROFILES=card-worker` estan activos solo en la app Coolify 28 desde el despliegue 1109. El valor `false` del ejemplo sigue siendo el default seguro para cualquier recurso nuevo. No usar nunca el destino compartido de produccion ni copiar las credenciales de app 28.
 
 ## Validacion post deploy
 

--- a/docs/deployment-environments.md
+++ b/docs/deployment-environments.md
@@ -224,14 +224,14 @@ No se migra ningun namespace de produccion. Si falta el marcador, el bootstrap s
 
 ### Card worker en staging
 
-`cuki-card-worker` queda fuera del arranque por defecto mediante el profile Compose `card-worker`. Staging dispone del bucket MinIO exclusivo `cukies-cards-staging`, hostname publico, prefijo y credenciales limitadas; el upload real y su limpieza se validaron el 6 de agosto de 2026. No se debe definir `COMPOSE_PROFILES=card-worker` ni cambiar `CARD_WORKER_UPLOAD=true` en la app 28 hasta desplegar y validar las URLs inmutables de #216. Esto evita tanto el bucle de reinicios como servir una card anterior desde la cache de Cloudflare despues de una regeneracion.
+`cuki-card-worker` queda fuera del arranque por defecto mediante el profile Compose `card-worker`, pero esta habilitado explicitamente en la app 28 con `COMPOSE_PROFILES=card-worker` y `CARD_WORKER_UPLOAD=true`. Usa el bucket MinIO exclusivo `cukies-cards-staging`, hostname publico, prefijo y credenciales limitadas. Las URLs inmutables de #216, dos regeneraciones con hashes distintos, los headers de cache, el setup y la limpieza completa se validaron el 6 de agosto de 2026; el despliegue 1109 dejo los nueve contenedores en ejecucion con cero reinicios.
 
-Para habilitarlo en el futuro:
+Controles operativos:
 
-1. desplegar #216 en `staging` y validar que cada URL incluye el SHA-256 del PNG;
-2. repetir `pnpm staging:cards:setup` y una generacion con fixture aislado, comprobando `Cache-Control: public, max-age=31536000, immutable`;
-3. eliminar el fixture, su job, el PNG local y el objeto S3 de prueba;
-4. definir `CARD_WORKER_UPLOAD=true` y `COMPOSE_PROFILES=card-worker` solo en la app 28, redesplegar y verificar que el noveno contenedor queda sano.
+1. mantener `CARD_WORKER_UPLOAD=true` y `COMPOSE_PROFILES=card-worker` exclusivamente en la app 28 mientras use el destino staging aislado;
+2. validar tras cada deploy el guard `staging-only`, `setup:prod`, `start`, acceso `HeadBucket`, Mongo ping y `restartCount=0`;
+3. comprobar que una regeneracion con contenido distinto produce otra URL `<prefix>/<tokenId-base64url>/<sha256>.png` con `Cache-Control: public, max-age=31536000, immutable`;
+4. para desactivarlo, cambiar `CARD_WORKER_UPLOAD=false`, retirar `COMPOSE_PROFILES` solo en la app 28 y redesplegar; no modificar la app 12.
 
 ## Gates para staging
 
@@ -265,12 +265,12 @@ Antes de considerar staging valido:
 - [x] Desplegar los cinco schedulers con gates desactivados y verificar guardas, credencial limitada y ausencia de heartbeats/runs.
 - [x] Retirar el card worker del arranque por defecto de staging mediante el profile `card-worker`.
 - [x] Provisionar bucket MinIO, hostname publico, prefijo y credenciales exclusivos de staging; validar setup, upload/render real y limpieza completa del fixture.
-- [ ] Desplegar URLs de card inmutables (#216), repetir el smoke y activar el profile `card-worker` solo en la app 28.
+- [x] Desplegar URLs de card inmutables (#216), repetir dos regeneraciones con hashes distintos, limpiar el fixture y activar el profile `card-worker` solo en la app 28 (PR #217; despliegue 1109).
 - [x] Vaciar OAuth social, Pusher, Resend, Telegram e IFTTT en staging; quedan deshabilitados hasta tener destinos exclusivos.
 - [x] Completar smoke E2E con una segunda wallet desde la UI: login firmado, cookie segura, BSC Testnet `97`, transacciones bloqueadas, APIs de competicion `200`, registro `1/1` en Mongo staging y `0/0` en la base productiva.
 - [x] Rotar preventivamente `STAGING_MONGO_REPLICA_KEY` en una ventana controlada, reiniciar solo la replica staging y repetir health/transacciones sin reutilizar ni cambiar credenciales de produccion.
 
-El siguiente bloque recomendado es desplegar #216, repetir el smoke aislado del card worker y activar solo ese worker en la app 28. En paralelo siguen pendientes decisiones de producto: aprobar la interpretacion de `500,000 UKI/dia`, el techo acumulado del pool de `450,000,000 UKI`, el inicio/frontera/gracia del ledger y si el limite de Cukie Master es 5 cupos totales o 5 por ruta. Despues se cargan rulesets versionados con todos los gates apagados, se prueban fencing e idempotencia mediante ticks manuales y se habilita como maximo un scheduler cada vez. El mirror secundario de source en BscScan y las integraciones externas propias de staging siguen siendo ampliaciones separadas; no bloquean la version de prueba base.
+El siguiente bloque recomendado depende de decisiones de producto: aprobar la interpretacion de `500,000 UKI/dia`, el techo acumulado del pool de `450,000,000 UKI`, el inicio/frontera/gracia del ledger y si el limite de Cukie Master es 5 cupos totales o 5 por ruta. Despues se cargan rulesets versionados con todos los gates apagados, se prueban fencing e idempotencia mediante ticks manuales y se habilita como maximo un scheduler cada vez. El mirror secundario de source en BscScan y las integraciones externas propias de staging siguen siendo ampliaciones separadas; no bloquean la version de prueba base.
 
 ## Gates para produccion
 


### PR DESCRIPTION
Refs #216

## Resumen

- corrige en `AGENTS.md` la identificación invertida de app 28 staging y app 12 producción;
- registra la activación validada del card worker aislado en app 28;
- marca como completado el checklist de MinIO/URLs inmutables/worker;
- documenta controles y rollback limitado a staging.

## Evidencia

- PR de código #217 / merge `1db2a58a5e88de956f8cec0c5464337ca6a8bc6a`.
- Coolify app 28 deployment 1109 terminado.
- 9 contenedores en ejecución, restart count 0.
- worker: guard, setup, Mongo ping y HeadBucket OK; 0 Cukies / 0 jobs tras limpieza.
- cinco gates de economía continúan en `false`.
- producción app 12 / main sigue en `fc81ed852aaff5f53c77e76b7933498c29312453`.

## Validación

- `git diff --check` — OK.
- Cambio exclusivamente documental; la base de la PR es `staging`.
