### PR TITLE
fix: reconciliar Cukie Master en 5 cupos por ruta

### DIFF
--- a/dapp/__tests__/lib/cukie-master-service.test.ts
+++ b/dapp/__tests__/lib/cukie-master-service.test.ts
@@ -736,18 +736,23 @@ describe('Cukie Master transactional allocation', () => {
     )).rejects.toThrow('ronda uki cambio');
     expect(mutableAllocationSnapshot(state)).toBe(before);
   });
-  it('allocates up to 5 per route, keeps one transaction and makes retries idempotent', async () => {
+  it('allocates up to 5 per route and serializes concurrent idempotent retries', async () => {
     const { repo, state } = memoryRepository();
     state.vesting.set('0xabc', { totalAllocatedRaw: rawUki(100_000), releasedRaw: '0' });
     state.nftPoints.set('0xabc', 15);
     let transactions = 0;
-    const service = createCukieMasterService(async (work) => {
+    let transactionQueue = Promise.resolve();
+    const service = createCukieMasterService(<T>(work: (repository: CukieMasterRepository) => Promise<T>) => {
       transactions += 1;
-      return work(repo);
+      const transaction = transactionQueue.then(() => work(repo));
+      transactionQueue = transaction.then(() => undefined, () => undefined);
+      return transaction;
     });
 
-    const first = await service.recalculateCukieMasterWallet('0xABC', now, 'req-1');
-    const duplicate = await service.recalculateCukieMasterWallet('0xABC', now, 'req-1');
+    const [first, duplicate] = await Promise.all([
+      service.recalculateCukieMasterWallet('0xABC', now, 'req-1'),
+      service.recalculateCukieMasterWallet('0xABC', now, 'req-1'),
+    ]);
 
     expect(first.positions.uki.allocatedSlots).toBe(5);
     expect(first.positions.nft.allocatedSlots).toBe(5);
@@ -755,6 +760,8 @@ describe('Cukie Master transactional allocation', () => {
     expect(first.positions.uki.activeFrom).toEqual(new Date(now.getTime() + DAY));
     expect(duplicate.positions.uki.revision).toBe(first.positions.uki.revision);
     expect(state.capacities.get('uki')?.allocatedSlots).toBe(5);
+    expect(state.capacities.get('nft')?.allocatedSlots).toBe(5);
+    expect(state.slots.size).toBe(10);
     expect(state.events.size).toBe(12);
     expect(transactions).toBe(2);
 

--- a/dapp/__tests__/lib/uki-economy-cukie-master.test.ts
+++ b/dapp/__tests__/lib/uki-economy-cukie-master.test.ts
@@ -35,6 +35,31 @@ function nftAssetSnapshot(assetId: string, overrides: Partial<{
 }
 
 describe('Cukie Master snapshots', () => {
+  it.each([
+    { eligibleUki: 100_000, originalCukiePoints: 0, ukiSlots: 5, nftSlots: 0 },
+    { eligibleUki: 0, originalCukiePoints: 15, ukiSlots: 0, nftSlots: 5 },
+    { eligibleUki: 60_000, originalCukiePoints: 6, ukiSlots: 3, nftSlots: 2 },
+    { eligibleUki: 100_000, originalCukiePoints: 15, ukiSlots: 5, nftSlots: 5 },
+    { eligibleUki: 999_999, originalCukiePoints: 999, ukiSlots: 5, nftSlots: 5 },
+  ])(
+    'keeps $ukiSlots UKI + $nftSlots NFT slots within the independent route limits',
+    ({ eligibleUki, originalCukiePoints, ukiSlots, nftSlots }) => {
+      const snapshot = buildCukieMasterSnapshot({
+        walletAddress: '0xABCDEF',
+        periodId: '2026-07-08',
+        eligibleUki,
+        originalCukiePoints,
+        calculatedAt,
+      });
+
+      expect(snapshot.routes.uki.slots).toBe(ukiSlots);
+      expect(snapshot.routes.nft.slots).toBe(nftSlots);
+      expect(snapshot.totalSlots).toBe(ukiSlots + nftSlots);
+      expect(snapshot.maxTotalSlots).toBe(10);
+      expect(snapshot.dailyCreditsPreview).toBe((ukiSlots + nftSlots) * 100);
+    },
+  );
+
   it('builds a 5-per-route snapshot with a potential total of 10 slots', () => {
     const snapshot = buildCukieMasterSnapshot({
       walletAddress: '0xABCDEF',

--- a/dapp/src/app/cukie-master/page.tsx
+++ b/dapp/src/app/cukie-master/page.tsx
@@ -19,7 +19,7 @@ export default function CukieMasterPage() {
       metrics={[
         { label: 'Ruta UKI', value: '500 cupos', helper: '20,000 UKI por cupo inicial' },
         { label: 'Ruta Cukies', value: '500 cupos', helper: '3 puntos en Cukies Originales' },
-        { label: 'Límite wallet', value: '5 cupos', helper: 'Sumando ruta UKI y ruta NFT' },
+        { label: 'Límite wallet', value: '10 cupos', helper: 'Máximo 5 por cada ruta' },
         { label: 'Créditos', value: '100 diarios', helper: 'Por cupo activo tras 24h' },
       ]}
       sections={[

--- a/dapp/src/components/landing/data.tsx
+++ b/dapp/src/components/landing/data.tsx
@@ -552,7 +552,7 @@ export const faqsByLocale: Record<PublicLocale, Array<{ question: string; answer
     {
       question: '¿Los UKI en vesting cuentan para ser Cukie Master?',
       answer:
-        'Sí. Los UKI comprados en preventa y sujetos a vesting cuentan de forma automática para obtener hasta 5 cupos de Cukie Master por wallet (1 cupo por cada 20,000 UKI comprados).',
+        'Sí. Los UKI comprados en preventa y sujetos a vesting cuentan de forma automática para obtener hasta 5 cupos por la ruta UKI (1 por cada 20,000 UKI comprados), además de los hasta 5 cupos de la ruta NFT.',
     },
     {
       question: '¿Los Cukies tendrán utilidad?',
@@ -580,7 +580,7 @@ De forma pasiva, puedes stakear tus tokens UKI para ser Cukie Master y ceder los
     {
       question: 'Do vested UKI count toward Cukie Master?',
       answer:
-        'Yes. UKI bought in the presale and subject to vesting automatically counts toward up to 5 Cukie Master slots per wallet (1 slot for every 20,000 UKI bought).',
+        'Yes. UKI bought in the presale and subject to vesting automatically counts toward up to 5 UKI-route slots (1 for every 20,000 UKI bought), in addition to up to 5 NFT-route slots.',
     },
     {
       question: 'Will Cukies have utility?',

--- a/docs/deployment-environments.md
+++ b/docs/deployment-environments.md
@@ -270,7 +270,7 @@ Antes de considerar staging valido:
 - [x] Completar smoke E2E con una segunda wallet desde la UI: login firmado, cookie segura, BSC Testnet `97`, transacciones bloqueadas, APIs de competicion `200`, registro `1/1` en Mongo staging y `0/0` en la base productiva.
 - [x] Rotar preventivamente `STAGING_MONGO_REPLICA_KEY` en una ventana controlada, reiniciar solo la replica staging y repetir health/transacciones sin reutilizar ni cambiar credenciales de produccion.
 
-El siguiente bloque recomendado depende de decisiones de producto: aprobar la interpretacion de `500,000 UKI/dia`, el techo acumulado del pool de `450,000,000 UKI`, el inicio/frontera/gracia del ledger y si el limite de Cukie Master es 5 cupos totales o 5 por ruta. Despues se cargan rulesets versionados con todos los gates apagados, se prueban fencing e idempotencia mediante ticks manuales y se habilita como maximo un scheduler cada vez. Las integraciones externas propias de staging siguen siendo ampliaciones separadas; no bloquean la version de prueba base.
+El siguiente bloque recomendado depende de decisiones de producto: aprobar la interpretacion de `500,000 UKI/dia`, el techo acumulado del pool de `450,000,000 UKI` y el inicio/frontera/gracia del ledger. El limite Cukie Master ya esta reconciliado en 5 cupos por ruta y 10 agregados. Despues se cargan rulesets versionados con todos los gates apagados, se prueban fencing e idempotencia mediante ticks manuales y se habilita como maximo un scheduler cada vez. Las integraciones externas propias de staging siguen siendo ampliaciones separadas; no bloquean la version de prueba base.
 
 ## Gates para produccion
 

--- a/docs/uki-current-operating-rules.md
+++ b/docs/uki-current-operating-rules.md
@@ -1,28 +1,26 @@
 # UKI current operating rules
 
-Estado: fuente operativa vigente para especificacion tecnica, con reconciliacion de producto pendiente.
+Estado: fuente operativa vigente para especificacion tecnica, con reconciliacion de emision pendiente.
 Fecha de sincronizacion de reglas aprobadas: 2026-05-17.
 Fecha de revision de la fuente mas reciente: 2026-08-06.
-Fuentes consolidadas: `/Users/fgomezserna/Downloads/Funcionamiento.docx` y `/Users/fgomezserna/Downloads/UKI/Preventa UKI.docx`.
-Fuente posterior revisada pero no consolidada: `/Users/fgomezserna/Downloads/Token UKI.docx`.
+Fuentes consolidadas: `/Users/fgomezserna/Downloads/Token UKI.docx`, `/Users/fgomezserna/Downloads/Funcionamiento.docx` y `/Users/fgomezserna/Downloads/UKI/Preventa UKI.docx`.
 
 Este documento sustituye como referencia de producto a los documentos antiguos de `Funcionamiento`, `dudas` y `para comentar`. Si una issue o documento anterior contradice estas reglas, estas reglas prevalecen hasta que producto apruebe una version nueva.
 
-## Reconciliacion pendiente con `Token UKI.docx`
+## Reconciliacion con `Token UKI.docx`
 
-`Token UKI.docx` es el ultimo documento recibido y la fuente mas reciente revisada. Las cifras operativas que repite coinciden en lo esencial con estas reglas: 500 cupos iniciales por ruta; requisitos iniciales de 3 puntos NFT o 20,000 UKI; tabla de puntos por rareza; ventana de ajuste de 48 horas; espera minima de 24 horas; y 100 creditos diarios por cupo. El documento no vuelve a fijar el supply, el reparto 45%/25%/18%/12%, el precio de preventa, el listing, la compra minima ni los vestings; para esos puntos siguen vigentes las fuentes consolidadas anteriores.
+`Token UKI.docx` es el ultimo documento recibido y la fuente mas reciente revisada. Prevalece para las reglas operativas que contiene: 500 cupos iniciales por ruta; maximo de 5 cupos por cada ruta y 10 agregados por wallet; requisitos iniciales de 3 puntos NFT o 20,000 UKI; tabla de puntos por rareza; ventana de ajuste de 48 horas; espera minima de 24 horas; y 100 creditos diarios por cupo. El documento no vuelve a fijar el supply, el reparto 45%/25%/18%/12%, el precio de preventa, el listing, la compra minima ni los vestings; para esos puntos siguen vigentes las fuentes consolidadas anteriores.
 
-No se adopta todavia como nueva fuente operativa porque quedan dos contradicciones que cambian el modelo economico:
+La regla de cupos queda reconciliada con la implementacion versionada `cukie-master-v1-5-per-route`. Permanece una contradiccion economica pendiente:
 
 1. **Reserva diaria frente a duracion del pool.** `Token UKI.docx` mantiene 500,000 UKI diarios. Las reglas consolidadas anteriores asignan 450,000,000 UKI al programa durante 6 anos. Tomadas conjuntamente, una emision constante de 500,000 UKI durante 6 anos consumiria aproximadamente 1,095,000,000 UKI. El pool de 450,000,000 UKI solo cubre 900 dias a ese ritmo. Para durar 6 anos, el promedio nominal seria de aproximadamente 205,479 UKI diarios. Hasta que producto decida, 500,000 UKI no debe cargarse como emision diaria garantizada. La opcion tecnica recomendada es tratarlo como capacidad maxima diaria, con techo acumulado de 450,000,000 UKI y reglas explicitas para UKI no distribuidos.
-2. **Limite de cupos Cukie Master.** La regla consolidada limita a 5 cupos totales por wallet sumando las rutas NFT y UKI. `Token UKI.docx` describe un maximo de 5 cupos por cada tipo, lo que permitiria hasta 10 por wallet. No se debe activar la regla de capacidad hasta elegir una de las dos interpretaciones.
 
 Tambien aparecen dos matices que no cambian cifras congeladas por ahora:
 
 - La preventa podria ampliarse despues de los 30 dias si no alcanza 3,000 ASM. El contrato soporta que el owner actualice la ventana con `setSaleWindow`, pero falta aprobar el criterio, la autoridad y el limite de extension antes de convertirlo en regla operativa.
 - El desbloqueo progresivo de claim 20%/40%/60%/80%/100% aparece como propuesta a valorar, no como decision aprobada ni comportamiento implementado.
 
-Mientras estos puntos sigan abiertos, los rulesets economicos y sus schedulers deben permanecer desactivados en staging.
+Mientras la emision siga abierta, los rulesets de rewards y sus schedulers deben permanecer desactivados en staging.
 
 ### Guardarrail tecnico de emision
 
@@ -128,7 +126,7 @@ Puntos por rareza:
 
 ### Limites y requisito dinamico
 
-- Maximo por wallet: 5 cupos de Cukie Master sumando ruta NFT y ruta UKI.
+- Maximo por wallet: 5 cupos por la ruta NFT y 5 por la ruta UKI; maximo agregado de 10.
 - Maximo global de cupos previsto: 5,000.
 - Si una ruta llena sus 500 cupos iniciales y se decide no abrir mas cupos en ese momento, el requisito sube.
 - Cuando el requisito sube, se abre una ventana de 48 horas para que los Cukie Masters ajusten staking y conserven posicion.

--- a/docs/uki-launch-technical-backlog.md
+++ b/docs/uki-launch-technical-backlog.md
@@ -351,7 +351,7 @@ Issues hijas:
 
 - UKI-014.1 Task - Especificar cupos por UKI
   - Inicial: 20,000 UKI por cupo.
-  - Maximo: 5 cupos por wallet sumando rutas.
+  - Maximo: 5 cupos por ruta y 10 agregados por wallet.
   - Requisito dinamico si se llenan cupos.
   - UKI comprado en preventa con vesting cuenta directamente para cupos.
   - Acceptance criteria:
@@ -719,7 +719,7 @@ UX image gate:
 - Estado: pendiente de validacion del usuario.
 - Pantalla: `Cukie Master`.
 - Prompt propuesto para imagen:
-  - "Pantalla Cukie Master para Cukies World, dos rutas de desbloqueo UKI staking y NFT points, contador de cupos, limite 5 por wallet, configuracion de creditos diarios, avisos de requisito dinamico, dark mode con acentos teal y magenta moderados."
+  - "Pantalla Cukie Master para Cukies World, dos rutas de desbloqueo UKI staking y NFT points, contador de cupos, limite 5 por ruta y 10 agregados por wallet, configuracion de creditos diarios, avisos de requisito dinamico, dark mode con acentos teal y magenta moderados."
 - No generar hasta recibir validacion explicita.
 
 Issues hijas:

--- a/docs/uki-ux-image-validation-plan.md
+++ b/docs/uki-ux-image-validation-plan.md
@@ -130,13 +130,13 @@ Ruta: `/cukie-master`.
 Prompt propuesto:
 
 ```text
-Pantalla Cukie Master para Cukies World UKI, fase coming next. Dos rutas de cupos: staking UKI y puntos de Cukies Originales. Mostrar 500 cupos iniciales por ruta, maximo 5 cupos por wallet, requisito 20,000 UKI por cupo, 3 puntos de Cukies Originales, UKI con vesting cuenta para cupos, espera 24h para creditos diarios y aviso de requisito dinamico con ventana 48h. UI operativa con contadores, sliders/inputs de stake, tabla de rarezas, alertas claras, dark mode teal/gold. Sin ranking completo, sin partida concreta, sin prometer recompensas economicas.
+Pantalla Cukie Master para Cukies World UKI, fase coming next. Dos rutas de cupos: staking UKI y puntos de Cukies Originales. Mostrar 500 cupos iniciales por ruta, maximo 5 cupos por ruta y 10 agregados por wallet, requisito 20,000 UKI por cupo, 3 puntos de Cukies Originales, UKI con vesting cuenta para cupos, espera 24h para creditos diarios y aviso de requisito dinamico con ventana 48h. UI operativa con contadores, sliders/inputs de stake, tabla de rarezas, alertas claras, dark mode teal/gold. Sin ranking completo, sin partida concreta, sin prometer recompensas economicas.
 ```
 
 Debe mostrar:
 
 - Dos rutas separadas.
-- Limite 5 cupos por wallet.
+- Limite de 5 cupos por ruta y 10 agregados por wallet.
 - Requisito dinamico y aviso 48h.
 - Fase posterior/coming next si no esta activo.
 


### PR DESCRIPTION
Closes #214

## Resumen
- consolida `Token UKI.docx` como la fuente más reciente para la regla Cukie Master;
- fija 5 cupos por ruta UKI y NFT, máximo 10 agregados por wallet;
- alinea documentación, prompt UX, página `/cukie-master` y copy de landing;
- añade la matriz `5+0`, `0+5`, `3+2`, `5+5` y exceso en ambas rutas;
- demuestra reintentos concurrentes idempotentes sin exceder 5 cupos por ruta.

## Validación
- `pnpm dapp lint` — OK
- `pnpm dapp typecheck` — OK
- 4 suites cercanas — 42 tests OK
- `pnpm --filter dapp test --runInBand` — 123 suites / 1.022 tests OK
- `git diff --check` — OK

## Operación y riesgo
- no cambia la lógica runtime: `cukie-master-v1-5-per-route` ya implementaba la regla aprobada;
- no activa `CHAIN_INDEXER_CUKIE_MASTER_ENABLED` ni ningún scheduler;
- destino exclusivo: `staging` / BSC Testnet 97 / bases staging;
- no se modifica `main`, mainnet ni producción.
