### PR TITLE
fix: propagate staging identity to guarded workers

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -181,6 +181,8 @@ services:
       NODE_ENV: production
       APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
       STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      COOLIFY_BRANCH: ${COOLIFY_BRANCH:?Coolify must expose the staging branch}
+      COOLIFY_RESOURCE_UUID: ${COOLIFY_RESOURCE_UUID:?Coolify must expose the staging resource UUID}
       DATABASE_URL: ${DATABASE_URL}
       CUKIES_DATABASE_URL: ${CUKIES_DATABASE_URL:-}
       CHAIN_INDEXER_MONGO_URL: ${CHAIN_INDEXER_MONGO_URL:-${DATABASE_URL}}
@@ -256,6 +258,8 @@ services:
       NODE_ENV: production
       APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
       STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      COOLIFY_BRANCH: ${COOLIFY_BRANCH:?Coolify must expose the staging branch}
+      COOLIFY_RESOURCE_UUID: ${COOLIFY_RESOURCE_UUID:?Coolify must expose the staging resource UUID}
       DATABASE_URL: ${DATABASE_URL}
       CHAIN_INDEXER_MONGO_URL: ${CHAIN_INDEXER_MONGO_URL:-${DATABASE_URL}}
       CHAIN_INDEXER_DB_NAME: ${CHAIN_INDEXER_DB_NAME:-cukieshub-new}
@@ -307,6 +311,8 @@ services:
       NODE_ENV: production
       APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
       STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      COOLIFY_BRANCH: ${COOLIFY_BRANCH:?Coolify must expose the staging branch}
+      COOLIFY_RESOURCE_UUID: ${COOLIFY_RESOURCE_UUID:?Coolify must expose the staging resource UUID}
       DATABASE_URL: ${DATABASE_URL}
       CHAIN_INDEXER_MONGO_URL: ${CHAIN_INDEXER_MONGO_URL:-${DATABASE_URL}}
       CHAIN_INDEXER_DB_NAME: ${CHAIN_INDEXER_DB_NAME:-cukieshub-new}
@@ -357,6 +363,8 @@ services:
       NODE_ENV: production
       APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
       STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      COOLIFY_BRANCH: ${COOLIFY_BRANCH:?Coolify must expose the staging branch}
+      COOLIFY_RESOURCE_UUID: ${COOLIFY_RESOURCE_UUID:?Coolify must expose the staging resource UUID}
       DATABASE_URL: ${DATABASE_URL}
       CHAIN_INDEXER_MONGO_URL: ${CHAIN_INDEXER_MONGO_URL:-${DATABASE_URL}}
       CHAIN_INDEXER_DB_NAME: ${CHAIN_INDEXER_DB_NAME:-cukieshub-new}
@@ -407,6 +415,8 @@ services:
       NODE_ENV: production
       APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
       STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      COOLIFY_BRANCH: ${COOLIFY_BRANCH:?Coolify must expose the staging branch}
+      COOLIFY_RESOURCE_UUID: ${COOLIFY_RESOURCE_UUID:?Coolify must expose the staging resource UUID}
       DATABASE_URL: ${DATABASE_URL}
       CHAIN_INDEXER_MONGO_URL: ${CHAIN_INDEXER_MONGO_URL:-${DATABASE_URL}}
       CHAIN_INDEXER_DB_NAME: ${CHAIN_INDEXER_DB_NAME:-cukieshub-new}
@@ -457,6 +467,8 @@ services:
       NODE_ENV: production
       APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
       STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      COOLIFY_BRANCH: ${COOLIFY_BRANCH:?Coolify must expose the staging branch}
+      COOLIFY_RESOURCE_UUID: ${COOLIFY_RESOURCE_UUID:?Coolify must expose the staging resource UUID}
       DATABASE_URL: ${DATABASE_URL}
       CHAIN_INDEXER_MONGO_URL: ${CHAIN_INDEXER_MONGO_URL:-${DATABASE_URL}}
       CHAIN_INDEXER_DB_NAME: ${CHAIN_INDEXER_DB_NAME:-cukieshub-new}
@@ -494,6 +506,8 @@ services:
       NODE_ENV: production
       APP_ENV: ${APP_ENV:?Set APP_ENV in Coolify environment variables}
       STAGING_ONLY_GUARD: ${STAGING_ONLY_GUARD:?Set STAGING_ONLY_GUARD=true for staging}
+      COOLIFY_BRANCH: ${COOLIFY_BRANCH:?Coolify must expose the staging branch}
+      COOLIFY_RESOURCE_UUID: ${COOLIFY_RESOURCE_UUID:?Coolify must expose the staging resource UUID}
       DATABASE_URL: ${DATABASE_URL}
       CARD_WORKER_MONGO_URL: ${CARD_WORKER_MONGO_URL:-${DATABASE_URL}}
       CARD_WORKER_DB_NAME: ${CARD_WORKER_DB_NAME:-cukieshub-new}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "chain-indexer": "pnpm --filter @cukies/chain-indexer",
     "card-worker": "pnpm --filter @cukies/cuki-card-worker",
     "guard:staging": "node scripts/assert-staging-only.mjs",
-    "guard:staging:test": "node --test scripts/assert-staging-only.test.mjs",
+    "guard:staging:test": "node --test scripts/assert-staging-only.test.mjs scripts/docker-compose-coolify.test.mjs",
     "staging:indexer:setup": "node scripts/assert-staging-only.mjs --scope chain-indexer && pnpm indexer:setup",
     "staging:economy:setup": "node scripts/assert-staging-only.mjs --scope chain-indexer && pnpm indexer:setup:economy",
     "staging:economy:setup:prod": "node scripts/assert-staging-only.mjs --scope chain-indexer && pnpm --filter @cukies/chain-indexer run setup:economy:prod",

--- a/scripts/docker-compose-coolify.test.mjs
+++ b/scripts/docker-compose-coolify.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const compose = await readFile(
+  new URL('../docker-compose.coolify.yml', import.meta.url),
+  'utf8',
+);
+
+const guardedWorkers = [
+  'chain-indexer',
+  'cukie-master-scheduler',
+  'competition-credit-scheduler',
+  'game-economy-scheduler',
+  'cukie-pool-scheduler',
+  'weekly-ranking-scheduler',
+  'cuki-card-worker',
+];
+
+function serviceDefinition(serviceName) {
+  const startMarker = `  ${serviceName}:\n`;
+  const start = compose.indexOf(startMarker);
+  assert.notEqual(start, -1, `missing ${serviceName} service`);
+
+  const remainder = compose.slice(start + startMarker.length);
+  const nextService = remainder.match(/^  [a-z0-9-]+:\n/m);
+  const end = nextService?.index === undefined
+    ? compose.length
+    : start + startMarker.length + nextService.index;
+
+  return compose.slice(start, end);
+}
+
+for (const serviceName of guardedWorkers) {
+  test(`${serviceName} receives the immutable Coolify staging identity`, () => {
+    const definition = serviceDefinition(serviceName);
+
+    assert.match(
+      definition,
+      /      COOLIFY_BRANCH: \$\{COOLIFY_BRANCH:\?Coolify must expose the staging branch\}/,
+    );
+    assert.match(
+      definition,
+      /      COOLIFY_RESOURCE_UUID: \$\{COOLIFY_RESOURCE_UUID:\?Coolify must expose the staging resource UUID\}/,
+    );
+  });
+}


### PR DESCRIPTION
Closes no issue; follow-up operativo de #213.

## Resumen
- propaga `COOLIFY_BRANCH` y `COOLIFY_RESOURCE_UUID` a los siete workers del compose de Coolify;
- mantiene la guarda staging-only como primera operación de cada worker;
- añade una prueba estructural para impedir que algún worker vuelva a perder la identidad del recurso.

## Evidencia del fallo
El despliegue staging `1120` sirvió correctamente el SHA `509ef4c`, pero los workers reiniciaban porque ambas variables no estaban declaradas en sus bloques `environment`. La guarda rechazó el arranque antes de cualquier tick o escritura.

## Validación
- `pnpm guard:staging:test` — 22/22 OK
- `docker compose -f docker-compose.coolify.yml config --no-interpolate --quiet` — OK
- `git diff --check` — OK

## Riesgo y despliegue
Sólo se desplegará en app28/branch `staging`. Los cinco gates económicos permanecen en `false`. No se toca app12, `main`, producción ni BSC mainnet.