### PR TITLE
feat: harden staging wallets and redesign Cukie Master

### DIFF
--- a/dapp/__tests__/api/economy-cukie-master.test.ts
+++ b/dapp/__tests__/api/economy-cukie-master.test.ts
@@ -134,6 +134,20 @@ describe('GET /api/economy/v1/cukie-master', () => {
 
   it('returns a no-store public DTO without source refs or hashes', async () => {
     mockVerify.mockResolvedValue({ id: 'user-1' } as never);
+    mockInventory.mockResolvedValue([{
+      assetId: 'cukies:42',
+      tokenId: '42',
+      imageUrl: 'https://cukies.s3.eu-west-3.amazonaws.com/png/tokens/v2/contract/42.png',
+      rarity: 'rare',
+      rarityPoints: 4,
+      contributesToCukieMaster: true,
+      contributionPoints: 4,
+      state: 'soft_staked',
+      blockers: [],
+      lock: { lockId: 'lock-42', fencingToken: 2 },
+      canSoftStake: false,
+      canUnstake: true,
+    }]);
     mockStatus.mockResolvedValue({
       walletAddress: WALLET,
       walletNormalized: WALLET,
@@ -155,6 +169,12 @@ describe('GET /api/economy/v1/cukie-master', () => {
       presaleLockedRaw: '20000000000000000000000',
       stakedUkiRaw: '5000000000000000000000',
     });
+    expect(body.data.nftInventory[0]).toEqual(expect.objectContaining({
+      assetId: 'cukies:42',
+      imageUrl: expect.stringContaining('/42.png'),
+      contributesToCukieMaster: true,
+      contributionPoints: 4,
+    }));
     expect(JSON.stringify(body)).not.toMatch(/sourceHash|refs|internal warning|secret-asset-id/);
   });
 

--- a/dapp/__tests__/components/cukie-master-page.test.tsx
+++ b/dapp/__tests__/components/cukie-master-page.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import CukieMasterPage from '@/app/cukie-master/page';
+
+jest.mock('@/components/cukie-master/workspace', () => ({
+  CukieMasterWorkspace: ({ testnetOnly }: { testnetOnly?: boolean }) => (
+    <div data-testnet-only={String(Boolean(testnetOnly))}>Workspace personal</div>
+  ),
+}));
+jest.mock('@/components/cukie-master/credit-panel', () => ({
+  CompetitionCreditPanel: () => <div>Panel de créditos activo</div>,
+}));
+jest.mock('@/components/launch/info-page', () => ({
+  LaunchInfoPage: ({
+    eyebrow,
+    variant,
+    beforeSections,
+    afterSections,
+    sections,
+    note,
+  }: {
+    eyebrow: string;
+    variant?: string;
+    beforeSections?: ReactNode;
+    afterSections?: ReactNode;
+    sections: Array<{ title: string; text?: string; bullets?: string[] }>;
+    note?: string;
+  }) => (
+    <main data-variant={variant}>
+      <p>{eyebrow}</p>
+      {beforeSections}
+      {sections.map((section) => (
+        <section key={section.title}>
+          <h2>{section.title}</h2>
+          <p>{section.text}</p>
+          {section.bullets?.map((bullet) => <p key={bullet}>{bullet}</p>)}
+        </section>
+      ))}
+      <p>{note}</p>
+      {afterSections}
+    </main>
+  ),
+}));
+jest.mock('@/components/landing/sale-config', () => ({
+  UKI_PRESALE_CHAIN_LABEL: 'BNB Smart Chain Testnet',
+}));
+
+describe('CukieMasterPage', () => {
+  const previousFlag = process.env.COMPETITION_CREDITS_RUNTIME_ENABLED;
+  const previousAppEnv = process.env.APP_ENV;
+
+  afterEach(() => {
+    if (previousFlag === undefined) delete process.env.COMPETITION_CREDITS_RUNTIME_ENABLED;
+    else process.env.COMPETITION_CREDITS_RUNTIME_ENABLED = previousFlag;
+    if (previousAppEnv === undefined) delete process.env.APP_ENV;
+    else process.env.APP_ENV = previousAppEnv;
+  });
+
+  it('prioriza el workspace y no anuncia créditos activos cuando el runtime está cerrado', () => {
+    process.env.COMPETITION_CREDITS_RUNTIME_ENABLED = 'false';
+    process.env.APP_ENV = 'staging';
+    const { container } = render(<CukieMasterPage />);
+
+    expect(container.querySelector('main')).toHaveAttribute('data-variant', 'workspace');
+    expect(screen.getByText('Workspace personal')).toBeInTheDocument();
+    expect(screen.getByText('Workspace personal')).toHaveAttribute('data-testnet-only', 'true');
+    expect(screen.getByText(/Área de pruebas · BNB Smart Chain Testnet/i)).toBeInTheDocument();
+    expect(screen.getByText(/todavía no está activa en este entorno de pruebas/i)).toBeInTheDocument();
+    expect(screen.queryByText('Panel de créditos activo')).not.toBeInTheDocument();
+    expect(container).not.toHaveTextContent('La UI debe');
+  });
+
+  it('muestra el panel de créditos únicamente cuando el runtime está habilitado', () => {
+    process.env.COMPETITION_CREDITS_RUNTIME_ENABLED = 'true';
+    render(<CukieMasterPage />);
+
+    expect(screen.getByText('Panel de créditos activo')).toBeInTheDocument();
+    expect(screen.getByText(/La asignación de créditos está activa en este entorno/i)).toBeInTheDocument();
+  });
+});

--- a/dapp/__tests__/components/cukie-master-status-panel.test.tsx
+++ b/dapp/__tests__/components/cukie-master-status-panel.test.tsx
@@ -1,16 +1,30 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { CukieMasterStatusPanel } from '@/components/cukie-master/status-panel';
 import { useAuth } from '@/providers/auth-provider';
 import type { User } from '@/types';
 
 jest.mock('@/providers/auth-provider');
+jest.mock('@/components/landing/wallet-connect-dynamic', () => ({
+  LandingWalletConnectButton: ({ evmOnly }: { evmOnly?: boolean }) => (
+    <button type="button" data-evm-only={String(Boolean(evmOnly))}>Conectar wallet EVM</button>
+  ),
+}));
+jest.mock('@/components/legacy-marketplace/cuki-image', () => ({
+  CukiImage: ({ alt, src }: { alt: string; src?: string | null }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src={src ?? undefined} />
+  ),
+}));
 jest.mock('lucide-react', () => ({
   AlertTriangle: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
+  ArrowRight: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
   CheckCircle2: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
   Clock3: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
   Loader2: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
   Lock: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
+  ShieldCheck: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
+  Sparkles: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
   Unlock: (props: React.HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
 }));
 
@@ -42,7 +56,7 @@ describe('CukieMasterStatusPanel', () => {
     render(<CukieMasterStatusPanel />);
 
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(screen.getByText(/Conecta y autentica tu wallet/i)).toBeInTheDocument();
+    expect(screen.getByText(/Conecta una wallet EVM/i)).toBeInTheDocument();
   });
 
   it('renders only the persisted public slot status returned by the API', async () => {
@@ -93,18 +107,23 @@ describe('CukieMasterStatusPanel', () => {
 
     render(<CukieMasterStatusPanel />);
 
-    await waitFor(() => expect(screen.getByText('Total activo')).toBeInTheDocument());
-    expect(screen.getByText('Ruta UKI')).toBeInTheDocument();
-    expect(screen.getByText('Ruta Cukies')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Cupos activos')).toBeInTheDocument());
+    expect(screen.getByText('1/10')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Ruta UKI/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Ruta Cukies/i })).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Progreso Ruta UKI' })).toHaveAttribute('aria-valuenow', '2');
     expect(screen.getByText('Cupo 1')).toBeInTheDocument();
-    expect(screen.getByText('UKI computables')).toBeInTheDocument();
-    expect(screen.getByText('Exceso tras cupos')).toBeInTheDocument();
-    expect(screen.getByText('45.000 UKI')).toBeInTheDocument();
-    expect(screen.getByText('Exceso tras cupos').parentElement).toHaveTextContent('5000 UKI');
+    expect(screen.getByText('UKI que ya cuentan')).toBeInTheDocument();
+    expect(screen.getByText(/45\.000 UKI = 40\.000 UKI en vesting \+ 5000 UKI en staking/i)).toBeInTheDocument();
+    expect(screen.getByText('Margen tras cupos').parentElement).toHaveTextContent('5000 UKI');
     expect(fetchMock).toHaveBeenCalledWith(
       `/api/economy/v1/cukie-master?walletAddress=${walletAddress}`,
       expect.objectContaining({ cache: 'no-store', credentials: 'same-origin' }),
     );
+    fireEvent.click(screen.getByRole('button', { name: 'Actualizar estado' }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    window.dispatchEvent(new Event('cukies:cukie-master:refresh'));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
   });
 
   it('fails closed without showing stale slot numbers when the API is unavailable', async () => {
@@ -116,8 +135,71 @@ describe('CukieMasterStatusPanel', () => {
 
     render(<CukieMasterStatusPanel />);
 
-    await waitFor(() => expect(screen.getByText(/no está disponible con garantías/i)).toBeInTheDocument());
-    expect(screen.queryByText('Total activo')).not.toBeInTheDocument();
-    expect(screen.queryByText('cupos asignados')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText(/No podemos verificar tu estado económico/i)).toBeInTheDocument());
+    expect(screen.queryByText('Cupos activos')).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+  });
+
+  it('shows NFT contribution separately from potential points and exposes contextual actions', async () => {
+    mockUseAuth.mockReturnValue(authValue(user));
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: 'ok',
+        data: {
+          walletNormalized: walletAddress,
+          totals: { desiredSlots: 1, allocatedSlots: 1, maxPotentialSlots: 10 },
+          routes: {
+            uki: {
+              position: null,
+              currentRequirement: { route: 'uki', ukiRaw: '20000000000000000000000' },
+              pendingRequirement: null,
+              requirementGraceEndsAt: null,
+              deficitToNextSlot: { route: 'uki', ukiRaw: '20000000000000000000000' },
+              deficitToPreserveSlots: null,
+              slots: [],
+              source: { complete: true, status: 'available', route: 'uki', totalUkiRaw: '0', presaleLockedRaw: '0', stakedUkiRaw: '0' },
+            },
+            nft: {
+              position: { status: 'active', desiredSlots: 1, allocatedSlots: 1, protectedSlots: 0, graceEndsAt: null },
+              currentRequirement: { route: 'nft', nftPoints: 3 },
+              pendingRequirement: null,
+              requirementGraceEndsAt: null,
+              deficitToNextSlot: { route: 'nft', nftPoints: 2 },
+              deficitToPreserveSlots: null,
+              slots: [{
+                route: 'nft', ordinal: 1, eligibilityEpoch: 1, status: 'active',
+                creditEligibleFrom: '2026-07-10T00:00:00.000Z', graceEndsAt: null,
+              }],
+              source: { complete: true, status: 'available', route: 'nft', originalCukiePoints: 4 },
+            },
+          },
+          nftInventory: [
+            {
+              assetId: 'cukies:42', tokenId: '42', imageUrl: 'https://example.com/42.png', rarity: 'rare', rarityPoints: 4,
+              contributesToCukieMaster: true, contributionPoints: 4, state: 'soft_staked', blockers: [],
+              lock: { lockId: 'lock-42', fencingToken: 1 }, canSoftStake: false, canUnstake: true,
+            },
+            {
+              assetId: 'cukies:7', tokenId: '7', imageUrl: null, rarity: 'common', rarityPoints: 1,
+              contributesToCukieMaster: false, contributionPoints: 0, state: 'available', blockers: [],
+              lock: null, canSoftStake: true, canUnstake: false,
+            },
+          ],
+        },
+      }),
+    });
+
+    render(<CukieMasterStatusPanel />);
+    await waitFor(() => expect(screen.getByRole('tab', { name: /Ruta Cukies/i })).toBeInTheDocument());
+    const nftTab = screen.getByRole('tab', { name: /Ruta Cukies/i });
+    fireEvent.mouseDown(nftTab, { button: 0, ctrlKey: false });
+    fireEvent.click(nftTab);
+
+    await waitFor(() => expect(screen.getByText('Aporta 4 puntos a tu ruta')).toBeInTheDocument());
+    expect(screen.getByText('Puede aportar 1 punto')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dejar de usar Cukie #42 para Cukie Master' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Usar Cukie #7 para Cukie Master' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Cukie #42' })).toHaveAttribute('src', 'https://example.com/42.png');
   });
 });

--- a/dapp/__tests__/components/landing-header.test.tsx
+++ b/dapp/__tests__/components/landing-header.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import { LandingHeader } from '@/components/landing/header';
 import { PUBLIC_LOCALE_STORAGE_KEY } from '@/lib/public-locale';
@@ -9,9 +9,21 @@ jest.mock('lucide-react', () => ({
   X: ({ className }: { className?: string }) => <div data-testid="x-icon" className={className} />,
 }));
 
-jest.mock('@/components/landing/wallet-connect-dynamic', () => ({
-  LandingWalletConnectButton: () => <button type="button">Wallet</button>,
-}));
+jest.mock('@/components/landing/wallet-connect-dynamic', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { createPortal } = jest.requireActual<typeof import('react-dom')>('react-dom');
+  return {
+    LandingWalletConnectButton: ({ evmOnly }: { evmOnly?: boolean }) => {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <>
+          <button type="button" data-evm-only={String(Boolean(evmOnly))} onClick={() => setOpen(true)}>Wallet</button>
+          {open ? createPortal(<div role="dialog" aria-label="Selector wallet">Selector wallet</div>, document.body) : null}
+        </>
+      );
+    },
+  };
+});
 
 describe('components/landing/LandingHeader', () => {
   beforeEach(() => {
@@ -63,5 +75,44 @@ describe('components/landing/LandingHeader', () => {
       expect(screen.getAllByRole('link', { name: 'Home' }).length).toBeGreaterThan(0);
       expect(document.documentElement.lang).toBe('en');
     });
+  });
+
+  it('mantiene el menú móvil fuera del foco hasta abrirlo y permite cerrarlo con Escape', () => {
+    render(
+      <PublicLocaleProvider>
+        <LandingHeader evmOnly />
+      </PublicLocaleProvider>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Abrir menú' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('dialog', { name: 'Menú' })).not.toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('dialog', { name: 'Menú' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Wallet' }).every((button) => (
+      button.getAttribute('data-evm-only') === 'true'
+    ))).toBe(true);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('dialog', { name: 'Menú' })).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('conserva abierto el selector de wallet al cerrar el drawer móvil', () => {
+    render(
+      <PublicLocaleProvider>
+        <LandingHeader evmOnly />
+      </PublicLocaleProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Abrir menú' }));
+    const drawer = screen.getByRole('dialog', { name: 'Menú' });
+    fireEvent.click(within(drawer).getByRole('button', { name: 'Wallet' }));
+
+    expect(screen.queryByRole('dialog', { name: 'Menú' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Abrir menú' })).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByRole('dialog', { name: 'Selector wallet' })).toBeInTheDocument();
   });
 });

--- a/dapp/__tests__/components/uki-staking-panel.test.tsx
+++ b/dapp/__tests__/components/uki-staking-panel.test.tsx
@@ -11,6 +11,7 @@ import {
 import { UkiStakingPanel } from '@/components/cukie-master/uki-staking-panel';
 import { useHasMounted } from '@/hooks/use-has-mounted';
 import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/providers/auth-provider';
 
 jest.mock('wagmi', () => ({
   useAccount: jest.fn(),
@@ -21,6 +22,7 @@ jest.mock('wagmi', () => ({
 }));
 jest.mock('@/hooks/use-has-mounted');
 jest.mock('@/hooks/use-toast');
+jest.mock('@/providers/auth-provider');
 jest.mock('@/components/landing/wallet-connect-dynamic', () => ({
   LandingWalletConnectButton: ({ evmOnly }: { evmOnly?: boolean }) => (
     <button type="button" data-evm-only={String(Boolean(evmOnly))}>
@@ -46,6 +48,7 @@ jest.mock('lucide-react', () => ({
   AlertTriangle: () => null,
   ArrowDownToLine: () => null,
   ArrowUpFromLine: () => null,
+  Check: () => null,
   ExternalLink: () => null,
   Loader2: () => null,
   ShieldCheck: () => null,
@@ -60,6 +63,7 @@ const mockUseWaitForTransactionReceipt = useWaitForTransactionReceipt as jest.Mo
 const mockUseWriteContract = useWriteContract as jest.MockedFunction<typeof useWriteContract>;
 const mockUseHasMounted = useHasMounted as jest.MockedFunction<typeof useHasMounted>;
 const mockUseToast = useToast as jest.MockedFunction<typeof useToast>;
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 const walletAddress = '0x3333333333333333333333333333333333333333';
 const tokenAddress = '0x1111111111111111111111111111111111111111';
@@ -106,6 +110,13 @@ describe('UkiStakingPanel', () => {
       isSuccess: false,
     } as never);
     mockUseToast.mockReturnValue({ toast } as never);
+    mockUseAuth.mockReturnValue({
+      user: { walletAddress },
+      isLoading: false,
+      isWaitingForApproval: false,
+      walletType: 'evm',
+      fetchUser: jest.fn(),
+    } as never);
     mockUseReadContract.mockImplementation((config) => {
       switch (config?.functionName) {
         case 'ukiToken':
@@ -134,6 +145,23 @@ describe('UkiStakingPanel', () => {
     expect(writeContract).not.toHaveBeenCalled();
   });
 
+  it('offers quick amounts and previews the resulting route capacity with vesting included', () => {
+    render(<UkiStakingPanel routePreview={{
+      currentRequirementRaw: parseUnits('20000', 18).toString(),
+      presaleLockedRaw: parseUnits('20000', 18).toString(),
+      indexedStakedRaw: parseUnits('25000', 18).toString(),
+      allocatedSlots: 2,
+    }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '40.000' }));
+    expect(screen.getByLabelText('Cantidad de UKI')).toHaveValue('40000');
+    expect(screen.getByText(/Capacidad teórica tras confirmar: 4\/5 cupos por UKI/i)).toBeInTheDocument();
+    expect(screen.getByText(/20\.000 en vesting \+ 65\.000 en staking/i)).toBeInTheDocument();
+    expect(screen.getByText('Conectar')).toBeInTheDocument();
+    expect(screen.getByText('Autorizar')).toBeInTheDocument();
+    expect(screen.getAllByText('Depositar')).toHaveLength(2);
+  });
+
   it('switches explicitly to BSC Testnet when the wallet is on another chain', () => {
     mockUseAccount.mockReturnValue({
       address: walletAddress,
@@ -148,6 +176,23 @@ describe('UkiStakingPanel', () => {
       { chainId: 97 },
       expect.objectContaining({ onError: expect.any(Function) }),
     );
+    expect(writeContract).not.toHaveBeenCalled();
+  });
+
+  it('blocks contract writes until the connected EVM wallet has authenticated', () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isLoading: false,
+      isWaitingForApproval: false,
+      walletType: null,
+      fetchUser: jest.fn(),
+    } as never);
+
+    render(<UkiStakingPanel />);
+
+    expect(screen.getByText(/Firma el acceso con esta wallet/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Conectar wallet para gestionar staking/i }))
+      .toHaveAttribute('data-evm-only', 'true');
     expect(writeContract).not.toHaveBeenCalled();
   });
 

--- a/dapp/__tests__/components/uki-staking-panel.test.tsx
+++ b/dapp/__tests__/components/uki-staking-panel.test.tsx
@@ -22,7 +22,11 @@ jest.mock('wagmi', () => ({
 jest.mock('@/hooks/use-has-mounted');
 jest.mock('@/hooks/use-toast');
 jest.mock('@/components/landing/wallet-connect-dynamic', () => ({
-  LandingWalletConnectButton: () => <button type="button">Conectar wallet para gestionar staking</button>,
+  LandingWalletConnectButton: ({ evmOnly }: { evmOnly?: boolean }) => (
+    <button type="button" data-evm-only={String(Boolean(evmOnly))}>
+      Conectar wallet para gestionar staking
+    </button>
+  ),
 }));
 jest.mock('@/components/landing/sale-config', () => ({
   UKI_PRESALE_CHAIN_ID: 97,
@@ -125,7 +129,8 @@ describe('UkiStakingPanel', () => {
 
     render(<UkiStakingPanel />);
 
-    expect(screen.getByRole('button', { name: /Conectar wallet para gestionar staking/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Conectar wallet para gestionar staking/i }))
+      .toHaveAttribute('data-evm-only', 'true');
     expect(writeContract).not.toHaveBeenCalled();
   });
 
@@ -139,8 +144,31 @@ describe('UkiStakingPanel', () => {
     render(<UkiStakingPanel />);
     fireEvent.click(screen.getByRole('button', { name: /Cambiar a BNB Smart Chain Testnet/i }));
 
-    expect(switchChain).toHaveBeenCalledWith({ chainId: 97 });
+    expect(switchChain).toHaveBeenCalledWith(
+      { chainId: 97 },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
     expect(writeContract).not.toHaveBeenCalled();
+  });
+
+  it('explains how to finish the switch when the EVM wallet rejects it', () => {
+    mockUseAccount.mockReturnValue({
+      address: walletAddress,
+      chainId: 56,
+      isConnected: true,
+    } as never);
+
+    render(<UkiStakingPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /Cambiar a BNB Smart Chain Testnet/i }));
+
+    const switchOptions = switchChain.mock.calls[0]?.[1] as { onError?: () => void } | undefined;
+    switchOptions?.onError?.();
+
+    expect(toast).toHaveBeenCalledWith({
+      title: 'No se pudo cambiar la red',
+      description: 'Abre tu wallet y acepta el cambio a BNB Smart Chain Testnet.',
+      variant: 'destructive',
+    });
   });
 
   it('approves only the entered UKI amount when allowance is insufficient', () => {

--- a/dapp/__tests__/components/wallet-connect-button.test.tsx
+++ b/dapp/__tests__/components/wallet-connect-button.test.tsx
@@ -88,4 +88,24 @@ describe('components/landing/WalletConnectButton', () => {
       });
     });
   });
+
+  it('does not offer a native TRON session inside an EVM-only flow', async () => {
+    mockUseAccount.mockReturnValue({ isConnected: false } as any);
+    mockUseTronLink.mockReturnValue({
+      address: 'TJEAyJ111111111111111111111111111VjhM',
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      error: null,
+      isConnected: true,
+      isInstalled: true,
+      isLoading: false,
+    } as any);
+
+    render(<WalletConnectButton evmOnly label="Conectar wallet EVM" />);
+    fireEvent.click(screen.getByRole('button', { name: /Conectar wallet EVM/i }));
+
+    expect(await screen.findByText(/Elige una wallet EVM y acepta el cambio/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /TronLink TRON/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Firmar wallet actual/i })).not.toBeInTheDocument();
+  });
 });

--- a/dapp/__tests__/hooks/use-tronlink.test.tsx
+++ b/dapp/__tests__/hooks/use-tronlink.test.tsx
@@ -1,0 +1,65 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useTronLink } from '@/hooks/use-tronlink';
+
+const tronAddress = 'TJEAyJ111111111111111111111111111VjhM';
+
+describe('useTronLink', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    Object.defineProperty(window, 'tron', {
+      configurable: true,
+      value: {
+        selectedAddress: tronAddress,
+        defaultAddress: { base58: tronAddress },
+        on: jest.fn(),
+        removeListener: jest.fn(),
+      },
+      writable: true,
+    });
+    Object.defineProperty(window, 'tronWeb', {
+      configurable: true,
+      value: {
+        ready: true,
+        defaultAddress: { base58: tronAddress },
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    delete window.tron;
+    delete window.tronWeb;
+  });
+
+  it('keeps every hook instance disconnected until an explicit reconnect', async () => {
+    const first = renderHook(() => useTronLink());
+    const second = renderHook(() => useTronLink());
+
+    expect(first.result.current.address).toBe(tronAddress);
+    expect(second.result.current.address).toBe(tronAddress);
+
+    act(() => first.result.current.disconnect());
+
+    expect(first.result.current.isConnected).toBe(false);
+    expect(second.result.current.isConnected).toBe(false);
+    expect(window.localStorage.getItem('cukies:tronlink:disconnected')).toBe('1');
+
+    first.unmount();
+    const remounted = renderHook(() => useTronLink());
+    expect(remounted.result.current.isConnected).toBe(false);
+    expect(remounted.result.current.address).toBeNull();
+
+    await act(async () => {
+      await remounted.result.current.connect();
+    });
+
+    expect(remounted.result.current.isConnected).toBe(true);
+    expect(remounted.result.current.address).toBe(tronAddress);
+    expect(window.localStorage.getItem('cukies:tronlink:disconnected')).toBeNull();
+
+    second.unmount();
+    remounted.unmount();
+  });
+});

--- a/dapp/__tests__/lib/cukie-master-nft-operations.test.ts
+++ b/dapp/__tests__/lib/cukie-master-nft-operations.test.ts
@@ -1,0 +1,87 @@
+import { getCukieMasterNftRouteSummaryFromDb } from '@/lib/nft-inventory';
+import { getEconomyDb } from '@/lib/indexer-db/mongodb';
+import { getCukieMasterNftInventory } from '@/lib/uki-economy/cukie-master/nft-operations';
+
+jest.mock('@/lib/nft-inventory', () => ({
+  getCukieMasterNftRouteSummaryFromDb: jest.fn(),
+}));
+jest.mock('@/lib/indexer-db/mongodb', () => ({
+  getEconomyDb: jest.fn(),
+}));
+
+const mockSummary = getCukieMasterNftRouteSummaryFromDb as jest.MockedFunction<
+  typeof getCukieMasterNftRouteSummaryFromDb
+>;
+const mockDb = getEconomyDb as jest.MockedFunction<typeof getEconomyDb>;
+const wallet = '0x1111111111111111111111111111111111111111';
+
+function asset(
+  assetId: string,
+  tokenId: string,
+  rarity: string,
+  canonicalState: string,
+  rarityPoints: number,
+) {
+  return { assetId, tokenId, rarity, canonicalState, rarityPoints } as never;
+}
+
+describe('getCukieMasterNftInventory', () => {
+  it('separates potential rarity points from the contribution retained by compatible locks', async () => {
+    mockSummary.mockResolvedValue({
+      walletNormalized: wallet,
+      eligibleAssets: [
+        asset('cukies:soft', '42', 'rare', 'soft_staked', 4),
+        asset('cukies:game', '43', 'epic', 'assigned_to_game', 7),
+        asset('cukies:available', '44', 'common', 'available', 1),
+      ],
+      rejectedAssets: [{
+        asset: asset('cukies:listed', '45', 'rare', 'listed', 4),
+        blockers: ['listed'],
+      }],
+    } as never);
+    const locks = [
+      {
+        assetId: 'cukies:soft', lockId: 'lock-soft', status: 'active', reason: 'soft_stake',
+        ownerNormalized: wallet, fencingToken: 2,
+      },
+      {
+        assetId: 'cukies:game', lockId: 'lock-game', status: 'active', reason: 'game_assignment',
+        ownerNormalized: wallet, fencingToken: 3, retainsSoftStakeEntitlement: true,
+      },
+    ];
+    mockDb.mockResolvedValue({
+      collection: () => ({
+        find: () => ({ toArray: async () => locks }),
+      }),
+    } as never);
+
+    const inventory = await getCukieMasterNftInventory(wallet, new Date('2026-08-08T10:00:00.000Z'));
+    const byId = new Map(inventory.map((item) => [item.assetId, item]));
+
+    expect(byId.get('cukies:soft')).toEqual(expect.objectContaining({
+      imageUrl: expect.stringContaining('/42.png'),
+      rarityPoints: 4,
+      contributesToCukieMaster: true,
+      contributionPoints: 4,
+      canUnstake: true,
+    }));
+    expect(byId.get('cukies:game')).toEqual(expect.objectContaining({
+      rarityPoints: 7,
+      contributesToCukieMaster: true,
+      contributionPoints: 7,
+      canUnstake: false,
+    }));
+    expect(byId.get('cukies:available')).toEqual(expect.objectContaining({
+      rarityPoints: 1,
+      contributesToCukieMaster: false,
+      contributionPoints: 0,
+      canSoftStake: true,
+    }));
+    expect(byId.get('cukies:listed')).toEqual(expect.objectContaining({
+      rarityPoints: 4,
+      contributesToCukieMaster: false,
+      contributionPoints: 0,
+      blockers: ['listed'],
+    }));
+  });
+});

--- a/dapp/src/app/cukie-master/page.tsx
+++ b/dapp/src/app/cukie-master/page.tsx
@@ -1,45 +1,46 @@
 import type { Metadata } from 'next';
 import { CompetitionCreditPanel } from '@/components/cukie-master/credit-panel';
-import { CukieMasterStatusPanel } from '@/components/cukie-master/status-panel';
-import { UkiStakingPanel } from '@/components/cukie-master/uki-staking-panel';
+import { CukieMasterWorkspace } from '@/components/cukie-master/workspace';
 import { LaunchInfoPage } from '@/components/launch/info-page';
+import { UKI_PRESALE_CHAIN_LABEL } from '@/components/landing/sale-config';
 
 export const metadata: Metadata = {
   title: 'Cukie Master | Cukies World',
   description: 'Requisitos, cupos y créditos de competición para Cukie Master.',
 };
 
+export const dynamic = 'force-dynamic';
+
 export default function CukieMasterPage() {
+  const creditsEnabled = process.env.COMPETITION_CREDITS_RUNTIME_ENABLED?.trim().toLowerCase() === 'true';
+  const isStaging = process.env.APP_ENV?.trim().toLowerCase() === 'staging';
+
   return (
     <LaunchInfoPage
-      eyebrow="Funcional en BSC Testnet"
+      variant="workspace"
+      eyebrow={`${isStaging ? 'Área de pruebas' : 'Red configurada'} · ${UKI_PRESALE_CHAIN_LABEL}`}
       title="Cukie Master"
-      subtitle="Gestiona el staking de UKI, consulta tus cupos por UKI o Cukies Originales y revisa los créditos de competición desde un único apartado."
+      subtitle="Comprueba primero qué activos ya te cuentan. Después completa lo que te falte con UKI o Cukies Originales, sin hacer staking innecesario."
       heroImage="/brand/generated/uki-cukie-master-scene-v2.png"
       heroAlt="Escena Cukie Master con token UKI y bóveda"
-      primaryCta={{ label: 'Gestionar staking', href: '#uki-staking' }}
-      secondaryCta={{ label: 'Ver mis cupos', href: '#mi-estado' }}
+      primaryCta={{ label: 'Ver mi estado', href: '#mi-estado' }}
+      secondaryCta={{ label: 'Cómo funciona', href: '#como-funciona' }}
       metrics={[
-        { label: 'Ruta UKI', value: '500 cupos', helper: '20,000 UKI por cupo inicial' },
-        { label: 'Ruta Cukies', value: '500 cupos', helper: '3 puntos en Cukies Originales' },
-        { label: 'Límite wallet', value: '10 cupos', helper: 'Máximo 5 por cada ruta' },
-        { label: 'Créditos', value: '100 diarios', helper: 'Por cupo activo tras 24h' },
+        { label: 'Ruta UKI', value: '20.000 UKI', helper: 'Requisito inicial por cupo' },
+        { label: 'Ruta Cukies', value: '3 puntos', helper: 'Requisito inicial por cupo' },
+        { label: 'Límite por wallet', value: '10 cupos', helper: 'Máximo 5 por cada ruta' },
+        { label: 'Validación inicial', value: '24 horas', helper: 'Antes de que un cupo pase a activo' },
       ]}
-      beforeSections={
-        <>
-          <UkiStakingPanel />
-          <CukieMasterStatusPanel />
-          <CompetitionCreditPanel />
-        </>
-      }
+      beforeSections={<CukieMasterWorkspace testnetOnly={isStaging} />}
+      afterSections={creditsEnabled ? <CompetitionCreditPanel /> : undefined}
       sections={[
         {
           title: 'Ruta UKI',
-          text: 'Los UKI comprados en preventa cuentan para Cukie Master aunque estén en vesting.',
+          text: 'Los UKI de preventa que siguen en vesting ya cuentan. Solo necesitas añadir staking si aún te falta cantidad para el siguiente cupo.',
           bullets: [
-            'Requisito inicial: 20,000 UKI por cupo.',
-            'Se suma UKI en vesting y UKI liberado o stakeado adicional.',
-            'El exceso no da beneficios extra, pero sirve como margen si sube el requisito.',
+            'Se suman los UKI en vesting y los UKI depositados en staking.',
+            'El panel muestra la suma completa y el déficit exacto para el siguiente cupo.',
+            'Puedes retirar UKI, pero tus cupos se recalcularán con la nueva cantidad.',
           ],
         },
         {
@@ -60,21 +61,23 @@ export default function CukieMasterPage() {
         {
           title: 'Requisito dinámico',
           bullets: [
-            'Si una ruta llena sus cupos y se decide no abrir más, el requisito puede subir.',
-            'La UI debe mostrar requisito anterior, nuevo requisito y cupos que se conservan.',
-            'Cuando el requisito sube, hay una ventana de 48 horas para ajustar staking.',
+            'Si una ruta completa su capacidad, el requisito de entrada puede actualizarse.',
+            'Verás el requisito vigente, cualquier cambio pendiente y los cupos que conservas.',
+            'Si cambia el requisito, tendrás una ventana de 48 horas para ajustar tus activos.',
           ],
         },
         {
           title: 'Créditos de competición',
           bullets: [
-            'Cada cupo activo recibe 100 créditos diarios.',
-            'La primera asignación exige ser Cukie Master al menos 24 horas.',
-            'Los créditos pueden usarse para jugar o aportarse al pool de créditos.',
+            creditsEnabled
+              ? 'La asignación de créditos está activa en este entorno y aparecerá debajo de las reglas.'
+              : 'La asignación de créditos todavía no está activa en este entorno de pruebas.',
+            'Cuando se habilite, solo contarán los cupos que ya hayan pasado a estado activo.',
+            'No mostramos saldos ni recompensas estimadas mientras el servicio no está habilitado.',
           ],
         },
       ]}
-      note="Cukie Master no debe comunicarse como rentabilidad garantizada. La UI debe hablar de cupos, créditos, reglas vigentes, estimaciones y estados pendientes."
+      note="Cukie Master da acceso a cupos y utilidades dentro del ecosistema. No implica una rentabilidad garantizada. Comprueba siempre el estado y los requisitos vigentes antes de confirmar una operación."
     />
   );
 }

--- a/dapp/src/app/globals.css
+++ b/dapp/src/app/globals.css
@@ -331,6 +331,11 @@ body {
       linear-gradient(180deg, #04111a 0%, #04030a 48%, #010608 100%);
   }
 
+  .uki-landing :where(a, button, input, select, summary):focus-visible {
+    outline: 2px solid var(--uki-cyan);
+    outline-offset: 3px;
+  }
+
   .uki-container {
     width: min(100% - 5rem, 1440px);
     margin-inline: auto;
@@ -385,8 +390,13 @@ body {
   }
 
   .uki-nav-link {
+    display: inline-flex;
+    min-height: 2.75rem;
+    min-width: 2.75rem;
+    align-items: center;
+    justify-content: center;
     border-bottom: 1px solid transparent;
-    padding-bottom: 0.5rem;
+    padding-inline: 0.15rem;
     font-size: 0.72rem;
     font-weight: 800;
     letter-spacing: 0.18em;
@@ -422,7 +432,8 @@ body {
   }
 
   .uki-language-switcher button {
-    min-width: 2.35rem;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
     border: 0;
     border-radius: 999px;
     background: transparent;

--- a/dapp/src/components/cukie-master/status-panel.tsx
+++ b/dapp/src/components/cukie-master/status-panel.tsx
@@ -1,20 +1,41 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { AlertTriangle, CheckCircle2, Clock3, Loader2, Lock, Unlock } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  Loader2,
+  Lock,
+  ShieldCheck,
+  Sparkles,
+  Unlock,
+} from 'lucide-react';
 import { formatUnits } from 'viem';
 
-import { Panel } from '@/components/landing/primitives';
+import { CukiImage } from '@/components/legacy-marketplace/cuki-image';
+import { LandingButton, Panel } from '@/components/landing/primitives';
+import { LandingWalletConnectButton } from '@/components/landing/wallet-connect-dynamic';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import type { UkiRoutePreview } from '@/components/cukie-master/types';
 import { useAuth } from '@/providers/auth-provider';
 
+const MAX_ROUTE_SLOTS = 5;
+const CUKIE_MASTER_REFRESH_EVENT = 'cukies:cukie-master:refresh';
+const STAKING_REFRESH_DELAYS_MS = [0, 3_000, 8_000, 15_000] as const;
+
+type RouteKey = 'uki' | 'nft';
+
 type PublicSlot = {
-  route: 'uki' | 'nft';
+  route: RouteKey;
   ordinal: number;
   eligibilityEpoch: number;
   status: 'qualifying' | 'active' | 'grace' | 'inactive';
   creditEligibleFrom: string;
   graceEndsAt: string | null;
 };
+
+type Requirement = { route: 'uki'; ukiRaw: string } | { route: 'nft'; nftPoints: number };
 
 type PublicRoute = {
   position: null | {
@@ -33,7 +54,7 @@ type PublicRoute = {
   source: {
     complete: boolean;
     status: 'available' | 'unavailable';
-    route?: 'uki' | 'nft';
+    route?: RouteKey;
     totalUkiRaw?: string;
     presaleLockedRaw?: string;
     stakedUkiRaw?: string;
@@ -41,14 +62,16 @@ type PublicRoute = {
   };
 };
 
-type Requirement = { route: 'uki'; ukiRaw: string } | { route: 'nft'; nftPoints: number };
-
 type PublicNft = {
   assetId: string;
   tokenId: string | null;
+  imageUrl: string | null;
   rarity: string;
   rarityPoints: number | null;
+  contributesToCukieMaster: boolean;
+  contributionPoints: number;
   state: string;
+  blockers: string[];
   lock: null | { lockId: string; fencingToken: number };
   canSoftStake: boolean;
   canUnstake: boolean;
@@ -76,23 +99,52 @@ function dateLabel(value: string | null) {
   }).format(date);
 }
 
-export function CukieMasterStatusPanel() {
+function slotCounts(route: PublicRoute) {
+  return route.slots.reduce(
+    (counts, slot) => ({ ...counts, [slot.status]: counts[slot.status] + 1 }),
+    { active: 0, qualifying: 0, grace: 0, inactive: 0 },
+  );
+}
+
+export function CukieMasterStatusPanel({
+  onUkiRouteData,
+}: {
+  onUkiRouteData?: (preview: UkiRoutePreview | null) => void;
+} = {}) {
   const { user, isLoading: authLoading } = useAuth();
   const [status, setStatus] = useState<PublicStatus | null>(null);
   const [state, setState] = useState<'idle' | 'loading' | 'ready' | 'unavailable'>('idle');
+  const [activeRoute, setActiveRoute] = useState<RouteKey>('uki');
   const [reloadNonce, setReloadNonce] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const [mutatingAsset, setMutatingAsset] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
+  const hasReadyStatusRef = useRef(false);
+  const loadedWalletRef = useRef<string | null>(null);
+  const requestIdRef = useRef(0);
+  const refreshTimersRef = useRef<number[]>([]);
 
   useEffect(() => {
     if (authLoading) return;
     if (!user?.walletAddress) {
+      hasReadyStatusRef.current = false;
+      loadedWalletRef.current = null;
       setStatus(null);
       setState('idle');
+      setIsRefreshing(false);
       return;
     }
+    const walletNormalized = user.walletAddress.toLowerCase();
+    const backgroundRefresh = hasReadyStatusRef.current
+      && loadedWalletRef.current === walletNormalized;
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
     const controller = new AbortController();
-    setState('loading');
+    if (backgroundRefresh) setIsRefreshing(true);
+    else {
+      setStatus(null);
+      setState('loading');
+    }
     fetch(
       `/api/economy/v1/cukie-master?walletAddress=${encodeURIComponent(user.walletAddress)}`,
       { cache: 'no-store', credentials: 'same-origin', signal: controller.signal },
@@ -100,16 +152,73 @@ export function CukieMasterStatusPanel() {
       .then(async (response) => {
         const body = await response.json() as { data?: PublicStatus };
         if (!response.ok || !body.data) throw new Error('CUKIE_MASTER_UNAVAILABLE');
+        hasReadyStatusRef.current = true;
+        loadedWalletRef.current = walletNormalized;
         setStatus(body.data);
         setState('ready');
       })
       .catch((error: unknown) => {
         if (error instanceof DOMException && error.name === 'AbortError') return;
-        setStatus(null);
-        setState('unavailable');
+        if (!backgroundRefresh) {
+          hasReadyStatusRef.current = false;
+          loadedWalletRef.current = null;
+          setStatus(null);
+          setState('unavailable');
+        }
+      })
+      .finally(() => {
+        if (requestIdRef.current === requestId) setIsRefreshing(false);
       });
     return () => controller.abort();
   }, [authLoading, reloadNonce, user?.walletAddress]);
+
+  useEffect(() => {
+    const clearRefreshTimers = () => {
+      refreshTimersRef.current.forEach((timer) => window.clearTimeout(timer));
+      refreshTimersRef.current = [];
+    };
+    const refresh = () => {
+      clearRefreshTimers();
+      refreshTimersRef.current = STAKING_REFRESH_DELAYS_MS.map((delay) => window.setTimeout(
+        () => setReloadNonce((value) => value + 1),
+        delay,
+      ));
+    };
+    window.addEventListener(CUKIE_MASTER_REFRESH_EVENT, refresh);
+    return () => {
+      window.removeEventListener(CUKIE_MASTER_REFRESH_EVENT, refresh);
+      clearRefreshTimers();
+    };
+  }, []);
+
+  useEffect(() => {
+    const route = status?.routes.uki;
+    if (
+      state !== 'ready'
+      || !route?.source.complete
+      || route.currentRequirement.route !== 'uki'
+      || route.source.presaleLockedRaw === undefined
+      || route.source.stakedUkiRaw === undefined
+    ) {
+      onUkiRouteData?.(null);
+      return;
+    }
+    onUkiRouteData?.({
+      currentRequirementRaw: route.currentRequirement.ukiRaw,
+      presaleLockedRaw: route.source.presaleLockedRaw,
+      indexedStakedRaw: route.source.stakedUkiRaw,
+      allocatedSlots: route.position?.allocatedSlots ?? 0,
+    });
+  }, [onUkiRouteData, state, status]);
+
+  const inventory = useMemo(() => [...(status?.nftInventory ?? [])].sort((left, right) => {
+    if (left.contributesToCukieMaster !== right.contributesToCukieMaster) {
+      return left.contributesToCukieMaster ? -1 : 1;
+    }
+    if (left.canSoftStake !== right.canSoftStake) return left.canSoftStake ? -1 : 1;
+    return (right.rarityPoints ?? -1) - (left.rarityPoints ?? -1)
+      || left.assetId.localeCompare(right.assetId);
+  }), [status?.nftInventory]);
 
   async function mutateNft(asset: PublicNft, operation: 'soft_stake' | 'unstake') {
     if (!user?.walletAddress || mutatingAsset) return;
@@ -135,225 +244,433 @@ export function CukieMasterStatusPanel() {
       if (!response.ok) throw new Error('NFT_OPERATION_FAILED');
       setReloadNonce((value) => value + 1);
     } catch {
-      setMutationError('No se pudo completar la operación NFT con garantías. Revisa el estado e inténtalo de nuevo.');
+      setMutationError('No se pudo completar la operación. El estado del NFT no ha cambiado; inténtalo de nuevo.');
     } finally {
       setMutatingAsset(null);
     }
   }
 
+  const totalCounts = status ? {
+    active: slotCounts(status.routes.uki).active + slotCounts(status.routes.nft).active,
+    qualifying: slotCounts(status.routes.uki).qualifying + slotCounts(status.routes.nft).qualifying,
+    grace: slotCounts(status.routes.uki).grace + slotCounts(status.routes.nft).grace,
+  } : null;
+
   return (
-    <section id="mi-estado" className="uki-container relative z-[2] pb-10">
-      <Panel innerClassName="p-5 sm:p-7">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <p className="uki-label">Estado verificable</p>
-            <h2 className="mt-2 font-headline text-2xl font-black uppercase text-[var(--uki-cream)]">
-              Mis cupos Cukie Master
+    <section id="mi-estado" className="uki-container relative z-[2] min-w-0 scroll-mt-28 pb-8">
+      <Panel className="min-w-0" innerClassName="min-w-0 p-5 sm:p-7">
+        <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div className="min-w-0">
+            <p className="text-xs font-black uppercase tracking-[0.12em] text-[var(--uki-muted)]">Tu estado personal</p>
+            <h2 className="mt-2 break-words font-headline text-2xl font-black uppercase text-[var(--uki-cream)] sm:text-3xl">
+              Tus cupos Cukie Master
             </h2>
+            <p className="mt-2 max-w-2xl text-sm font-semibold leading-relaxed text-[var(--uki-text)]">
+              Revisamos vesting, staking e inventario antes de recomendarte ninguna acción.
+            </p>
           </div>
           {status ? (
-            <p className="text-xs font-semibold text-[var(--uki-muted)]">
-              Wallet {shortWallet(status.walletNormalized)}
-            </p>
+            <div className="flex min-w-0 flex-col items-start gap-2 sm:items-end">
+              <p className="max-w-full truncate text-xs font-semibold text-[var(--uki-muted)]">
+                Wallet {shortWallet(status.walletNormalized)}
+              </p>
+              <button
+                type="button"
+                disabled={isRefreshing}
+                onClick={() => setReloadNonce((value) => value + 1)}
+                className="inline-flex min-h-11 min-w-11 items-center justify-center gap-2 rounded-[7px] border border-white/10 px-3 text-xs font-black uppercase text-[var(--uki-text)] hover:border-[var(--uki-cyan-border)] hover:text-[var(--uki-cyan)] disabled:cursor-wait disabled:opacity-60"
+              >
+                {isRefreshing ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+                {isRefreshing ? 'Actualizando' : 'Actualizar estado'}
+              </button>
+            </div>
           ) : null}
         </div>
 
         {authLoading || state === 'loading' ? (
-          <div className="mt-6 flex items-center gap-3 text-sm font-semibold text-[var(--uki-text)]">
-            <Loader2 className="h-5 w-5 animate-spin text-[var(--uki-cyan)]" />
-            Verificando fuentes e inventario…
+          <div role="status" aria-live="polite" className="mt-6 flex items-center gap-3 text-sm font-semibold text-[var(--uki-text)]">
+            <Loader2 className="h-5 w-5 animate-spin text-[var(--uki-cyan)]" aria-hidden="true" />
+            Verificando tus activos y cupos…
           </div>
         ) : null}
 
         {!authLoading && state === 'idle' ? (
-          <p className="mt-6 text-sm font-semibold leading-relaxed text-[var(--uki-text)]">
-            Conecta y autentica tu wallet para consultar cupos. No se muestra ninguna estimación
-            si las fuentes on-chain o el inventario no están completos.
-          </p>
+          <div className="mt-6 grid min-w-0 gap-4 rounded-[10px] border border-[var(--uki-cyan-border)] bg-black/20 p-4 sm:p-5 lg:grid-cols-[1fr_auto] lg:items-center">
+            <div className="min-w-0">
+              <p className="font-headline text-lg font-black uppercase text-[var(--uki-cream)]">Conecta una wallet EVM</p>
+              <p className="mt-2 text-sm font-semibold leading-relaxed text-[var(--uki-text)]">
+                Firma el acceso para consultar datos personales. No calculamos cupos con información incompleta.
+              </p>
+            </div>
+            <LandingWalletConnectButton
+              className="min-h-11 justify-center"
+              evmOnly
+              label="Conectar wallet EVM"
+              compactLabel="Conectar"
+              showCompactText={false}
+            />
+          </div>
         ) : null}
 
         {state === 'unavailable' ? (
-          <div className="mt-6 flex gap-3 rounded-[8px] border border-amber-300/30 bg-amber-300/10 p-4">
-            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-300" />
+          <div role="alert" className="mt-6 flex gap-3 rounded-[8px] border border-amber-300/30 bg-amber-300/10 p-4">
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-300" aria-hidden="true" />
             <p className="text-sm font-semibold leading-relaxed text-[var(--uki-text)]">
-              El estado económico no está disponible con garantías ahora mismo. Los cupos
-              persistidos no se alteran y volveremos a mostrarlos cuando indexador, bootstrap y
-              reconciliación estén saludables.
+              No podemos verificar tu estado económico ahora mismo. No mostramos cifras antiguas ni cambiamos tus cupos; vuelve a intentarlo en unos minutos.
             </p>
           </div>
         ) : null}
 
-        {state === 'ready' && status ? (
-          <div className="mt-6 grid gap-4 lg:grid-cols-[0.72fr_1fr_1fr]">
-            <div className="rounded-[8px] border border-[var(--uki-cyan-border)] bg-black/20 p-5">
-              <p className="uki-label">Total activo</p>
-              <p className="mt-2 font-headline text-4xl font-black text-[var(--uki-cyan)]">
-                {status.totals.allocatedSlots}
-              </p>
-              <p className="mt-2 text-xs font-semibold text-[var(--uki-muted)]">
-                de {status.totals.maxPotentialSlots} posibles, máximo 5 por ruta
-              </p>
+        {state === 'ready' && status && totalCounts ? (
+          <>
+            <div className="mt-6 grid min-w-0 gap-3 sm:grid-cols-3">
+              <StatusMetric
+                label="Cupos activos"
+                value={`${totalCounts.active}/${status.totals.maxPotentialSlots}`}
+                helper={`${status.totals.allocatedSlots} asignados entre las dos rutas`}
+                tone="cyan"
+              />
+              <StatusMetric
+                label="En validación"
+                value={String(totalCounts.qualifying)}
+                helper="Pendientes de completar las primeras 24 horas"
+              />
+              <StatusMetric
+                label="En gracia"
+                value={String(totalCounts.grace)}
+                helper="Cupos que aún puedes conservar ajustando activos"
+                tone={totalCounts.grace > 0 ? 'warning' : 'neutral'}
+              />
             </div>
-            <RouteCard label="Ruta UKI" route={status.routes.uki} />
-            <RouteCard label="Ruta Cukies" route={status.routes.nft} />
-          </div>
-        ) : null}
 
-        {state === 'ready' && status ? (
-          <div className="mt-4 rounded-[8px] border border-white/10 bg-black/20 p-5">
-            <div>
-              <p className="uki-label">Inventario Original BSC</p>
-              <h3 className="mt-2 font-headline text-xl font-black uppercase text-[var(--uki-cream)]">
-                Soft-staking Cukies
-              </h3>
-              <p className="mt-2 text-xs font-semibold leading-relaxed text-[var(--uki-muted)]">
-                La operación solo bloquea el uso económico del NFT; nunca transfiere el token ni firma automáticamente.
-              </p>
-            </div>
-            {mutationError ? (
-              <p role="alert" className="mt-3 text-sm font-semibold text-amber-300">{mutationError}</p>
-            ) : null}
-            <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-              {status.nftInventory.length === 0 ? (
-                <p className="text-sm font-semibold text-[var(--uki-muted)]">Sin Cukies Originales BSC operables.</p>
-              ) : status.nftInventory.map((asset) => (
-                <div key={asset.assetId} className="flex items-center justify-between gap-3 rounded-[8px] border border-white/10 p-3">
-                  <div>
-                    <p className="text-sm font-bold text-[var(--uki-cream)]">
-                      Cukie #{asset.tokenId ?? asset.assetId.slice(-8)}
-                    </p>
-                    <p className="text-xs font-semibold capitalize text-[var(--uki-muted)]">
-                      {asset.rarity} · {asset.rarityPoints ?? 0} puntos · {asset.state}
-                    </p>
-                  </div>
-                  {asset.canSoftStake ? (
-                    <button
-                      type="button"
-                      disabled={Boolean(mutatingAsset)}
-                      onClick={() => void mutateNft(asset, 'soft_stake')}
-                      className="inline-flex items-center gap-1.5 rounded-[7px] border border-[var(--uki-cyan-border)] px-3 py-2 text-xs font-black uppercase text-[var(--uki-cyan)] disabled:opacity-50"
-                    >
-                      {mutatingAsset === asset.assetId ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Lock className="h-3.5 w-3.5" />}
-                      Activar
-                    </button>
-                  ) : asset.canUnstake ? (
-                    <button
-                      type="button"
-                      disabled={Boolean(mutatingAsset)}
-                      onClick={() => void mutateNft(asset, 'unstake')}
-                      className="inline-flex items-center gap-1.5 rounded-[7px] border border-white/15 px-3 py-2 text-xs font-black uppercase text-[var(--uki-text)] disabled:opacity-50"
-                    >
-                      {mutatingAsset === asset.assetId ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Unlock className="h-3.5 w-3.5" />}
-                      Retirar
-                    </button>
-                  ) : (
-                    <span className="text-[10px] font-black uppercase text-[var(--uki-muted)]">No disponible</span>
-                  )}
+            <Tabs value={activeRoute} onValueChange={(value) => setActiveRoute(value as RouteKey)} className="mt-5 min-w-0">
+              <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                  <p className="text-xs font-black uppercase tracking-[0.12em] text-[var(--uki-muted)]">Elige una ruta</p>
+                  <h3 className="mt-1 font-headline text-xl font-black uppercase text-[var(--uki-cream)]">Estado y siguiente acción</h3>
                 </div>
-              ))}
-            </div>
-          </div>
+                <p className="text-xs font-semibold text-[var(--uki-muted)]">Máximo {MAX_ROUTE_SLOTS} cupos por ruta</p>
+              </div>
+              <TabsList className="mt-4 grid h-auto w-full min-w-0 grid-cols-1 gap-3 bg-transparent p-0 sm:grid-cols-2">
+                <RouteTab value="uki" label="Ruta UKI" route={status.routes.uki} />
+                <RouteTab value="nft" label="Ruta Cukies" route={status.routes.nft} />
+              </TabsList>
+
+              <TabsContent value="uki" className="mt-4 min-w-0">
+                <RouteDetail label="Ruta UKI" route={status.routes.uki} />
+                <div className="mt-4 flex flex-col gap-3 rounded-[8px] border border-[var(--uki-cyan-border)] bg-[var(--uki-cyan-soft)] p-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm font-black text-[var(--uki-cream)]">¿Te faltan UKI para el siguiente cupo?</p>
+                    <p className="mt-1 text-xs font-semibold leading-relaxed text-[var(--uki-muted)]">El vesting ya está incluido. Deposita únicamente el déficit que quieras cubrir.</p>
+                  </div>
+                  <LandingButton href="#uki-staking" className="shrink-0">Gestionar staking</LandingButton>
+                </div>
+              </TabsContent>
+
+              <TabsContent value="nft" className="mt-4 min-w-0">
+                <RouteDetail label="Ruta Cukies" route={status.routes.nft} />
+                <NftInventory
+                  assets={inventory}
+                  activePoints={status.routes.nft.source.originalCukiePoints}
+                  mutatingAsset={mutatingAsset}
+                  mutationError={mutationError}
+                  onMutate={mutateNft}
+                />
+              </TabsContent>
+            </Tabs>
+          </>
         ) : null}
       </Panel>
     </section>
   );
 }
 
-function RouteCard({ label, route }: { label: string; route: PublicRoute }) {
-  const ukiBreakdown = getUkiBreakdown(route);
+function StatusMetric({
+  label,
+  value,
+  helper,
+  tone = 'neutral',
+}: {
+  label: string;
+  value: string;
+  helper: string;
+  tone?: 'cyan' | 'warning' | 'neutral';
+}) {
+  const valueClass = tone === 'cyan'
+    ? 'text-[var(--uki-cyan)]'
+    : tone === 'warning'
+      ? 'text-amber-300'
+      : 'text-[var(--uki-cream)]';
   return (
-    <div className="rounded-[8px] border border-white/10 bg-black/20 p-5">
-      <div className="flex items-center justify-between gap-3">
-        <p className="font-headline text-lg font-black uppercase text-[var(--uki-cream)]">{label}</p>
-        {route.source.complete ? (
-          <CheckCircle2 className="h-5 w-5 text-[var(--uki-cyan)]" />
-        ) : (
-          <AlertTriangle className="h-5 w-5 text-amber-300" />
-        )}
-      </div>
-      <p className="mt-3 text-3xl font-black text-[var(--uki-gold)]">
-        {route.position?.allocatedSlots ?? 0}
-      </p>
-      <p className="text-xs font-semibold text-[var(--uki-muted)]">cupos asignados</p>
-      <dl className="mt-4 grid gap-2 text-xs font-semibold">
-        <div className="flex justify-between gap-3">
-          <dt className="text-[var(--uki-muted)]">Requisito actual</dt>
-          <dd className="text-right text-[var(--uki-text)]">{requirementLabel(route.currentRequirement)}</dd>
-        </div>
-        {route.pendingRequirement ? (
-          <div className="flex justify-between gap-3">
-            <dt className="text-amber-300">Nuevo requisito</dt>
-            <dd className="text-right text-amber-200">
-              {requirementLabel(route.pendingRequirement)} · hasta {dateLabel(route.requirementGraceEndsAt) ?? '48h'}
-            </dd>
-          </div>
-        ) : null}
-        <div className="flex justify-between gap-3">
-          <dt className="text-[var(--uki-muted)]">Cupos protegidos</dt>
-          <dd className="text-right text-[var(--uki-text)]">{route.position?.protectedSlots ?? 0}</dd>
-        </div>
-        <div className="flex justify-between gap-3">
-          <dt className="text-[var(--uki-muted)]">
-            {route.deficitToPreserveSlots ? 'Déficit para conservar cupos' : 'Déficit próximo cupo'}
-          </dt>
-          <dd className="text-right text-[var(--uki-text)]">
-            {route.deficitToPreserveSlots
-              ? requirementLabel(route.deficitToPreserveSlots)
-              : route.deficitToNextSlot
-                ? requirementLabel(route.deficitToNextSlot)
-                : route.source.complete
-                  ? 'Máximo alcanzado'
-                  : 'No disponible'}
-          </dd>
-        </div>
-      </dl>
-      {ukiBreakdown ? (
-        <dl className="mt-4 grid grid-cols-2 gap-2 border-t border-white/10 pt-4 text-xs font-semibold">
-          <SourceMetric label="UKI computables" value={ukiBreakdown.total} />
-          <SourceMetric label="Exceso tras cupos" value={ukiBreakdown.excess} />
-          <SourceMetric label="En vesting" value={ukiBreakdown.locked} />
-          <SourceMetric label="Staking indexado" value={ukiBreakdown.staked} />
-        </dl>
-      ) : null}
-      <div className="mt-4 space-y-2">
-        {route.slots.length === 0 ? (
-          <p className="text-xs font-semibold text-[var(--uki-muted)]">Sin cupos en esta ruta.</p>
-        ) : route.slots.map((slot) => (
-          <div key={`${slot.route}:${slot.ordinal}:${slot.eligibilityEpoch}`} className="flex items-center justify-between gap-3 text-xs font-semibold">
-            <span className="text-[var(--uki-text)]">Cupo {slot.ordinal}</span>
-            <span className="flex items-center gap-1.5 text-[var(--uki-muted)]">
-              <Clock3 className="h-3.5 w-3.5" />
-              {slot.status === 'active'
-                ? 'Activo'
-                : slot.status === 'grace'
-                  ? `Gracia hasta ${dateLabel(slot.graceEndsAt) ?? 'pendiente'}`
-                  : slot.status === 'qualifying'
-                    ? `Disponible ${dateLabel(slot.creditEligibleFrom) ?? 'tras 24h'}`
-                    : 'Inactivo'}
+    <div className="min-w-0 rounded-[8px] border border-white/10 bg-black/20 p-4">
+      <p className="text-xs font-black uppercase tracking-[0.1em] text-[var(--uki-muted)]">{label}</p>
+      <p className={`mt-2 font-headline text-3xl font-black ${valueClass}`}>{value}</p>
+      <p className="mt-2 text-xs font-semibold leading-relaxed text-[var(--uki-muted)]">{helper}</p>
+    </div>
+  );
+}
+
+function RouteTab({ value, label, route }: { value: RouteKey; label: string; route: PublicRoute }) {
+  const allocated = route.position?.allocatedSlots ?? 0;
+  const counts = slotCounts(route);
+  return (
+    <TabsTrigger
+      value={value}
+      className="group min-h-[7.5rem] min-w-0 whitespace-normal rounded-[10px] border border-white/10 bg-black/20 p-4 text-left text-[var(--uki-text)] shadow-none data-[state=active]:border-[var(--uki-cyan)] data-[state=active]:bg-[var(--uki-cyan-soft)] data-[state=active]:text-[var(--uki-cream)]"
+    >
+      <span className="block min-w-0 w-full">
+        <span className="flex items-center justify-between gap-3">
+          <span className="font-headline text-lg font-black uppercase">{label}</span>
+          {route.source.complete
+            ? <CheckCircle2 className="h-5 w-5 shrink-0 text-[var(--uki-cyan)]" aria-hidden="true" />
+            : <AlertTriangle className="h-5 w-5 shrink-0 text-amber-300" aria-hidden="true" />}
+        </span>
+        <span className="mt-2 flex items-end justify-between gap-3">
+          <span className="font-headline text-2xl font-black text-[var(--uki-gold)]">{allocated}/{MAX_ROUTE_SLOTS}</span>
+          <span className="text-xs font-semibold text-[var(--uki-muted)]">{counts.active} activos · {counts.qualifying} validando</span>
+        </span>
+        <span
+          role="progressbar"
+          aria-label={`Progreso ${label}`}
+          aria-valuemin={0}
+          aria-valuemax={MAX_ROUTE_SLOTS}
+          aria-valuenow={allocated}
+          aria-valuetext={`${allocated} de ${MAX_ROUTE_SLOTS} cupos`}
+          className="mt-3 block h-2 overflow-hidden rounded-full bg-white/10"
+        >
+          <span className="block h-full rounded-full bg-[var(--uki-cyan)]" style={{ width: `${Math.min(100, allocated * 20)}%` }} />
+        </span>
+      </span>
+    </TabsTrigger>
+  );
+}
+
+function RouteDetail({ label, route }: { label: string; route: PublicRoute }) {
+  const ukiBreakdown = getUkiBreakdown(route);
+  const counts = slotCounts(route);
+  const deficit = route.deficitToPreserveSlots ?? route.deficitToNextSlot;
+  return (
+    <div className="min-w-0 rounded-[10px] border border-white/10 bg-black/20 p-4 sm:p-5">
+      <div className="grid min-w-0 gap-5 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="min-w-0">
+          <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <h4 className="font-headline text-xl font-black uppercase text-[var(--uki-cream)]">{label}</h4>
+            <span className="w-fit rounded-full border border-white/10 px-3 py-1 text-xs font-black uppercase text-[var(--uki-muted)]">
+              {counts.active} activos · {counts.qualifying} en validación · {counts.grace} en gracia
             </span>
           </div>
-        ))}
+
+          {!route.source.complete ? (
+            <div role="alert" className="mt-4 flex gap-3 rounded-[8px] border border-amber-300/30 bg-amber-300/10 p-3">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" aria-hidden="true" />
+              <p className="text-xs font-semibold leading-relaxed text-[var(--uki-text)]">La fuente de esta ruta está incompleta; no uses estas cifras para operar.</p>
+            </div>
+          ) : ukiBreakdown ? (
+            <div className="mt-4 rounded-[8px] border border-[var(--uki-cyan-border)] bg-[var(--uki-cyan-soft)] p-4">
+              <p className="text-xs font-black uppercase tracking-[0.1em] text-[var(--uki-muted)]">UKI que ya cuentan</p>
+              <p className="mt-2 break-words text-base font-black text-[var(--uki-cream)]">
+                {ukiBreakdown.total} = {ukiBreakdown.locked} en vesting + {ukiBreakdown.staked} en staking
+              </p>
+            </div>
+          ) : (
+            <div className="mt-4 rounded-[8px] border border-[var(--uki-cyan-border)] bg-[var(--uki-cyan-soft)] p-4">
+              <p className="text-xs font-black uppercase tracking-[0.1em] text-[var(--uki-muted)]">Puntos que ya cuentan</p>
+              <p className="mt-2 text-2xl font-black text-[var(--uki-gold)]">{route.source.originalCukiePoints ?? 0} puntos</p>
+            </div>
+          )}
+
+          <dl className="mt-4 grid min-w-0 gap-3 text-sm font-semibold sm:grid-cols-2">
+            <RouteMetric label="Requisito vigente" value={requirementLabel(route.currentRequirement)} />
+            <RouteMetric
+              label={route.deficitToPreserveSlots ? 'Déficit para conservar' : 'Déficit siguiente cupo'}
+              value={deficit
+                ? requirementLabel(deficit)
+                : route.source.complete ? 'Máximo alcanzado' : 'No disponible'}
+            />
+            <RouteMetric label="Cupos protegidos" value={String(route.position?.protectedSlots ?? 0)} />
+            {ukiBreakdown ? <RouteMetric label="Margen tras cupos" value={ukiBreakdown.excess} /> : null}
+          </dl>
+
+          {route.pendingRequirement ? (
+            <div className="mt-4 rounded-[8px] border border-amber-300/30 bg-amber-300/10 p-3 text-xs font-semibold leading-relaxed text-amber-100">
+              Próximo requisito: {requirementLabel(route.pendingRequirement)}. Puedes ajustarte hasta {dateLabel(route.requirementGraceEndsAt) ?? 'el final de la ventana de 48 horas'}.
+            </div>
+          ) : null}
+        </div>
+
+        <div className="min-w-0 border-t border-white/10 pt-4 lg:border-l lg:border-t-0 lg:pl-5 lg:pt-0">
+          <p className="text-xs font-black uppercase tracking-[0.1em] text-[var(--uki-muted)]">Estado de cada cupo</p>
+          <div className="mt-3 space-y-2">
+            {route.slots.length === 0 ? (
+              <p className="text-sm font-semibold text-[var(--uki-muted)]">Todavía no hay cupos asignados en esta ruta.</p>
+            ) : route.slots.map((slot) => (
+              <div key={`${slot.route}:${slot.ordinal}:${slot.eligibilityEpoch}`} className="flex min-w-0 items-start justify-between gap-3 rounded-[7px] border border-white/10 px-3 py-2.5 text-xs font-semibold">
+                <span className="shrink-0 text-[var(--uki-text)]">Cupo {slot.ordinal}</span>
+                <span className="flex min-w-0 items-start gap-1.5 text-right text-[var(--uki-muted)]">
+                  <Clock3 className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                  <span>{slotStatusLabel(slot)}</span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
+    </div>
+  );
+}
+
+function RouteMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-[7px] border border-white/10 p-3">
+      <dt className="text-xs text-[var(--uki-muted)]">{label}</dt>
+      <dd className="mt-1 break-words text-[var(--uki-text)]">{value}</dd>
+    </div>
+  );
+}
+
+function NftInventory({
+  assets,
+  activePoints,
+  mutatingAsset,
+  mutationError,
+  onMutate,
+}: {
+  assets: PublicNft[];
+  activePoints?: number;
+  mutatingAsset: string | null;
+  mutationError: string | null;
+  onMutate: (asset: PublicNft, operation: 'soft_stake' | 'unstake') => Promise<void>;
+}) {
+  const availablePoints = assets.reduce(
+    (total, asset) => total + (asset.canSoftStake ? asset.rarityPoints ?? 0 : 0),
+    0,
+  );
+  return (
+    <section aria-labelledby="cukie-master-inventory-title" className="mt-4 min-w-0 rounded-[10px] border border-white/10 bg-black/20 p-4 sm:p-5">
+      <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-xs font-black uppercase tracking-[0.1em] text-[var(--uki-muted)]">Inventario Original BSC</p>
+          <h4 id="cukie-master-inventory-title" className="mt-1 font-headline text-xl font-black uppercase text-[var(--uki-cream)]">Elige qué Cukies usar</h4>
+          <p className="mt-2 max-w-2xl text-sm font-semibold leading-relaxed text-[var(--uki-muted)]">
+            Usar un Cukie bloquea su uso económico, pero no transfiere el NFT ni firma por ti.
+          </p>
+        </div>
+        <div className="grid shrink-0 grid-cols-2 gap-2">
+          <MiniMetric label="Activos" value={`${activePoints ?? 0} pts`} />
+          <MiniMetric label="Disponibles" value={`+${availablePoints} pts`} />
+        </div>
+      </div>
+
+      {mutationError ? <p role="alert" className="mt-4 text-sm font-semibold text-amber-300">{mutationError}</p> : null}
+      {mutatingAsset ? <p role="status" aria-live="polite" className="mt-3 text-xs font-semibold text-[var(--uki-cyan)]">Actualizando el inventario de forma segura…</p> : null}
+
+      <div className="mt-4 grid min-w-0 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {assets.length === 0 ? (
+          <p className="text-sm font-semibold text-[var(--uki-muted)]">No hay Cukies Originales BSC disponibles para esta wallet.</p>
+        ) : assets.map((asset) => {
+          const name = `Cukie #${asset.tokenId ?? asset.assetId.slice(-8)}`;
+          const points = asset.rarityPoints;
+          const isMutating = mutatingAsset === asset.assetId;
+          return (
+            <article key={asset.assetId} className="min-w-0 overflow-hidden rounded-[10px] border border-white/10 bg-[#07131d]">
+              <div className="relative aspect-[4/3] min-w-0 overflow-hidden bg-black/25">
+                <CukiImage src={asset.imageUrl} alt={name} sizes="(min-width: 1280px) 24vw, (min-width: 640px) 44vw, 90vw" className="object-contain p-3" />
+                <span className={`absolute left-3 top-3 rounded-full border px-2.5 py-1 text-xs font-black uppercase ${rarityClass(asset.rarity)}`}>
+                  {rarityLabel(asset.rarity)}
+                </span>
+                {asset.contributesToCukieMaster ? (
+                  <span className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full border border-[var(--uki-cyan-border)] bg-[#160a22]/90 px-2.5 py-1 text-xs font-black text-[var(--uki-cyan)]">
+                    <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" /> En uso
+                  </span>
+                ) : null}
+              </div>
+              <div className="min-w-0 p-4">
+                <div className="flex min-w-0 items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <h5 className="truncate text-base font-black text-[var(--uki-cream)]">{name}</h5>
+                    <p className="mt-1 text-xs font-semibold text-[var(--uki-muted)]">{stateLabel(asset.state)}</p>
+                  </div>
+                  <span className="shrink-0 text-right font-headline text-lg font-black text-[var(--uki-gold)]">
+                    {points === null ? '—' : `${points} pts`}
+                  </span>
+                </div>
+
+                <div className={`mt-3 flex min-h-11 items-center gap-2 rounded-[7px] border p-3 text-xs font-semibold ${
+                  asset.contributesToCukieMaster
+                    ? 'border-[var(--uki-cyan-border)] bg-[var(--uki-cyan-soft)] text-[var(--uki-text)]'
+                    : 'border-white/10 text-[var(--uki-muted)]'
+                }`}>
+                  <Sparkles className="h-4 w-4 shrink-0 text-[var(--uki-cyan)]" aria-hidden="true" />
+                  {asset.contributesToCukieMaster
+                    ? `Aporta ${pointsLabel(asset.contributionPoints)} a tu ruta`
+                    : points === null
+                      ? 'Puntuación no verificable'
+                      : asset.canSoftStake
+                        ? `Puede aportar ${pointsLabel(points)}`
+                        : blockerLabel(asset.blockers[0])}
+                </div>
+
+                {asset.canSoftStake ? (
+                  <button
+                    type="button"
+                    disabled={Boolean(mutatingAsset)}
+                    onClick={() => void onMutate(asset, 'soft_stake')}
+                    aria-label={`Usar ${name} para Cukie Master`}
+                    className="mt-3 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-[7px] border border-[var(--uki-cyan-border)] px-3 py-2 text-center text-xs font-black uppercase text-[var(--uki-cyan)] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isMutating ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Lock className="h-4 w-4" aria-hidden="true" />}
+                    Usar para Cukie Master
+                  </button>
+                ) : asset.canUnstake ? (
+                  <button
+                    type="button"
+                    disabled={Boolean(mutatingAsset)}
+                    onClick={() => void onMutate(asset, 'unstake')}
+                    aria-label={`Dejar de usar ${name} para Cukie Master`}
+                    className="mt-3 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-[7px] border border-white/15 px-3 py-2 text-center text-xs font-black uppercase text-[var(--uki-text)] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isMutating ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Unlock className="h-4 w-4" aria-hidden="true" />}
+                    Dejar de usar
+                  </button>
+                ) : (
+                  <p className="mt-3 flex min-h-11 items-center justify-center rounded-[7px] border border-white/10 px-3 text-center text-xs font-black uppercase text-[var(--uki-muted)]">
+                    {asset.contributesToCukieMaster ? 'Aportación mantenida' : 'No disponible'}
+                  </p>
+                )}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function MiniMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[7px] border border-white/10 bg-black/20 px-3 py-2 text-right">
+      <p className="text-xs font-semibold text-[var(--uki-muted)]">{label}</p>
+      <p className="mt-1 font-black text-[var(--uki-cream)]">{value}</p>
     </div>
   );
 }
 
 function getUkiBreakdown(route: PublicRoute) {
   if (
-    !route.source.complete ||
-    route.source.route !== 'uki' ||
-    route.source.totalUkiRaw === undefined ||
-    route.source.presaleLockedRaw === undefined ||
-    route.source.stakedUkiRaw === undefined ||
-    route.currentRequirement.route !== 'uki'
+    !route.source.complete
+    || route.source.route !== 'uki'
+    || route.source.totalUkiRaw === undefined
+    || route.source.presaleLockedRaw === undefined
+    || route.source.stakedUkiRaw === undefined
+    || route.currentRequirement.route !== 'uki'
   ) return null;
 
   try {
     const total = BigInt(route.source.totalUkiRaw);
     const requirement = BigInt(route.currentRequirement.ukiRaw);
     if (requirement <= BigInt(0)) return null;
-    const qualifyingSlots = total / requirement > BigInt(5)
-      ? BigInt(5)
+    const qualifyingSlots = total / requirement > BigInt(MAX_ROUTE_SLOTS)
+      ? BigInt(MAX_ROUTE_SLOTS)
       : total / requirement;
     const excess = total - (qualifyingSlots * requirement);
     return {
@@ -367,13 +684,65 @@ function getUkiBreakdown(route: PublicRoute) {
   }
 }
 
-function SourceMetric({ label, value }: { label: string; value: string }) {
-  return (
-    <div>
-      <dt className="text-[var(--uki-muted)]">{label}</dt>
-      <dd className="mt-1 text-[var(--uki-text)]">{value}</dd>
-    </div>
-  );
+function slotStatusLabel(slot: PublicSlot) {
+  if (slot.status === 'active') return 'Activo';
+  if (slot.status === 'grace') return `En gracia hasta ${dateLabel(slot.graceEndsAt) ?? 'fecha pendiente'}`;
+  if (slot.status === 'qualifying') return `Activo desde ${dateLabel(slot.creditEligibleFrom) ?? 'que complete 24h'}`;
+  return 'Inactivo';
+}
+
+function rarityLabel(rarity: string) {
+  return ({
+    common: 'Común',
+    uncommon: 'No común',
+    rare: 'Raro',
+    epic: 'Épico',
+    legendary: 'Legendario',
+    goat: 'Goat',
+  } as Record<string, string>)[rarity] ?? 'Sin verificar';
+}
+
+function pointsLabel(points: number) {
+  return `${points} ${points === 1 ? 'punto' : 'puntos'}`;
+}
+
+function rarityClass(rarity: string) {
+  return ({
+    common: 'border-white/20 bg-black/70 text-[var(--uki-text)]',
+    uncommon: 'border-emerald-300/30 bg-emerald-950/80 text-emerald-200',
+    rare: 'border-cyan-300/30 bg-cyan-950/80 text-cyan-200',
+    epic: 'border-purple-300/30 bg-purple-950/80 text-purple-200',
+    legendary: 'border-amber-300/30 bg-amber-950/80 text-amber-200',
+    goat: 'border-pink-300/30 bg-pink-950/80 text-pink-200',
+  } as Record<string, string>)[rarity] ?? 'border-white/20 bg-black/70 text-[var(--uki-muted)]';
+}
+
+function stateLabel(state: string) {
+  return ({
+    available: 'Disponible',
+    soft_staked: 'Usado en Cukie Master',
+    assigned_to_game: 'Asignado temporalmente a una partida',
+    in_pool: 'Depositado en un pool',
+    listed: 'Listado en marketplace',
+    bridging: 'En proceso de bridge',
+    invalidated: 'Pendiente de revisión',
+  } as Record<string, string>)[state] ?? 'Estado no verificable';
+}
+
+function blockerLabel(blocker?: string) {
+  return ({
+    missing_rarity: 'Rareza pendiente de verificar',
+    missing_generation: 'Generación pendiente de verificar',
+    second_generation: 'Solo cuentan Cukies Originales',
+    listed: 'Retíralo del marketplace para usarlo',
+    bridging: 'Espera a que termine el bridge',
+    already_locked: 'Ya está reservado para otro uso',
+    in_pool: 'Retíralo del pool para usarlo',
+    assigned_to_game: 'Está asignado a una partida',
+    invalidated: 'Requiere revisión de inventario',
+    unknown_state: 'Estado pendiente de verificar',
+    unsupported_network: 'Solo cuentan activos en BSC',
+  } as Record<string, string>)[blocker ?? ''] ?? 'No puede usarse en este momento';
 }
 
 function requirementLabel(requirement: Requirement) {

--- a/dapp/src/components/cukie-master/types.ts
+++ b/dapp/src/components/cukie-master/types.ts
@@ -1,0 +1,6 @@
+export type UkiRoutePreview = {
+  currentRequirementRaw: string;
+  presaleLockedRaw: string;
+  indexedStakedRaw: string;
+  allocatedSlots: number;
+};

--- a/dapp/src/components/cukie-master/uki-staking-panel.tsx
+++ b/dapp/src/components/cukie-master/uki-staking-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { AlertTriangle, ArrowDownToLine, ArrowUpFromLine, ExternalLink, Loader2, ShieldCheck } from 'lucide-react';
+import { AlertTriangle, ArrowDownToLine, ArrowUpFromLine, Check, ExternalLink, Loader2, ShieldCheck } from 'lucide-react';
 import { formatUnits, parseUnits, type Address } from 'viem';
 import {
   useAccount,
@@ -14,6 +14,7 @@ import {
 import { LandingWalletConnectButton } from '@/components/landing/wallet-connect-dynamic';
 import { Panel } from '@/components/landing/primitives';
 import { UKI_PRESALE_CHAIN_ID, UKI_PRESALE_CHAIN_LABEL } from '@/components/landing/sale-config';
+import type { UkiRoutePreview } from '@/components/cukie-master/types';
 import { useHasMounted } from '@/hooks/use-has-mounted';
 import { useToast } from '@/hooks/use-toast';
 import {
@@ -22,12 +23,14 @@ import {
   ukiSaleContracts,
   ukiStakingAbi,
 } from '@/lib/contracts/uki-sale';
+import { useAuth } from '@/providers/auth-provider';
 
 const TOKEN_DECIMALS = 18;
 const DEFAULT_AMOUNT = '20000';
 
 type StakingOperation = 'stake' | 'unstake';
 type TransactionAction = 'approve' | 'stake' | 'unstake' | null;
+type WorkflowStepState = 'done' | 'current' | 'upcoming';
 
 function parseTokenAmount(value: string) {
   const trimmed = value.trim();
@@ -52,7 +55,13 @@ function sameAddress(left?: string, right?: string) {
   return Boolean(left && right && left.toLowerCase() === right.toLowerCase());
 }
 
-export function UkiStakingPanel() {
+export function UkiStakingPanel({
+  routePreview = null,
+  testnetOnly = false,
+}: {
+  routePreview?: UkiRoutePreview | null;
+  testnetOnly?: boolean;
+}) {
   const { address, chainId, isConnected } = useAccount();
   const { switchChain, isPending: isSwitching } = useSwitchChain();
   const { writeContract, data: txHash, error, isPending, reset } = useWriteContract();
@@ -61,20 +70,31 @@ export function UkiStakingPanel() {
     query: { enabled: Boolean(txHash) },
   });
   const { toast } = useToast();
+  const {
+    user,
+    isLoading: authLoading,
+    isWaitingForApproval,
+    walletType,
+  } = useAuth();
   const hasMounted = useHasMounted();
   const handledReceiptHashRef = useRef<string | null>(null);
   const [amount, setAmount] = useState(DEFAULT_AMOUNT);
   const [operation, setOperation] = useState<StakingOperation>('stake');
   const [lastAction, setLastAction] = useState<TransactionAction>(null);
+  const [lastCompletedAction, setLastCompletedAction] = useState<TransactionAction>(null);
   const [approvedAmount, setApprovedAmount] = useState<bigint | null>(null);
 
   const tokenAddress = ukiSaleContracts.ukiTokenAddress as Address | undefined;
   const stakingAddress = ukiSaleContracts.ukiStakingAddress as Address | undefined;
   const parsedAmount = useMemo(() => parseTokenAmount(amount), [amount]);
   const isWrongChain = Boolean(hasMounted && isConnected && chainId !== UKI_PRESALE_CHAIN_ID);
+  const isUnsafeStagingChain = testnetOnly && UKI_PRESALE_CHAIN_ID !== 97;
+  const isAuthenticatedEvm = Boolean(
+    walletType === 'evm' && sameAddress(user?.walletAddress, address),
+  );
   const hasContractConfig = Boolean(tokenAddress && stakingAddress);
-  const publicReadsEnabled = Boolean(hasContractConfig);
-  const walletReadsEnabled = Boolean(address && hasContractConfig && !isWrongChain);
+  const publicReadsEnabled = Boolean(hasContractConfig && !isUnsafeStagingChain);
+  const walletReadsEnabled = Boolean(address && hasContractConfig && !isWrongChain && !isUnsafeStagingChain);
 
   const {
     data: stakingToken,
@@ -160,6 +180,10 @@ export function UkiStakingPanel() {
     hasMounted &&
     isConnected &&
     !isWrongChain &&
+    !isUnsafeStagingChain &&
+    !authLoading &&
+    !isWaitingForApproval &&
+    isAuthenticatedEvm &&
     hasContractConfig &&
     protocolReadsReady &&
     tokenMatches &&
@@ -173,10 +197,25 @@ export function UkiStakingPanel() {
     !isBusy,
   );
   const txUrl = txHash ? getBscScanTxUrl(txHash) : null;
+  const outcomePreview = useMemo(() => buildOutcomePreview({
+    operation,
+    parsedAmount,
+    stakedBalance,
+    routePreview,
+  }), [operation, parsedAmount, routePreview, stakedBalance]);
+  const workflowSteps = buildWorkflowSteps({
+    operation,
+    isConnected,
+    isWrongChain,
+    isAuthenticatedEvm,
+    needsApproval,
+    lastCompletedAction,
+  });
 
   useEffect(() => {
     setApprovedAmount(null);
     setLastAction(null);
+    setLastCompletedAction(null);
     handledReceiptHashRef.current = null;
   }, [address, stakingAddress, tokenAddress]);
 
@@ -192,6 +231,7 @@ export function UkiStakingPanel() {
 
     if (lastAction === 'approve' && parsedAmount) {
       setApprovedAmount(parsedAmount);
+      setLastCompletedAction('approve');
       toast({
         title: 'Permiso UKI confirmado',
         description: 'Ahora puedes confirmar el staking con una segunda firma.',
@@ -199,12 +239,16 @@ export function UkiStakingPanel() {
     } else if (lastAction === 'stake') {
       setAmount(DEFAULT_AMOUNT);
       setApprovedAmount(null);
+      setLastCompletedAction('stake');
+      window.dispatchEvent(new Event('cukies:cukie-master:refresh'));
       toast({
         title: 'Staking confirmado',
         description: 'Tus UKI ya constan en el contrato de Cukie Master.',
       });
     } else if (lastAction === 'unstake') {
       setAmount(DEFAULT_AMOUNT);
+      setLastCompletedAction('unstake');
+      window.dispatchEvent(new Event('cukies:cukie-master:refresh'));
       toast({
         title: 'Retirada confirmada',
         description: 'Los UKI retirados han vuelto a tu wallet.',
@@ -238,12 +282,18 @@ export function UkiStakingPanel() {
     setOperation(nextOperation);
     setAmount(DEFAULT_AMOUNT);
     setLastAction(null);
+    setLastCompletedAction(null);
     reset();
   }
 
   function useMaximumBalance() {
     if (availableBalance === undefined) return;
     setAmount(formatUnits(availableBalance, TOKEN_DECIMALS));
+  }
+
+  function selectQuickAmount(value: string) {
+    setAmount(value);
+    setLastCompletedAction(null);
   }
 
   function switchToStagingNetwork() {
@@ -265,6 +315,7 @@ export function UkiStakingPanel() {
     if (!tokenAddress || !stakingAddress || !parsedAmount || !canTransact) return;
     reset();
     handledReceiptHashRef.current = null;
+    setLastCompletedAction(null);
 
     if (needsApproval) {
       setLastAction('approve');
@@ -301,17 +352,17 @@ export function UkiStakingPanel() {
             : 'Retirar UKI';
 
   return (
-    <section id="uki-staking" className="uki-container relative z-[2] pb-6 pt-2">
-      <Panel innerClassName="p-5 sm:p-7">
-        <div className="grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
-          <div>
-            <p className="uki-label">Contrato activo en testnet</p>
+    <section id="uki-staking" className="uki-container relative z-[2] min-w-0 scroll-mt-28 pb-8">
+      <Panel className="min-w-0" innerClassName="min-w-0 p-5 sm:p-7">
+        <div className="grid min-w-0 gap-8 lg:grid-cols-[0.78fr_1.22fr]">
+          <div className="min-w-0">
+            <p className="text-xs font-black uppercase tracking-[0.12em] text-[var(--uki-muted)]">Contrato configurado · {UKI_PRESALE_CHAIN_LABEL}</p>
             <h2 className="mt-2 font-headline text-3xl font-black uppercase leading-tight text-[var(--uki-cream)]">
               Staking de UKI
             </h2>
             <p className="mt-3 text-sm font-semibold leading-relaxed text-[var(--uki-text)]">
-              Deposita UKI en el contrato de Cukie Master o retíralos cuando quieras. La operación
-              no genera rentabilidad: se usa para calcular tus cupos y créditos de competición.
+              Deposita solo los UKI que te falten o retíralos cuando quieras. El vesting ya cuenta
+              por separado y la operación no implica una rentabilidad garantizada.
             </p>
 
             <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
@@ -323,12 +374,14 @@ export function UkiStakingPanel() {
               <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-[var(--uki-cyan)]" />
               <p className="text-xs font-semibold leading-relaxed text-[var(--uki-muted)]">
                 Red: {UKI_PRESALE_CHAIN_LABEL}. Necesitas tBNB para el gas. El requisito oficial,
-                los UKI en vesting y tus cupos aparecen en “Mis cupos Cukie Master”.
+                los UKI en vesting y tus cupos aparecen en “Tus cupos Cukie Master”.
               </p>
             </div>
           </div>
 
-          <div className="rounded-[10px] border border-white/10 bg-black/25 p-4 sm:p-5">
+          <div className="min-w-0 rounded-[10px] border border-white/10 bg-black/25 p-4 sm:p-5">
+            <StakingWorkflow steps={workflowSteps} />
+
             <div className="grid grid-cols-2 gap-2" role="group" aria-label="Operación de staking">
               <OperationButton
                 active={operation === 'stake'}
@@ -347,30 +400,43 @@ export function UkiStakingPanel() {
             <label htmlFor="uki-staking-amount" className="mt-5 block text-xs font-black uppercase tracking-[0.12em] text-[var(--uki-muted)]">
               Cantidad de UKI
             </label>
-            <div className="mt-2 flex overflow-hidden rounded-[8px] border border-white/15 bg-[#02090d] focus-within:border-[var(--uki-cyan)]">
+            <div className="mt-2 flex min-w-0 overflow-hidden rounded-[8px] border border-white/15 bg-[#02090d] focus-within:border-[var(--uki-cyan)]">
               <input
                 id="uki-staking-amount"
                 inputMode="decimal"
                 autoComplete="off"
                 value={amount}
                 disabled={isBusy}
-                onChange={(event) => setAmount(event.target.value)}
+                aria-describedby="uki-staking-available"
+                aria-invalid={Boolean(!parsedAmount || (availableBalance !== undefined && !hasEnoughBalance))}
+                onChange={(event) => {
+                  setAmount(event.target.value);
+                  setLastCompletedAction(null);
+                }}
                 className="min-w-0 flex-1 bg-transparent px-4 py-3 text-lg font-black text-[var(--uki-cream)] outline-none disabled:opacity-50"
               />
-              <button
-                type="button"
-                disabled={availableBalance === undefined || isBusy}
-                onClick={useMaximumBalance}
-                className="border-l border-white/10 px-4 text-xs font-black uppercase text-[var(--uki-cyan)] disabled:opacity-40"
-              >
-                Máximo
-              </button>
+              <span className="flex shrink-0 items-center border-l border-white/10 px-4 text-xs font-black uppercase text-[var(--uki-muted)]">UKI</span>
             </div>
-            <p className="mt-2 text-right text-xs font-semibold text-[var(--uki-muted)]">
+            <div className="mt-3 grid grid-cols-3 gap-2" role="group" aria-label="Cantidades rápidas">
+              <QuickAmountButton label="20.000" onClick={() => selectQuickAmount('20000')} disabled={isBusy} />
+              <QuickAmountButton label="40.000" onClick={() => selectQuickAmount('40000')} disabled={isBusy} />
+              <QuickAmountButton label="Máximo" onClick={useMaximumBalance} disabled={availableBalance === undefined || isBusy} />
+            </div>
+            <p id="uki-staking-available" className="mt-2 text-right text-xs font-semibold text-[var(--uki-muted)]">
               Disponible: {formatTokenAmount(availableBalance)} UKI
             </p>
 
-            {!hasContractConfig ? (
+            {outcomePreview ? (
+              <div className="mt-4 rounded-[8px] border border-[var(--uki-cyan-border)] bg-[var(--uki-cyan-soft)] p-4">
+                <p className="text-xs font-black uppercase tracking-[0.1em] text-[var(--uki-muted)]">Resultado estimado</p>
+                <p className="mt-2 text-sm font-black leading-relaxed text-[var(--uki-cream)]">{outcomePreview.summary}</p>
+                <p className="mt-1 text-xs font-semibold leading-relaxed text-[var(--uki-muted)]">{outcomePreview.detail}</p>
+              </div>
+            ) : null}
+
+            {isUnsafeStagingChain ? (
+              <InlineWarning text="Configuración bloqueada: el entorno staging exige BNB Smart Chain Testnet (chain 97)." />
+            ) : !hasContractConfig ? (
               <InlineWarning text="El contrato de staking no está configurado para este entorno." />
             ) : protocolReadFailed ? (
               <InlineWarning text="No se ha podido verificar que token y contrato coincidan. Las operaciones están bloqueadas." />
@@ -378,6 +444,10 @@ export function UkiStakingPanel() {
               <InlineWarning text="Los nuevos depósitos están pausados en el contrato. Las retiradas siguen disponibles." />
             ) : walletReadFailed ? (
               <InlineWarning text="No se han podido leer los balances con garantías. No se enviará ninguna transacción." />
+            ) : hasMounted && isConnected && !isWrongChain && !authLoading && !isAuthenticatedEvm ? (
+              <InlineWarning text={isWaitingForApproval
+                ? 'Aprueba el mensaje de acceso en tu wallet.'
+                : 'Firma el acceso con esta wallet antes de autorizar o depositar UKI.'} />
             ) : parsedAmount && availableBalance !== undefined && !hasEnoughBalance ? (
               <InlineWarning text={`No tienes suficiente UKI ${operation === 'stake' ? 'líquido' : 'en staking'} para esta operación.`} />
             ) : !parsedAmount ? (
@@ -385,7 +455,15 @@ export function UkiStakingPanel() {
             ) : null}
 
             <div className="mt-5">
-              {!hasMounted || !isConnected ? (
+              {isUnsafeStagingChain ? (
+                <button
+                  type="button"
+                  disabled
+                  className="uki-button uki-button-primary w-full justify-center cursor-not-allowed opacity-40"
+                >
+                  Staging bloqueado por configuración
+                </button>
+              ) : !hasMounted || !isConnected ? (
                 <LandingWalletConnectButton
                   className="w-full justify-center"
                   evmOnly
@@ -402,6 +480,14 @@ export function UkiStakingPanel() {
                 >
                   <span>{isSwitching ? 'Cambiando red' : `Cambiar a ${UKI_PRESALE_CHAIN_LABEL}`}</span>
                 </button>
+              ) : !isAuthenticatedEvm ? (
+                <LandingWalletConnectButton
+                  className="w-full justify-center"
+                  evmOnly
+                  label="Firmar wallet"
+                  compactLabel="Firmar"
+                  showCompactText={false}
+                />
               ) : (
                 <button
                   type="button"
@@ -421,12 +507,26 @@ export function UkiStakingPanel() {
               </p>
             ) : null}
 
+            {isBusy || lastCompletedAction ? (
+              <p role="status" aria-live="polite" className="mt-3 text-center text-xs font-semibold text-[var(--uki-muted)]">
+                {isConfirming
+                  ? `Esperando confirmación en ${UKI_PRESALE_CHAIN_LABEL}…`
+                  : lastCompletedAction === 'approve'
+                    ? 'Autorización confirmada. Ya puedes depositar.'
+                    : lastCompletedAction === 'stake'
+                      ? 'Depósito confirmado. Actualizando tus cupos.'
+                      : lastCompletedAction === 'unstake'
+                        ? 'Retirada confirmada. Actualizando tus cupos.'
+                        : 'Abre tu wallet y confirma la operación.'}
+              </p>
+            ) : null}
+
             {txUrl ? (
               <a
                 href={txUrl}
                 target="_blank"
                 rel="noreferrer"
-                className="mt-4 inline-flex items-center gap-2 text-xs font-black uppercase text-[var(--uki-cyan)] hover:underline"
+                className="mt-4 inline-flex min-h-11 items-center gap-2 text-xs font-black uppercase text-[var(--uki-cyan)] hover:underline"
               >
                 Ver última transacción <ExternalLink className="h-3.5 w-3.5" />
               </a>
@@ -463,7 +563,7 @@ function OperationButton({
       type="button"
       aria-pressed={active}
       onClick={onClick}
-      className={`inline-flex items-center justify-center gap-2 rounded-[7px] border px-4 py-3 text-xs font-black uppercase transition-colors ${
+      className={`inline-flex min-h-11 items-center justify-center gap-2 rounded-[7px] border px-4 py-3 text-xs font-black uppercase transition-colors ${
         active
           ? 'border-[var(--uki-cyan)] bg-[var(--uki-cyan)]/10 text-[var(--uki-cyan)]'
           : 'border-white/10 text-[var(--uki-muted)] hover:border-white/25 hover:text-[var(--uki-text)]'
@@ -473,6 +573,136 @@ function OperationButton({
       {label}
     </button>
   );
+}
+
+function QuickAmountButton({
+  label,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="inline-flex min-h-11 min-w-0 items-center justify-center rounded-[7px] border border-white/10 px-2 text-center text-xs font-black uppercase text-[var(--uki-text)] hover:border-[var(--uki-cyan-border)] hover:text-[var(--uki-cyan)] disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      {label}
+    </button>
+  );
+}
+
+function StakingWorkflow({
+  steps,
+}: {
+  steps: Array<{ label: string; state: WorkflowStepState }>;
+}) {
+  return (
+    <div className="mb-5 min-w-0 border-b border-white/10 pb-5">
+      <p className="text-xs font-black uppercase tracking-[0.1em] text-[var(--uki-muted)]">Pasos de la operación</p>
+      <ol className={`mt-3 grid min-w-0 gap-2 ${steps.length === 5 ? 'grid-cols-2 sm:grid-cols-5' : 'grid-cols-2 sm:grid-cols-4'}`}>
+        {steps.map((step, index) => (
+          <li
+            key={step.label}
+            aria-current={step.state === 'current' ? 'step' : undefined}
+            className={`min-w-0 rounded-[7px] border p-2.5 ${
+              step.state === 'done'
+                ? 'border-[var(--uki-cyan-border)] bg-[var(--uki-cyan-soft)] text-[var(--uki-cyan)]'
+                : step.state === 'current'
+                  ? 'border-[var(--uki-gold)]/45 bg-[var(--uki-gold)]/10 text-[var(--uki-gold)]'
+                  : 'border-white/10 text-[var(--uki-muted)]'
+            }`}
+          >
+            <span className="flex items-center gap-2">
+              <span className="grid h-6 w-6 shrink-0 place-items-center rounded-full border border-current text-xs font-black">
+                {step.state === 'done' ? <Check className="h-3.5 w-3.5" aria-hidden="true" /> : index + 1}
+              </span>
+              <span className="min-w-0 break-words text-xs font-black uppercase leading-tight">{step.label}</span>
+            </span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function buildWorkflowSteps({
+  operation,
+  isConnected,
+  isWrongChain,
+  isAuthenticatedEvm,
+  needsApproval,
+  lastCompletedAction,
+}: {
+  operation: StakingOperation;
+  isConnected: boolean;
+  isWrongChain: boolean;
+  isAuthenticatedEvm: boolean;
+  needsApproval: boolean;
+  lastCompletedAction: TransactionAction;
+}) {
+  const networkStepLabel = UKI_PRESALE_CHAIN_ID === 97 ? 'BSC Testnet' : 'BSC Mainnet';
+  const labels = operation === 'stake'
+    ? ['Conectar', networkStepLabel, 'Firmar', 'Autorizar', 'Depositar']
+    : ['Conectar', networkStepLabel, 'Firmar', 'Retirar'];
+  let completedSteps = 0;
+  if (isConnected) completedSteps = 1;
+  if (isConnected && !isWrongChain) completedSteps = 2;
+  if (isConnected && !isWrongChain && isAuthenticatedEvm) completedSteps = 3;
+  if (operation === 'stake' && isAuthenticatedEvm && !needsApproval) completedSteps = 4;
+  if (operation === 'stake' && lastCompletedAction === 'stake') completedSteps = 5;
+  if (operation === 'unstake' && lastCompletedAction === 'unstake') completedSteps = 4;
+
+  return labels.map((label, index) => ({
+    label,
+    state: (index < completedSteps
+      ? 'done'
+      : index === completedSteps
+        ? 'current'
+        : 'upcoming') as WorkflowStepState,
+  }));
+}
+
+function buildOutcomePreview({
+  operation,
+  parsedAmount,
+  stakedBalance,
+  routePreview,
+}: {
+  operation: StakingOperation;
+  parsedAmount: bigint | null;
+  stakedBalance?: bigint;
+  routePreview: UkiRoutePreview | null;
+}) {
+  if (!parsedAmount || !routePreview) return null;
+  try {
+    const requirement = BigInt(routePreview.currentRequirementRaw);
+    const locked = BigInt(routePreview.presaleLockedRaw);
+    const currentStaked = stakedBalance ?? BigInt(routePreview.indexedStakedRaw);
+    if (requirement <= BigInt(0) || locked < BigInt(0) || currentStaked < BigInt(0)) return null;
+    if (operation === 'unstake' && parsedAmount > currentStaked) return null;
+    const projectedStaked = operation === 'stake'
+      ? currentStaked + parsedAmount
+      : currentStaked - parsedAmount;
+    const total = locked + projectedStaked;
+    const theoreticalSlots = Math.min(5, Number(total / requirement));
+    const remainder = total % requirement;
+    const deficit = theoreticalSlots >= 5
+      ? BigInt(0)
+      : remainder === BigInt(0) ? requirement : requirement - remainder;
+    return {
+      summary: `Capacidad teórica tras confirmar: ${theoreticalSlots}/5 cupos por UKI.`,
+      detail: `${formatTokenAmount(total)} UKI computables = ${formatTokenAmount(locked)} en vesting + ${formatTokenAmount(projectedStaked)} en staking.${
+        deficit > BigInt(0) ? ` Faltarían ${formatTokenAmount(deficit)} UKI para el siguiente cupo.` : ' Máximo de la ruta alcanzado.'
+      } La asignación final se actualiza cuando el indexador confirma la operación.`,
+    };
+  } catch {
+    return null;
+  }
 }
 
 function InlineWarning({ text }: { text: string }) {

--- a/dapp/src/components/cukie-master/uki-staking-panel.tsx
+++ b/dapp/src/components/cukie-master/uki-staking-panel.tsx
@@ -246,6 +246,21 @@ export function UkiStakingPanel() {
     setAmount(formatUnits(availableBalance, TOKEN_DECIMALS));
   }
 
+  function switchToStagingNetwork() {
+    switchChain(
+      { chainId: UKI_PRESALE_CHAIN_ID },
+      {
+        onError: () => {
+          toast({
+            title: 'No se pudo cambiar la red',
+            description: `Abre tu wallet y acepta el cambio a ${UKI_PRESALE_CHAIN_LABEL}.`,
+            variant: 'destructive',
+          });
+        },
+      },
+    );
+  }
+
   function handleSubmit() {
     if (!tokenAddress || !stakingAddress || !parsedAmount || !canTransact) return;
     reset();
@@ -373,6 +388,7 @@ export function UkiStakingPanel() {
               {!hasMounted || !isConnected ? (
                 <LandingWalletConnectButton
                   className="w-full justify-center"
+                  evmOnly
                   label="Conectar wallet para gestionar staking"
                   compactLabel="Conectar wallet"
                   showCompactText={false}
@@ -381,7 +397,7 @@ export function UkiStakingPanel() {
                 <button
                   type="button"
                   disabled={isSwitching}
-                  onClick={() => switchChain({ chainId: UKI_PRESALE_CHAIN_ID })}
+                  onClick={switchToStagingNetwork}
                   className="uki-button uki-button-primary w-full justify-center disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   <span>{isSwitching ? 'Cambiando red' : `Cambiar a ${UKI_PRESALE_CHAIN_LABEL}`}</span>

--- a/dapp/src/components/cukie-master/workspace.tsx
+++ b/dapp/src/components/cukie-master/workspace.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { CukieMasterStatusPanel } from '@/components/cukie-master/status-panel';
+import type { UkiRoutePreview } from '@/components/cukie-master/types';
+import { UkiStakingPanel } from '@/components/cukie-master/uki-staking-panel';
+
+export function CukieMasterWorkspace({ testnetOnly = false }: { testnetOnly?: boolean }) {
+  const [ukiRoutePreview, setUkiRoutePreview] = useState<UkiRoutePreview | null>(null);
+  const updatePreview = useCallback((preview: UkiRoutePreview | null) => {
+    setUkiRoutePreview(preview);
+  }, []);
+
+  return (
+    <>
+      <CukieMasterStatusPanel onUkiRouteData={updatePreview} />
+      <UkiStakingPanel routePreview={ukiRoutePreview} testnetOnly={testnetOnly} />
+    </>
+  );
+}

--- a/dapp/src/components/landing/header.tsx
+++ b/dapp/src/components/landing/header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -39,9 +39,11 @@ const headerCopy = {
   },
 } as const satisfies Record<PublicLocale, Record<string, string>>;
 
-export function LandingHeader() {
+export function LandingHeader({ evmOnly = false }: { evmOnly?: boolean }) {
   const [isOpen, setIsOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
   const { locale, setLocale } = usePublicLocale();
 
@@ -61,6 +63,39 @@ export function LandingHeader() {
       window.removeEventListener('scroll', handleScroll);
     };
   }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const menu = mobileMenuRef.current;
+    const focusable = () => Array.from(menu?.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ) ?? []);
+    focusable()[0]?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setIsOpen(false);
+        menuButtonRef.current?.focus();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const items = focusable();
+      const first = items[0];
+      const last = items.at(-1);
+      if (!first || !last) return;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen]);
 
   const toggleMenu = () => setIsOpen(!isOpen);
   const closeMenu = () => setIsOpen(false);
@@ -93,14 +128,18 @@ export function LandingHeader() {
 
           <div className="hidden items-center gap-3 lg:flex">
             <LanguageSwitcher locale={locale} setLocale={setLocale} selectorLabel={copy.languageSelector} />
-            <LandingWalletConnectButton />
+            <LandingWalletConnectButton evmOnly={evmOnly} />
           </div>
 
           {/* Botón de Menú Móvil */}
           <button
-            className="flex h-10 w-10 items-center justify-center rounded-[8px] border border-white/10 bg-white/5 text-[var(--uki-cyan)] hover:bg-white/10 lg:hidden"
+            ref={menuButtonRef}
+            type="button"
+            className="flex h-11 w-11 items-center justify-center rounded-[8px] border border-white/10 bg-white/5 text-[var(--uki-cyan)] hover:bg-white/10 lg:hidden"
             onClick={toggleMenu}
             aria-label={isOpen ? copy.closeMenu : copy.openMenu}
+            aria-expanded={isOpen}
+            aria-controls="uki-mobile-navigation"
           >
             {isOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
           </button>
@@ -109,7 +148,14 @@ export function LandingHeader() {
 
       {/* Drawer del Menú Móvil */}
       <div
-        className={`fixed inset-y-0 right-0 z-[70] w-64 transform border-l border-white/10 bg-[#060a12]/95 p-6 shadow-[0_0_40px_rgba(228,92,255,0.15)] backdrop-blur-md transition-transform duration-300 ease-in-out lg:hidden ${
+        ref={mobileMenuRef}
+        id="uki-mobile-navigation"
+        role="dialog"
+        aria-modal="true"
+        aria-hidden={!isOpen}
+        inert={isOpen ? undefined : ('' as unknown as boolean)}
+        aria-label={copy.menuTitle}
+        className={`fixed inset-y-0 right-0 z-[70] w-64 max-w-[calc(100vw-2rem)] transform border-l border-white/10 bg-[#060a12]/95 p-6 shadow-[0_0_40px_rgba(228,92,255,0.15)] backdrop-blur-md transition-transform duration-300 ease-in-out lg:hidden ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >
@@ -118,7 +164,8 @@ export function LandingHeader() {
             <div className="flex items-center justify-between pb-4 border-b border-white/10">
               <span className="font-headline text-lg font-black uppercase text-[var(--uki-cyan)]">{copy.menuTitle}</span>
               <button
-                className="flex h-8 w-8 items-center justify-center rounded-[6px] border border-white/10 bg-white/5 text-[var(--uki-muted)] hover:text-white"
+                type="button"
+                className="flex h-11 w-11 items-center justify-center rounded-[6px] border border-white/10 bg-white/5 text-[var(--uki-muted)] hover:text-white"
                 onClick={closeMenu}
                 aria-label={copy.closeMenu}
               >
@@ -145,7 +192,7 @@ export function LandingHeader() {
             <LanguageSwitcher locale={locale} setLocale={setLocale} onChange={closeMenu} className="pt-1" selectorLabel={copy.languageSelector} />
           </div>
           <div className="pt-6 border-t border-white/10" onClick={closeMenu}>
-            <LandingWalletConnectButton />
+            <LandingWalletConnectButton evmOnly={evmOnly} />
           </div>
         </div>
       </div>

--- a/dapp/src/components/landing/primitives.tsx
+++ b/dapp/src/components/landing/primitives.tsx
@@ -72,8 +72,8 @@ export function Panel({
   id?: string;
 }) {
   return (
-    <div id={id} className={`uki-panel-shell ${className}`}>
-      <div className={`uki-panel-core ${innerClassName}`}>{children}</div>
+    <div id={id} className={`uki-panel-shell min-w-0 ${className}`}>
+      <div className={`uki-panel-core min-w-0 ${innerClassName}`}>{children}</div>
     </div>
   );
 }

--- a/dapp/src/components/landing/wallet-connect-button.tsx
+++ b/dapp/src/components/landing/wallet-connect-button.tsx
@@ -13,6 +13,7 @@ import { WalletConnectorDialog } from './wallet-connector-dialog';
 
 type WalletConnectButtonProps = {
   className?: string;
+  evmOnly?: boolean;
   label?: string;
   compactLabel?: string;
   showCompactText?: boolean;
@@ -32,6 +33,7 @@ function isSameWalletAddress(left?: string | null, right?: string | null) {
 
 export function WalletConnectButton({
   className = '',
+  evmOnly = false,
   label = 'Conectar wallet',
   compactLabel = 'Wallet',
   showCompactText = true,
@@ -58,11 +60,25 @@ export function WalletConnectButton({
     () => (hasMounted ? getVisibleWalletConnectors(connectors) : []),
     [connectors, hasMounted],
   );
-  const activeAddress = hasMounted && isConnected ? address : hasMounted && isTronConnected ? tronAddress : null;
-  const activeWalletType = hasMounted && isConnected ? 'evm' : hasMounted && isTronConnected ? 'tron' : null;
+  const activeAddress = hasMounted && isConnected
+    ? address
+    : hasMounted && !evmOnly && isTronConnected
+      ? tronAddress
+      : null;
+  const activeWalletType = hasMounted && isConnected
+    ? 'evm'
+    : hasMounted && !evmOnly && isTronConnected
+      ? 'tron'
+      : null;
   const isWrongChain = hasMounted && isConnected && chainId !== UKI_PRESALE_CHAIN_ID;
   const isAuthenticatedWallet = isSameWalletAddress(user?.walletAddress, activeAddress);
-  const isBusy = hasMounted && (isPending || isSwitching || isAuthLoading || isWaitingForApproval || isTronLoading);
+  const isBusy = hasMounted && (
+    isPending ||
+    isSwitching ||
+    isAuthLoading ||
+    isWaitingForApproval ||
+    (!evmOnly && isTronLoading)
+  );
 
   const handleSwitchToPresaleChain = () => {
     switchChain(
@@ -165,7 +181,7 @@ export function WalletConnectButton({
       return;
     }
 
-    if (evmConnectors.length === 0 && !isTronInstalled) {
+    if (evmConnectors.length === 0 && (evmOnly || !isTronInstalled)) {
       toast({
         title: 'Wallet no encontrada',
         description: 'Instala una wallet EVM compatible para conectar.',
@@ -230,13 +246,17 @@ export function WalletConnectButton({
             : undefined
         }
         isConnecting={isPending}
-        description="Elige una wallet EVM para BSC o conecta TronLink en modo TRON."
-        tronLinkNative={{
-          error: tronError,
-          isInstalled: isTronInstalled,
-          isLoading: isTronLoading,
-          onSelect: handleConnectTron,
-        }}
+        description={evmOnly
+          ? `Elige una wallet EVM y acepta el cambio a ${UKI_PRESALE_CHAIN_LABEL}.`
+          : 'Elige una wallet EVM para BSC o conecta TronLink en modo TRON.'}
+        tronLinkNative={evmOnly
+          ? undefined
+          : {
+              error: tronError,
+              isInstalled: isTronInstalled,
+              isLoading: isTronLoading,
+              onSelect: handleConnectTron,
+            }}
       />
     </>
   );

--- a/dapp/src/components/launch/info-page.tsx
+++ b/dapp/src/components/launch/info-page.tsx
@@ -1,9 +1,8 @@
 import Image from 'next/image';
-import Link from 'next/link';
 import type { ReactNode } from 'react';
-import { ArrowRight, CheckCircle2 } from 'lucide-react';
+import { ArrowRight, CheckCircle2, ChevronDown } from 'lucide-react';
+import { LandingHeader } from '@/components/landing/header';
 import { LandingButton, Panel } from '@/components/landing/primitives';
-import { LandingWalletConnectButton } from '@/components/landing/wallet-connect-dynamic';
 
 type InfoMetric = {
   label: string;
@@ -36,15 +35,8 @@ type InfoPageProps = {
   beforeSections?: ReactNode;
   afterSections?: ReactNode;
   note?: string;
+  variant?: 'standard' | 'workspace';
 };
-
-const publicNav = [
-  { label: 'Inicio', href: '/' },
-  { label: 'Jugar', href: '/games/treasure-hunt' },
-  { label: 'Premios', href: '/premios' },
-  { label: 'Vesting', href: '/vesting' },
-  { label: 'Cukie Master', href: '/cukie-master' },
-];
 
 export function LaunchInfoPage({
   eyebrow,
@@ -59,39 +51,32 @@ export function LaunchInfoPage({
   beforeSections,
   afterSections,
   note,
+  variant = 'standard',
 }: InfoPageProps) {
+  const isWorkspace = variant === 'workspace';
+
   return (
-    <main className="uki-landing min-h-screen overflow-hidden bg-[var(--uki-bg)] text-[var(--uki-cream)]">
+    <main className="uki-landing min-h-screen overflow-x-clip bg-[var(--uki-bg)] text-[var(--uki-cream)]">
       <div className="uki-noise" />
       <div className="uki-grid-bg" />
-      <header className="uki-landing-header">
-        <nav className="uki-container flex h-[5.7rem] items-center justify-between">
-          <Link href="/" className="uki-header-logo relative block h-[5.1rem] w-48 overflow-hidden" aria-label="Inicio Cukies World">
-            <Image src="/Cukie_logo_first.png" alt="Cukies World" fill className="object-contain object-left" sizes="11rem" priority />
-          </Link>
+      <LandingHeader evmOnly={isWorkspace} />
 
-          <div className="hidden items-center gap-6 lg:flex">
-            {publicNav.map((item) => (
-              <Link key={item.href} href={item.href} className="uki-nav-link">
-                {item.label}
-              </Link>
-            ))}
-          </div>
-
-          <LandingWalletConnectButton />
-        </nav>
-      </header>
-
-      <section className="uki-container relative z-[2] grid min-h-[34rem] gap-8 pt-36 pb-12 lg:grid-cols-[0.92fr_1.08fr] lg:items-center">
-        <div>
+      <section className={`uki-container relative z-[2] grid min-w-0 gap-6 ${
+        isWorkspace
+          ? 'pb-7 pt-28 sm:grid-cols-[1.08fr_0.92fr] sm:items-center lg:min-h-[23rem] lg:gap-10'
+          : 'min-h-[34rem] pb-12 pt-36 lg:grid-cols-[0.92fr_1.08fr] lg:items-center'
+      }`}>
+        <div className="min-w-0">
           <p className="uki-launch-badge">{eyebrow}</p>
-          <h1 className="mt-5 max-w-4xl font-headline text-5xl font-black uppercase leading-[0.94] text-[var(--uki-cream)] sm:text-6xl lg:text-7xl">
+          <h1 className={`mt-5 max-w-4xl font-headline font-black uppercase leading-[0.94] text-[var(--uki-cream)] ${
+            isWorkspace ? 'text-4xl sm:text-5xl lg:text-6xl' : 'text-5xl sm:text-6xl lg:text-7xl'
+          }`}>
             {title}
           </h1>
-          <p className="mt-5 max-w-2xl text-lg leading-relaxed text-[var(--uki-text)]">
+          <p className={`mt-4 max-w-2xl leading-relaxed text-[var(--uki-text)] ${isWorkspace ? 'text-base sm:text-lg' : 'text-lg'}`}>
             {subtitle}
           </p>
-          <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+          <div className="mt-5 flex flex-col gap-3 sm:flex-row">
             <LandingButton href={primaryCta.href}>{primaryCta.label}</LandingButton>
             {secondaryCta ? (
               <LandingButton href={secondaryCta.href} variant="secondary">
@@ -101,68 +86,110 @@ export function LaunchInfoPage({
           </div>
         </div>
 
-        <div className="relative min-h-[22rem] overflow-hidden rounded-[14px] border border-[var(--uki-cyan-border)] bg-[#02090d] lg:min-h-[31rem]">
+        <div className={`relative min-w-0 overflow-hidden rounded-[14px] border border-[var(--uki-cyan-border)] bg-[#02090d] ${
+          isWorkspace ? 'hidden min-h-[14rem] sm:block lg:min-h-[18rem]' : 'min-h-[22rem] lg:min-h-[31rem]'
+        }`}>
           <Image src={heroImage} alt={heroAlt} fill className="object-cover" sizes="(min-width: 1024px) 52vw, 100vw" priority />
           <div className="absolute inset-0 bg-gradient-to-t from-[#02090d]/74 via-transparent to-transparent" />
         </div>
       </section>
 
-      <section className="uki-container relative z-[2] grid gap-3 pb-8 sm:grid-cols-2 lg:grid-cols-4">
-        {metrics.map((metric) => (
-          <article key={metric.label} className="rounded-[8px] border border-[var(--uki-cyan-border)] bg-[#071923]/82 p-4">
-            <p className="uki-label">{metric.label}</p>
-            <p className="mt-2 font-headline text-2xl font-black uppercase leading-tight text-[var(--uki-cream)]">{metric.value}</p>
-            {metric.helper ? <p className="mt-2 text-xs font-semibold leading-snug text-[var(--uki-muted)]">{metric.helper}</p> : null}
-          </article>
-        ))}
-      </section>
+      {!isWorkspace ? <InfoMetrics metrics={metrics} /> : null}
 
       {beforeSections}
 
-      <section className="uki-container relative z-[2] grid gap-4 pb-10 lg:grid-cols-2">
-        {sections.map((section) => (
-          <Panel key={section.title} innerClassName="h-full p-5 sm:p-6">
-            <div className="flex items-start gap-3">
-              <CheckCircle2 className="mt-1 h-5 w-5 shrink-0 text-[var(--uki-cyan)]" strokeWidth={1.8} />
-              <div>
-                <h2 className="font-headline text-xl font-black uppercase tracking-[0.04em] text-[var(--uki-cyan)]">{section.title}</h2>
-                {section.text ? <p className="mt-3 text-sm leading-relaxed text-[var(--uki-text)]">{section.text}</p> : null}
+      {isWorkspace ? (
+        <section id="como-funciona" className="uki-container relative z-[2] min-w-0 scroll-mt-28 pb-10">
+          <Panel className="min-w-0" innerClassName="min-w-0 overflow-hidden">
+            <details className="group">
+              <summary className="flex min-h-16 cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 text-left sm:px-7">
+                <div className="min-w-0">
+                  <p className="text-xs font-black uppercase tracking-[0.12em] text-[var(--uki-muted)]">Información secundaria</p>
+                  <h2 className="mt-1 font-headline text-xl font-black uppercase text-[var(--uki-cream)]">Reglas y requisitos</h2>
+                </div>
+                <ChevronDown className="h-5 w-5 shrink-0 text-[var(--uki-cyan)] transition-transform group-open:rotate-180" aria-hidden="true" />
+              </summary>
+              <div className="min-w-0 border-t border-white/10 p-4 sm:p-6">
+                <InfoMetrics metrics={metrics} nested />
+                <div className="mt-4 grid min-w-0 gap-4 lg:grid-cols-2">
+                  {sections.map((section) => <InfoSectionCard key={section.title} section={section} nested />)}
+                </div>
+                {note ? <InfoNote note={note} nested /> : null}
               </div>
-            </div>
-
-            {section.bullets ? (
-              <ul className="mt-5 space-y-3 text-sm font-semibold leading-relaxed text-[var(--uki-text)]">
-                {section.bullets.map((item) => (
-                  <li key={item} className="flex gap-3">
-                    <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-[var(--uki-gold)]" strokeWidth={1.8} />
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-
-            {section.table ? <InfoTable table={section.table} /> : null}
+            </details>
           </Panel>
-        ))}
-      </section>
+        </section>
+      ) : (
+        <>
+          <section className="uki-container relative z-[2] grid min-w-0 gap-4 pb-10 lg:grid-cols-2">
+            {sections.map((section) => <InfoSectionCard key={section.title} section={section} />)}
+          </section>
+          {note ? <InfoNote note={note} /> : null}
+        </>
+      )}
 
       {afterSections}
-
-      {note ? (
-        <section className="uki-container relative z-[2] pb-14">
-          <div className="rounded-[10px] border border-[var(--uki-cyan-border)] bg-[#071923]/82 p-5 text-sm font-semibold leading-relaxed text-[var(--uki-text)]">
-            {note}
-          </div>
-        </section>
-      ) : null}
     </main>
   );
 }
 
+function InfoMetrics({ metrics, nested = false }: { metrics: InfoMetric[]; nested?: boolean }) {
+  return (
+    <section className={`${nested ? '' : 'uki-container relative z-[2] pb-8'} grid min-w-0 gap-3 sm:grid-cols-2 lg:grid-cols-4`}>
+      {metrics.map((metric) => (
+        <article key={metric.label} className="min-w-0 rounded-[8px] border border-[var(--uki-cyan-border)] bg-[#071923]/82 p-4">
+          <p className="text-xs font-black uppercase tracking-[0.1em] text-[var(--uki-muted)]">{metric.label}</p>
+          <p className="mt-2 break-words font-headline text-2xl font-black uppercase leading-tight text-[var(--uki-cream)]">{metric.value}</p>
+          {metric.helper ? <p className="mt-2 text-xs font-semibold leading-snug text-[var(--uki-muted)]">{metric.helper}</p> : null}
+        </article>
+      ))}
+    </section>
+  );
+}
+
+function InfoSectionCard({ section, nested = false }: { section: InfoSection; nested?: boolean }) {
+  const Heading = nested ? 'h3' : 'h2';
+
+  return (
+    <Panel className="min-w-0" innerClassName="h-full min-w-0 p-5 sm:p-6">
+      <div className="flex min-w-0 items-start gap-3">
+        <CheckCircle2 className="mt-1 h-5 w-5 shrink-0 text-[var(--uki-cyan)]" strokeWidth={1.8} />
+        <div className="min-w-0">
+          <Heading className="break-words font-headline text-xl font-black uppercase tracking-[0.04em] text-[var(--uki-cyan)]">{section.title}</Heading>
+          {section.text ? <p className="mt-3 text-sm leading-relaxed text-[var(--uki-text)]">{section.text}</p> : null}
+        </div>
+      </div>
+
+      {section.bullets ? (
+        <ul className="mt-5 space-y-3 text-sm font-semibold leading-relaxed text-[var(--uki-text)]">
+          {section.bullets.map((item) => (
+            <li key={item} className="flex min-w-0 gap-3">
+              <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-[var(--uki-gold)]" strokeWidth={1.8} />
+              <span className="min-w-0 break-words">{item}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {section.table ? <InfoTable table={section.table} /> : null}
+    </Panel>
+  );
+}
+
+function InfoNote({ note, nested = false }: { note: string; nested?: boolean }) {
+  const content = (
+    <div className="rounded-[10px] border border-[var(--uki-cyan-border)] bg-[#071923]/82 p-5 text-sm font-semibold leading-relaxed text-[var(--uki-text)]">
+      {note}
+    </div>
+  );
+  if (nested) return <div className="mt-4">{content}</div>;
+  return <section className="uki-container relative z-[2] pb-14">{content}</section>;
+}
+
 function InfoTable({ table }: { table: InfoTable }) {
   return (
-    <div className="mt-5 overflow-x-auto rounded-[8px] border border-white/10">
-      <table className="w-full min-w-[34rem] border-collapse text-left text-sm">
+    <div className="mt-5 max-w-full overflow-x-auto rounded-[8px] border border-white/10">
+      <table className="w-full min-w-full border-collapse text-left text-sm sm:min-w-[34rem]">
         <thead className="bg-white/[0.06] text-[var(--uki-cyan)]">
           <tr>
             {table.headers.map((header) => (
@@ -176,7 +203,7 @@ function InfoTable({ table }: { table: InfoTable }) {
           {table.rows.map((row, rowIndex) => (
             <tr key={`row-${rowIndex}`}>
               {row.map((cell, cellIndex) => (
-                <td key={`cell-${rowIndex}-${cellIndex}`} className="px-4 py-3 align-top font-semibold">
+                <td key={`cell-${rowIndex}-${cellIndex}`} className="break-words px-4 py-3 align-top font-semibold">
                   {cell}
                 </td>
               ))}

--- a/dapp/src/hooks/use-tronlink.ts
+++ b/dapp/src/hooks/use-tronlink.ts
@@ -18,6 +18,35 @@ interface TronLinkState {
   error: string | null;
 }
 
+const TRONLINK_DISCONNECTED_STORAGE_KEY = 'cukies:tronlink:disconnected';
+let tronLinkManuallyDisconnected = false;
+
+function isManualDisconnectActive() {
+  if (tronLinkManuallyDisconnected) return true;
+  if (typeof window === 'undefined') return false;
+
+  try {
+    return window.localStorage.getItem(TRONLINK_DISCONNECTED_STORAGE_KEY) === '1';
+  } catch {
+    return tronLinkManuallyDisconnected;
+  }
+}
+
+function setManualDisconnect(active: boolean) {
+  tronLinkManuallyDisconnected = active;
+  if (typeof window === 'undefined') return;
+
+  try {
+    if (active) {
+      window.localStorage.setItem(TRONLINK_DISCONNECTED_STORAGE_KEY, '1');
+    } else {
+      window.localStorage.removeItem(TRONLINK_DISCONNECTED_STORAGE_KEY);
+    }
+  } catch {
+    // The in-memory flag still keeps every hook instance disconnected in this page.
+  }
+}
+
 function getTronWeb() {
   if (typeof window === 'undefined') return null;
   return window.tronWeb ?? window.tronLink?.tronWeb ?? window.tron?.tronWeb ?? null;
@@ -73,10 +102,22 @@ export function useTronLink() {
     if (typeof window === 'undefined') return;
 
     try {
+      const isInstalled = Boolean(window.tron || window.tronWeb || window.tronLink);
+      if (isManualDisconnectActive()) {
+        setState((prev) => ({
+          ...prev,
+          isInstalled,
+          isConnected: false,
+          address: null,
+          isLoading: false,
+        }));
+        return;
+      }
+
       const address = getTronAddress();
       setState((prev) => ({
         ...prev,
-        isInstalled: Boolean(window.tron || window.tronWeb || window.tronLink),
+        isInstalled,
         isConnected: Boolean(address),
         address,
         error: address ? null : prev.error,
@@ -88,33 +129,17 @@ export function useTronLink() {
   }, []);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const checkTronLink = () => {
-        const isInstalled = !!(window.tron || window.tronWeb || window.tronLink);
-        const address = getTronAddress();
-        setState((prev) => ({
-          ...prev,
-          isInstalled,
-          isConnected: Boolean(address),
-          address,
-          isLoading: false,
-        }));
-      };
-
-      checkTronLink();
-
-      const interval = setInterval(checkTronLink, 1000);
-      return () => clearInterval(interval);
-    }
-  }, []);
-
-  useEffect(() => {
     if (typeof window === 'undefined') return;
 
     const handleMessage = (event: MessageEvent) => {
       const action = event.data?.message?.action ?? event.data?.action;
       const address = event.data?.message?.data?.address;
       if (typeof address === 'string') {
+        if (isManualDisconnectActive()) {
+          syncConnection();
+          return;
+        }
+
         setState((prev) => ({
           ...prev,
           isInstalled: true,
@@ -142,6 +167,11 @@ export function useTronLink() {
 
     const tron = window.tron;
     const handleAccountsChanged = (accounts: unknown) => {
+      if (isManualDisconnectActive()) {
+        syncConnection();
+        return;
+      }
+
       const [address] = Array.isArray(accounts) ? accounts : [];
       setState((prev) => ({
         ...prev,
@@ -152,21 +182,26 @@ export function useTronLink() {
         isLoading: false,
       }));
     };
+    const handleManualDisconnect = () => syncConnection();
 
     tron?.on?.('accountsChanged', handleAccountsChanged);
     window.addEventListener('message', handleMessage);
     window.addEventListener('focus', syncConnection);
     window.addEventListener('tronlink:connected', syncConnection);
+    window.addEventListener('tronlink:disconnected', handleManualDisconnect);
+    window.addEventListener('storage', syncConnection);
 
     const interval = setInterval(syncConnection, 1000);
     return () => {
       window.removeEventListener('message', handleMessage);
       window.removeEventListener('focus', syncConnection);
       window.removeEventListener('tronlink:connected', syncConnection);
+      window.removeEventListener('tronlink:disconnected', handleManualDisconnect);
+      window.removeEventListener('storage', syncConnection);
       tron?.removeListener?.('accountsChanged', handleAccountsChanged);
       clearInterval(interval);
     };
-  }, [state.isInstalled, syncConnection]);
+  }, [syncConnection]);
 
   const connect = useCallback(async () => {
     if (typeof window === 'undefined') {
@@ -177,6 +212,7 @@ export function useTronLink() {
       return null;
     }
 
+    setManualDisconnect(false);
     setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
     try {
@@ -285,11 +321,14 @@ export function useTronLink() {
   }, []);
 
   const disconnect = useCallback(() => {
+    setManualDisconnect(true);
     setState((prev) => ({
       ...prev,
       isConnected: false,
       address: null,
+      isLoading: false,
     }));
+    window.dispatchEvent(new Event('tronlink:disconnected'));
   }, []);
 
   return {

--- a/dapp/src/lib/uki-economy/cukie-master/nft-operations.ts
+++ b/dapp/src/lib/uki-economy/cukie-master/nft-operations.ts
@@ -9,9 +9,11 @@ import {
 import { createMongoNftAssetLockRepository } from '@/lib/nft-inventory/lock-repository';
 import { createNftAssetLockService } from '@/lib/nft-inventory/locks';
 import type { NftAssetLockDocument } from '@/lib/nft-inventory/lock-types';
+import { getLegacyMarketplaceNftImageUrl } from '@/lib/legacy-marketplace/config';
 import { normalizeWalletAddress } from '@/lib/wallet-address';
 
 import { DomainConflictError, DomainNotFoundError, DomainValidationError } from '../errors';
+import { CUKIE_MASTER_ORIGINAL_RARITY_POINTS } from '../rules';
 import { createMongoCukieMasterRepository } from './repository';
 import { createCukieMasterService } from './service';
 
@@ -20,14 +22,25 @@ export type CukieMasterNftOperation = 'soft_stake' | 'unstake';
 export type CukieMasterNftInventoryItem = {
   assetId: string;
   tokenId: string | null;
+  imageUrl: string | null;
   rarity: string;
   rarityPoints: number | null;
+  contributesToCukieMaster: boolean;
+  contributionPoints: number;
   state: string;
   blockers: NftInventoryBlocker[];
   lock: null | { lockId: string; fencingToken: number };
   canSoftStake: boolean;
   canUnstake: boolean;
 };
+
+function pointsForRarity(rarity: string) {
+  return Object.prototype.hasOwnProperty.call(CUKIE_MASTER_ORIGINAL_RARITY_POINTS, rarity)
+    ? CUKIE_MASTER_ORIGINAL_RARITY_POINTS[
+      rarity as keyof typeof CUKIE_MASTER_ORIGINAL_RARITY_POINTS
+    ]
+    : null;
+}
 
 export type CukieMasterNftOperationInput = {
   walletAddress: string;
@@ -87,20 +100,28 @@ async function inventoryFromDb(
   return normalized
     .map(({ asset, rarityPoints, blockers }) => {
       const lock = activeByAsset.get(asset.assetId);
-      const compatible = lock?.reason === 'soft_stake'
+      const compatibleSoftStake = lock?.reason === 'soft_stake'
         && lock.ownerNormalized === summary.walletNormalized;
+      const retainedGameEntitlement = lock?.reason === 'game_assignment'
+        && lock.ownerNormalized === summary.walletNormalized
+        && lock.retainsSoftStakeEntitlement === true;
+      const contributesToCukieMaster = compatibleSoftStake || retainedGameEntitlement;
+      const potentialPoints = rarityPoints ?? pointsForRarity(asset.rarity);
       return {
         assetId: asset.assetId,
         tokenId: asset.tokenId,
+        imageUrl: asset.tokenId ? getLegacyMarketplaceNftImageUrl(asset.tokenId) : null,
         rarity: asset.rarity,
-        rarityPoints,
+        rarityPoints: potentialPoints,
+        contributesToCukieMaster,
+        contributionPoints: contributesToCukieMaster ? potentialPoints ?? 0 : 0,
         state: asset.canonicalState,
         blockers,
-        lock: compatible && lock
+        lock: compatibleSoftStake && lock
           ? { lockId: lock.lockId, fencingToken: lock.fencingToken }
           : null,
         canSoftStake: asset.canonicalState === 'available' && blockers.length === 0,
-        canUnstake: asset.canonicalState === 'soft_staked' && compatible,
+        canUnstake: asset.canonicalState === 'soft_staked' && compatibleSoftStake,
       } satisfies CukieMasterNftInventoryItem;
     })
     .sort((left, right) => left.assetId.localeCompare(right.assetId));


### PR DESCRIPTION
## Qué cambia

- exige una sesión EVM autenticada para operar el staking de UKI y mantiene TronLink nativo fuera de ese flujo
- persiste la desconexión manual de TronLink para evitar reconexiones automáticas
- rediseña `/cukie-master` como workspace operativo: estado personal primero, rutas UKI/Cukies y siguiente acción explícita
- muestra vesting + staking, requisitos, déficit, cupos activos/en validación/en gracia y progreso por ruta
- añade inventario visual de Cukies Originales con imagen, rareza, puntos potenciales, contribución real, bloqueos y acciones contextuales
- convierte el staking en un flujo guiado de wallet, red, firma, autorización y depósito/retirada
- falla cerrado en staging si la cadena configurada no es BSC Testnet (`97`)
- actualiza el estado automáticamente tras una transacción y ofrece refresco manual mientras el indexador proyecta el evento
- oculta créditos de competición mientras su runtime esté desactivado
- corrige navegación móvil, foco, áreas táctiles, scroll de anclas y overflow responsive

## Motivo

La pantalla anterior mezclaba explicación, cifras y operaciones sin dejar claro qué activos ya contaban ni qué acción necesitaba cada wallet. También permitía estados ambiguos entre TronLink, autenticación EVM, red e indexación posterior a una transacción.

## Validación

- `pnpm --filter dapp exec tsc --noEmit --incremental false` OK
- `pnpm dapp lint` OK
- `pnpm --filter dapp exec jest --runInBand` OK: 128 suites, 1.044 tests
- `pnpm dapp build` OK
- `pnpm guard:staging:test` OK: 22 guardarraíles
- smoke responsive local en 360, 390, 768 y 1.440 px, sin overflow y con controles mínimos de 44×44 px

## Alcance y seguridad

La PR apunta exclusivamente a `staging`. No modifica contratos, direcciones, reglas económicas, schedulers, secretos, bases de producción ni el recurso Coolify de producción.
