### PR TITLE
fix: aplicar reparto UKI no distribuido 80/5/5/10

### DIFF
--- a/dapp/__tests__/lib/reward-calculation.test.ts
+++ b/dapp/__tests__/lib/reward-calculation.test.ts
@@ -145,12 +145,56 @@ describe("reward settlement calculations", () => {
 });
 
 describe("reward pool calculations", () => {
-  it("mantiene el UKI no distribuido no claimable hasta resolver la contradiccion operativa", () => {
-    const result = calculateUndistributedRewardAllocations(testRewardRule(), "7");
-    expect(result.allocations).toEqual([]);
-    expect(result.accruals).toEqual([
-      { category: "undistributed_pending", amountRaw: "7" },
-    ]);
+  it("reparte el UKI no distribuido 80/5/5/10 y conserva el total", () => {
+    const result = calculateUndistributedRewardAllocations(testRewardRule(), "10000");
+    expect(amountsByCategory(result.allocations)).toEqual({
+      treasury: "8000",
+      marketing: "500",
+      development: "500",
+      supply_reduction: "1000",
+    });
+    expect(result.accruals).toEqual([]);
+    expect(result.allocations.reduce(
+      (sum, allocation) => sum + BigInt(allocation.amountRaw),
+      BigInt(0),
+    )).toBe(BigInt(10000));
+  });
+
+  it("asigna el remainder raw de forma determinista sin perder unidades", () => {
+    const first = calculateUndistributedRewardAllocations(testRewardRule(), "7");
+    const replay = calculateUndistributedRewardAllocations(testRewardRule(), "7");
+
+    expect(first).toEqual(replay);
+    expect(amountsByCategory(first.allocations)).toEqual({
+      treasury: "6",
+      supply_reduction: "1",
+    });
+    expect(first.allocations.reduce(
+      (sum, allocation) => sum + BigInt(allocation.amountRaw),
+      BigInt(0),
+    )).toBe(BigInt(7));
+  });
+
+  it("omite destinos al 0% sin invalidar un reparto que conserva el 100%", () => {
+    const rule = testRewardRule({
+      undistributedBps: {
+        treasury: 10_000,
+        marketing: 0,
+        development: 0,
+        supplyReduction: 0,
+      },
+    });
+    rule.configHash = buildRewardRuleConfigHash(rule);
+
+    expect(calculateUndistributedRewardAllocations(rule, "7")).toMatchObject({
+      allocations: [{
+        walletNormalized: rule.destinations.treasury,
+        category: "treasury",
+        amountRaw: "7",
+      }],
+      accruals: [],
+      totalRaw: "7",
+    });
   });
 
   it("activa el floor de 0.75 por cada 10 solo si la regla lo declara", () => {

--- a/dapp/src/lib/uki-economy/rewards/calculation.ts
+++ b/dapp/src/lib/uki-economy/rewards/calculation.ts
@@ -70,14 +70,45 @@ export function calculateUndistributedRewardAllocations(
 ) {
   assertRewardRule(rule);
   const total = parseRawAmount(totalRaw);
+  const allocations = total === BigInt(0)
+    ? []
+    : apportionRaw(total, [
+        {
+          key: "treasury",
+          walletNormalized: rule.destinations.treasury,
+          category: "treasury" as const,
+          weight: BigInt(rule.undistributedBps.treasury),
+        },
+        {
+          key: "marketing",
+          walletNormalized: rule.destinations.marketing,
+          category: "marketing" as const,
+          weight: BigInt(rule.undistributedBps.marketing),
+        },
+        {
+          key: "development",
+          walletNormalized: rule.destinations.development,
+          category: "development" as const,
+          weight: BigInt(rule.undistributedBps.development),
+        },
+        {
+          key: "supply_reduction",
+          walletNormalized: rule.destinations.supplyReduction,
+          category: "supply_reduction" as const,
+          weight: BigInt(rule.undistributedBps.supplyReduction),
+        },
+      ].filter(({ weight }) => weight > BigInt(0))).map(({
+        walletNormalized,
+        category,
+        amountRaw,
+      }) => ({
+        walletNormalized,
+        category,
+        amountRaw: formatRawAmount(amountRaw),
+      }));
   return {
-    allocations: [] as RewardAllocationDraft[],
-    accruals: total === BigInt(0)
-      ? [] as RewardAccrualDraft[]
-      : [{
-          category: "undistributed_pending" as const,
-          amountRaw: formatRawAmount(total),
-        }],
+    allocations: combineDrafts(allocations),
+    accruals: [] as RewardAccrualDraft[],
     totalRaw: formatRawAmount(total),
   };
 }

--- a/docs/deployment-environments.md
+++ b/docs/deployment-environments.md
@@ -260,7 +260,8 @@ Antes de considerar staging valido:
 - [x] Confirmar el mirror secundario en las paginas publicas de BscScan Testnet: `UKIStaking` y `RewardsDistributor` muestran source verificado con coincidencia exacta, compilador `0.8.28` y 200 runs; no fue necesario obtener ni exponer una API key.
 - [x] Configurar HMAC distintas para administracion y juegos en staging y ejecutar dos veces el setup idempotente de economia v2.
 - [x] Implementar el ledger global fail-closed de presupuesto diario/acumulado, con fencing, replay por `sourceId` y auditoria de saldos; no contiene cifras aprobadas ni activa schedulers (issue #213).
-- [ ] Aprobar y cargar en staging los valores de `programStartsAt`, frontera/gracia UTC, maximo diario y techo acumulado irreversible del `RewardRule`.
+- [x] Reconciliar `500,000 UKI/dia` como maximo, `450,000,000 UKI` como techo acumulado, capacidad no usada `expires`, exceso `block` y reparto no distribuido 80/5/5/10.
+- [ ] Aprobar y cargar en staging `programStartsAt`, frontera/gracia UTC y direcciones de destino del `RewardRule`; los caps deben declararse explicitamente sin defaults.
 - [ ] Cargar reglas aprobadas de creditos, juegos, pools y ranking.
 - [x] Desplegar los cinco schedulers con gates desactivados y verificar guardas, credencial limitada y ausencia de heartbeats/runs.
 - [x] Retirar el card worker del arranque por defecto de staging mediante el profile `card-worker`.
@@ -270,7 +271,7 @@ Antes de considerar staging valido:
 - [x] Completar smoke E2E con una segunda wallet desde la UI: login firmado, cookie segura, BSC Testnet `97`, transacciones bloqueadas, APIs de competicion `200`, registro `1/1` en Mongo staging y `0/0` en la base productiva.
 - [x] Rotar preventivamente `STAGING_MONGO_REPLICA_KEY` en una ventana controlada, reiniciar solo la replica staging y repetir health/transacciones sin reutilizar ni cambiar credenciales de produccion.
 
-El siguiente bloque recomendado depende de decisiones de producto: aprobar la interpretacion de `500,000 UKI/dia`, el techo acumulado del pool de `450,000,000 UKI` y el inicio/frontera/gracia del ledger. El limite Cukie Master ya esta reconciliado en 5 cupos por ruta y 10 agregados. Despues se cargan rulesets versionados con todos los gates apagados, se prueban fencing e idempotencia mediante ticks manuales y se habilita como maximo un scheduler cada vez. Las integraciones externas propias de staging siguen siendo ampliaciones separadas; no bloquean la version de prueba base.
+El siguiente bloque recomendado depende de aprobar el inicio/frontera/gracia UTC del ledger y las direcciones staging de sus destinos. Los caps y las politicas ya estan reconciliados, y el limite Cukie Master queda en 5 cupos por ruta y 10 agregados. Despues se cargan rulesets versionados con todos los gates apagados, se prueban fencing e idempotencia mediante ticks manuales y se habilita como maximo un scheduler cada vez. Las integraciones externas propias de staging siguen siendo ampliaciones separadas; no bloquean la version de prueba base.
 
 ## Gates para produccion
 

--- a/docs/uki-current-operating-rules.md
+++ b/docs/uki-current-operating-rules.md
@@ -1,6 +1,6 @@
 # UKI current operating rules
 
-Estado: fuente operativa vigente para especificacion tecnica, con reconciliacion de emision pendiente.
+Estado: fuente operativa vigente para especificacion tecnica, con configuracion temporal de emision pendiente.
 Fecha de sincronizacion de reglas aprobadas: 2026-05-17.
 Fecha de revision de la fuente mas reciente: 2026-08-06.
 Fuentes consolidadas: `/Users/fgomezserna/Downloads/Token UKI.docx`, `/Users/fgomezserna/Downloads/Funcionamiento.docx` y `/Users/fgomezserna/Downloads/UKI/Preventa UKI.docx`.
@@ -11,20 +11,21 @@ Este documento sustituye como referencia de producto a los documentos antiguos d
 
 `Token UKI.docx` es el ultimo documento recibido y la fuente mas reciente revisada. Prevalece para las reglas operativas que contiene: 500 cupos iniciales por ruta; maximo de 5 cupos por cada ruta y 10 agregados por wallet; requisitos iniciales de 3 puntos NFT o 20,000 UKI; tabla de puntos por rareza; ventana de ajuste de 48 horas; espera minima de 24 horas; y 100 creditos diarios por cupo. El documento no vuelve a fijar el supply, el reparto 45%/25%/18%/12%, el precio de preventa, el listing, la compra minima ni los vestings; para esos puntos siguen vigentes las fuentes consolidadas anteriores.
 
-La regla de cupos queda reconciliada con la implementacion versionada `cukie-master-v1-5-per-route`. Permanece una contradiccion economica pendiente:
+La regla de cupos queda reconciliada con la implementacion versionada `cukie-master-v1-5-per-route`. La reserva de recompensas se reconcilia de esta forma:
 
-1. **Reserva diaria frente a duracion del pool.** `Token UKI.docx` mantiene 500,000 UKI diarios. Las reglas consolidadas anteriores asignan 450,000,000 UKI al programa durante 6 anos. Tomadas conjuntamente, una emision constante de 500,000 UKI durante 6 anos consumiria aproximadamente 1,095,000,000 UKI. El pool de 450,000,000 UKI solo cubre 900 dias a ese ritmo. Para durar 6 anos, el promedio nominal seria de aproximadamente 205,479 UKI diarios. Hasta que producto decida, 500,000 UKI no debe cargarse como emision diaria garantizada. La opcion tecnica recomendada es tratarlo como capacidad maxima diaria, con techo acumulado de 450,000,000 UKI y reglas explicitas para UKI no distribuidos.
+1. **Maximo diario y techo del programa.** Los 500,000 UKI son el maximo que puede reservar el conjunto de juegos en un dia, no una emision garantizada. El techo acumulado es 450,000,000 UKI, correspondiente al 45% del supply asignado al programa. Un dia al maximo consume presupuesto para 900 dias; para extender el programa durante 6 anos el uso diario real debe ser menor. La capacidad diaria no usada expira y no se acumula.
+2. **Exceso y UKI no distribuido.** Una fuente que exceda el maximo diario o acumulado se bloquea y nunca crea claims implicitos. El importe ya reservado que una regla calcule como no distribuido se materializa de forma determinista: 80% tesoreria, 5% marketing, 5% desarrollo y 10% reduccion de supply.
 
 Tambien aparecen dos matices que no cambian cifras congeladas por ahora:
 
 - La preventa podria ampliarse despues de los 30 dias si no alcanza 3,000 ASM. El contrato soporta que el owner actualice la ventana con `setSaleWindow`, pero falta aprobar el criterio, la autoridad y el limite de extension antes de convertirlo en regla operativa.
 - El desbloqueo progresivo de claim 20%/40%/60%/80%/100% aparece como propuesta a valorar, no como decision aprobada ni comportamiento implementado.
 
-Mientras la emision siga abierta, los rulesets de rewards y sus schedulers deben permanecer desactivados en staging.
+Antes de cargar el ruleset siguen pendientes `programStartsAt`, la frontera diaria UTC, la gracia de reserva tardia y las direcciones staging de los destinos. Hasta entonces los rulesets de rewards y sus schedulers deben permanecer desactivados en staging.
 
 ### Guardarrail tecnico de emision
 
-La Economy v2 exige ahora que cada `RewardRule` declare de forma explicita `programStartsAt`, frontera diaria UTC, gracia de reserva, `dailyCapRaw`, `lifetimeCapRaw`, politica de capacidad no usada y politica de exceso. No existen defaults para `500,000` ni `450,000,000` UKI: hasta que producto apruebe esas cifras y fechas no debe cargarse una regla activa.
+La Economy v2 exige ahora que cada `RewardRule` declare de forma explicita `programStartsAt`, frontera diaria UTC, gracia de reserva, `dailyCapRaw`, `lifetimeCapRaw`, politica de capacidad no usada y politica de exceso. No existen defaults en codigo: el ruleset staging debera cargar explicitamente 500,000 UKI como maximo diario y 450,000,000 UKI como techo acumulado una vez aprobados sus parametros temporales y destinos.
 
 Antes de crear un manifest, allocation o accrual, el servicio reserva el total bruto de la fuente dentro de la misma transaccion Mongo. El ledger usa tres colecciones globales:
 
@@ -32,7 +33,7 @@ Antes de crear un manifest, allocation o accrual, el servicio reserva el total b
 - `reward_emission_budget_days`: consumo por ventana diaria UTC;
 - `reward_emission_budget_events`: decision inmutable por `sourceId`, con saldos anterior/posterior, regla, hashes de calculo y motivo de bloqueo.
 
-Los replays no vuelven a consumir saldo. Un exceso diario/acumulado, una fuente anterior al inicio, una fecha economica futura o una reserva posterior al cierre devuelve `budget_blocked` y no materializa rewards. El sello semanal ancla tanto las reservas como los bloqueos y vuelve a validar cada evento antes de crear un draft Merkle; una decision ausente o manipulada impide claims. El techo acumulado, el inicio, la frontera, la gracia y las politicas no pueden cambiar mediante una nueva version ordinaria una vez iniciado el ledger; cualquier migracion futura requeriria una operacion separada y auditada. `unusedDailyCapacity=expires` y `overflowPolicy=block` son las unicas politicas implementadas en esta primera version, pero no se activan hasta recibir aprobacion de producto.
+Los replays no vuelven a consumir saldo. Un exceso diario/acumulado, una fuente anterior al inicio, una fecha economica futura o una reserva posterior al cierre devuelve `budget_blocked` y no materializa rewards. El sello semanal ancla tanto las reservas como los bloqueos y vuelve a validar cada evento antes de crear un draft Merkle; una decision ausente o manipulada impide claims. El techo acumulado, el inicio, la frontera, la gracia y las politicas no pueden cambiar mediante una nueva version ordinaria una vez iniciado el ledger; cualquier migracion futura requeriria una operacion separada y auditada. Las politicas vigentes son `unusedDailyCapacity=expires`, `overflowPolicy=block` y reparto no distribuido 80/5/5/10; no se activan hasta completar la configuracion temporal y de destinos.
 
 ## Preventa UKI
 
@@ -279,7 +280,7 @@ Puede quedar UKI sin distribuir si:
 - Hay creditos que se usan pero no se convierten a UKI.
 - Un jugador no tiene ranking #1 y por tanto no recibe el 100% de la parte restante.
 
-Distribucion propuesta:
+Distribucion vigente segun `Token UKI.docx`:
 
 | Destino | Porcentaje |
 | --- | ---: |


### PR DESCRIPTION
Refs #213

## Resumen
- reconcilia 500.000 UKI como máximo diario y 450M como techo acumulado;
- mantiene `unusedDailyCapacity=expires` y `overflowPolicy=block`;
- convierte `undistributed_pending` en allocations deterministas para tesorería (80%), marketing (5%), desarrollo (5%) y reducción de supply (10%);
- conserva exactamente el total raw, incluido remainder, y admite destinos configurados al 0%;
- actualiza la fuente operativa y el checklist de staging.

## Validación
- 5 suites de rewards: 50 tests OK
- `pnpm dapp lint` — OK
- `pnpm dapp typecheck` — OK
- `pnpm --filter dapp test --runInBand` — 123 suites / 1.024 tests OK
- `git diff --check` — OK

## Pendiente antes de cargar reglas
- `programStartsAt`;
- frontera diaria UTC;
- gracia de reservas tardías;
- direcciones staging para tesorería, marketing, desarrollo y reducción de supply.

## Seguridad operativa
- no carga rulesets ni activa workers;
- destino exclusivo `staging`;
- no modifica `main`, mainnet ni producción.
