### PR TITLE
[OPS][P0] Enforce staging-to-main promotion gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+/.github/workflows/ @fgomezserna @JairoGG-ai @accesovip
+/.github/release/ @fgomezserna @JairoGG-ai @accesovip
+/scripts/release/ @fgomezserna @JairoGG-ai @accesovip
+/.github/CODEOWNERS @fgomezserna @JairoGG-ai @accesovip

--- a/.github/ISSUE_TEMPLATE/release_candidate.yml
+++ b/.github/ISSUE_TEMPLATE/release_candidate.yml
@@ -1,13 +1,14 @@
 name: Release candidate
-description: Agrupa issues, validacion, responsables y decision go/no-go para una release UKI.
+description: Agrupa el SHA exacto de staging, validacion y decision para promover a main/live.
 title: "[RC] UKI <fase> <YYYY-MM-DD>"
 labels: ["area:ops", "area:security"]
 body:
   - type: markdown
     attributes:
       value: |
-        Usa esta plantilla para congelar una release candidate antes de promover cambios entre entornos.
-        Produccion requiere aprobacion explicita de tech, producto/QA y ops.
+        Usa esta plantilla para congelar el SHA exacto desplegado desde `staging`.
+        `main`/live solo recibe un PR desde `staging` tras deploy, QA y aprobacion explicita.
+        Mainnet y preventa permanecen congeladas; abrir esta RC no autoriza una promocion.
 
   - type: input
     id: release_name
@@ -24,9 +25,8 @@ body:
       label: Entorno objetivo
       description: Donde se quiere validar o publicar esta RC.
       options:
-        - Staging
-        - Production
-        - Staging y despues production
+        - Staging (deploy y QA)
+        - Main/live (promocion desde staging)
     validations:
       required: true
 
@@ -34,8 +34,8 @@ body:
     id: source_ref
     attributes:
       label: Ref origen
-      description: Rama, tag o commit que contiene los cambios.
-      placeholder: "main, release/staging-2026-05-13 o <sha>"
+      description: Rama staging y SHA completo exacto que contiene los cambios.
+      placeholder: "staging@0123456789abcdef0123456789abcdef01234567"
     validations:
       required: true
 
@@ -43,8 +43,8 @@ body:
     id: target_ref
     attributes:
       label: Ref destino
-      description: Rama, tag o deploy target esperado.
-      placeholder: "main, production, staging-20260513.1 o prod-20260513.1"
+      description: Destino controlado del candidato.
+      placeholder: "main (y tag prod-YYYYMMDD.N si aplica al mismo SHA)"
     validations:
       required: true
 
@@ -155,7 +155,7 @@ body:
       placeholder: |
         - Se cierran al merge:
         - Se cierran tras staging validado:
-        - Se cierran tras production validado:
+        - Se cierran tras main/live validado:
         - Permanecen abiertas/bloqueadas:
     validations:
       required: true
@@ -164,7 +164,7 @@ body:
     id: go_no_go
     attributes:
       label: Decision go/no-go
-      description: Completar o actualizar antes de publicar production.
+      description: Completar o actualizar antes de promover staging a main/live.
       value: |
         | Rol | Responsable | Decision | Fecha/hora | Nota |
         | --- | --- | --- | --- | --- |
@@ -183,5 +183,7 @@ body:
       options:
         - label: La RC tiene alcance cerrado y no mezcla trabajo fuera de la lista incluida.
           required: true
-        - label: Entiendo que production no se publica sin go explicito de tech, producto/QA y ops.
+        - label: Entiendo que main/live no se promueve sin go explicito de tech, producto/QA y ops.
+          required: true
+        - label: Si el destino es main, el PR incluira promotion.json ligado al PR/base SHA y el merge volvera por sync/main-* a staging.
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+- What changes:
+- Why:
+- Validation:
+
+## Release mode
+
+- [ ] Regular feature/fix targeting `staging`
+- [ ] Normal promotion from `staging` to `main`
+- [ ] Formal hotfix from `hotfix/*` to `main`
+
+For a PR targeting `main`, create or update `.github/release/promotion.json` in the PR head after
+the PR number is known. That file—not this mutable body or the labels—is the authorization source.
+It must follow `.github/release/promotion.schema.json` and bind both the exact PR number and current
+`main` base SHA. Any manifest change creates a new candidate SHA and invalidates earlier evidence.
+
+## Informational release notes
+
+- Candidate/head SHA:
+- Staging deployment and QA URLs (normal promotion):
+- Incident and production impact (hotfix):
+- Why staging cannot wait (hotfix):
+- Rollback:
+
+## Checklist
+
+- [ ] No secrets, generated env files or unrelated changes are included.
+- [ ] Tests and checks for the touched area are recorded above.
+- [ ] A normal promotion has the exact candidate deployed and approved in protected `Staging`.
+- [ ] A hotfix has an incident, urgency, exception reason and rollback in the immutable manifest.
+- [ ] Every merge to `main` will return through `sync/main-*`; that PR is reviewed, merged with a merge commit and never auto-merged.

--- a/.github/release/promotion.schema.json
+++ b/.github/release/promotion.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/fgomezserna/cukies-hub/.github/release/promotion.schema.json",
+  "title": "Cukies Hub immutable promotion manifest",
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "mode",
+        "pullRequest",
+        "baseSha",
+        "stagingEvidence",
+        "rollback"
+      ],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "mode": { "const": "normal" },
+        "pullRequest": { "type": "integer", "minimum": 1 },
+        "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "stagingEvidence": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 10,
+          "uniqueItems": true,
+          "items": { "type": "string", "format": "uri", "pattern": "^https://" }
+        },
+        "rollback": { "type": "string", "minLength": 16, "maxLength": 4000 }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "mode",
+        "pullRequest",
+        "baseSha",
+        "incident",
+        "urgency",
+        "whyStagingCannotWait",
+        "rollback"
+      ],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "mode": { "const": "hotfix" },
+        "pullRequest": { "type": "integer", "minimum": 1 },
+        "baseSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "incident": { "type": "string", "minLength": 16, "maxLength": 4000 },
+        "urgency": { "type": "string", "minLength": 16, "maxLength": 4000 },
+        "whyStagingCannotWait": { "type": "string", "minLength": 16, "maxLength": 4000 },
+        "rollback": { "type": "string", "minLength": 16, "maxLength": 4000 }
+      }
+    }
+  ]
+}

--- a/.github/workflows/main-promotion-gate.yml
+++ b/.github/workflows/main-promotion-gate.yml
@@ -1,0 +1,251 @@
+name: Main promotion gate
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: main-promotion-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  promotion-gate:
+    name: release/promotion-gate-runner
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: Release Gate
+      url: ${{ github.event.pull_request.html_url }}
+    steps:
+      # actions/create-github-app-token v2, pinned. The private key exists only in the protected
+      # Release Gate environment, so an arbitrary branch workflow cannot mint this identity.
+      - name: Mint the dedicated release status token
+        id: release_app
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ vars.RELEASE_GATE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_GATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-statuses: write
+
+      - name: Load the live pull request and immutable promotion manifest
+        id: live_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          raw_path="$RUNNER_TEMP/live-pr-${PR_NUMBER}.json"
+          event_path="$RUNNER_TEMP/live-pr-event-${PR_NUMBER}.json"
+          for attempt in {1..12}; do
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "$raw_path"
+            if jq -e --argjson pr_number "$PR_NUMBER" '
+              select(.number == $pr_number)
+              | select(.state == "open")
+              | select(.base.ref == "main")
+              | select(.head.sha | (type == "string" and test("^[0-9a-f]{40}$")))
+              | select(.head.ref | (type == "string" and length > 0))
+              | select(.mergeable == true)
+              | select(.merge_commit_sha | (type == "string" and test("^[0-9a-f]{40}$")))
+            ' "$raw_path" >/dev/null; then
+              break
+            fi
+            if [[ "$attempt" == '12' ]]; then
+              echo 'GitHub did not produce a mergeable, stable test merge commit.' >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          head_sha="$(jq -r '.head.sha' "$raw_path")"
+          head_ref="$(jq -r '.head.ref' "$raw_path")"
+          merge_sha="$(jq -r '.merge_commit_sha' "$raw_path")"
+          base_sha="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" \
+            --jq '.object.sha')"
+          merge_ref_sha="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/pull/${PR_NUMBER}/merge" \
+            --jq '.object.sha')"
+          if [[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo 'The live refs/heads/main SHA is invalid.' >&2
+            exit 1
+          fi
+          if [[ ! "$merge_ref_sha" =~ ^[0-9a-f]{40}$ || "$merge_ref_sha" != "$merge_sha" ]]; then
+            echo 'The live refs/pull test-merge SHA does not match the pull request payload.' >&2
+            exit 1
+          fi
+          manifest_path="$RUNNER_TEMP/promotion-${PR_NUMBER}-${head_sha}.json"
+          gh api \
+            -H 'Accept: application/vnd.github.raw+json' \
+            "repos/${GITHUB_REPOSITORY}/contents/.github/release/promotion.json?ref=${head_sha}" \
+            > "$manifest_path"
+          jq -c --arg base_sha "$base_sha" \
+            '.base.sha = $base_sha | { pull_request: . }' \
+            "$raw_path" > "$event_path"
+          printf 'head_sha=%s\n' "$head_sha" >> "$GITHUB_OUTPUT"
+          printf 'head_ref=%s\n' "$head_ref" >> "$GITHUB_OUTPUT"
+          printf 'base_sha=%s\n' "$base_sha" >> "$GITHUB_OUTPUT"
+          printf 'merge_sha=%s\n' "$merge_sha" >> "$GITHUB_OUTPUT"
+          if [[ "$head_ref" == 'staging' ]]; then
+            printf 'mode=normal\n' >> "$GITHUB_OUTPUT"
+          else
+            printf 'mode=hotfix\n' >> "$GITHUB_OUTPUT"
+          fi
+          printf 'event_path=%s\n' "$event_path" >> "$GITHUB_OUTPUT"
+          printf 'manifest_path=%s\n' "$manifest_path" >> "$GITHUB_OUTPUT"
+
+      - name: Publish pending promotion status on the GitHub test merge
+        env:
+          GH_TOKEN: ${{ steps.release_app.outputs.token }}
+          MERGE_SHA: ${{ steps.live_pr.outputs.merge_sha }}
+          STATUS_TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${MERGE_SHA}" \
+            -f state='pending' \
+            -f context='release/promotion-gate' \
+            -f description='Immutable promotion policy and release evidence are being verified.' \
+            -f target_url="$STATUS_TARGET_URL" >/dev/null
+
+      # actions/checkout v4.2.2. This is the trusted base SHA, never the PR head.
+      - name: Checkout trusted release tooling from the PR base
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ steps.live_pr.outputs.base_sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Enforce normal or hotfix promotion policy
+        env:
+          GITHUB_EVENT_PATH: ${{ steps.live_pr.outputs.event_path }}
+          PROMOTION_MANIFEST_PATH: ${{ steps.live_pr.outputs.manifest_path }}
+        run: node scripts/release/promotion-policy.mjs
+
+      - name: Verify the exact GitHub test merge and staging content parity
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PROMOTION_BASE_SHA: ${{ steps.live_pr.outputs.base_sha }}
+          PROMOTION_HEAD_SHA: ${{ steps.live_pr.outputs.head_sha }}
+          PROMOTION_MERGE_SHA: ${{ steps.live_pr.outputs.merge_sha }}
+          PROMOTION_MODE: ${{ steps.live_pr.outputs.mode }}
+        run: node scripts/release/verify-promotion-merge.mjs
+
+      - name: Verify the exact staging deployment for a normal promotion
+        if: steps.live_pr.outputs.head_ref == 'staging'
+        env:
+          RELEASE_CANDIDATE_SHA: ${{ steps.live_pr.outputs.head_sha }}
+          STAGING_HEALTH_URL: https://cukieshub.eurekand.com/api/health
+          DEPLOYMENT_VERIFY_TIMEOUT_MS: '120000'
+          DEPLOYMENT_VERIFY_INTERVAL_MS: '10000'
+          DEPLOYMENT_REQUEST_TIMEOUT_MS: '15000'
+        run: node scripts/release/verify-deployment.mjs
+
+      - name: Verify protected staging attestations for a normal promotion
+        if: steps.live_pr.outputs.head_ref == 'staging'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_CANDIDATE_SHA: ${{ steps.live_pr.outputs.head_sha }}
+          RELEASE_STATUS_CREATOR_LOGIN: ${{ steps.release_app.outputs.app-slug }}[bot]
+        run: node scripts/release/verify-attestations.mjs --repository "$GITHUB_REPOSITORY"
+
+      - name: Record the accepted promotion mode
+        env:
+          HEAD_REF: ${{ steps.live_pr.outputs.head_ref }}
+        run: |
+          set -euo pipefail
+          if [[ "$HEAD_REF" == 'staging' ]]; then
+            echo 'Normal staging promotion passed immutable policy, exact health, attestations and ancestry.'
+          else
+            echo 'Formal hotfix passed immutable policy; staging attestations are intentionally bypassed.'
+          fi
+
+      - name: Revalidate the live PR and test merge binding immediately before success
+        if: success()
+        env:
+          EXPECTED_HEAD_SHA: ${{ steps.live_pr.outputs.head_sha }}
+          EXPECTED_BASE_SHA: ${{ steps.live_pr.outputs.base_sha }}
+          EXPECTED_MERGE_SHA: ${{ steps.live_pr.outputs.merge_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PROMOTION_MANIFEST_PATH: ${{ steps.live_pr.outputs.manifest_path }}
+        run: |
+          set -euo pipefail
+          raw_path="$RUNNER_TEMP/final-live-pr-${PR_NUMBER}.json"
+          event_path="$RUNNER_TEMP/final-live-pr-event-${PR_NUMBER}.json"
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "$raw_path"
+          jq -e \
+            --argjson pr_number "$PR_NUMBER" \
+            --arg head_sha "$EXPECTED_HEAD_SHA" \
+            --arg merge_sha "$EXPECTED_MERGE_SHA" '
+            select(.number == $pr_number)
+            | select(.state == "open")
+            | select(.base.ref == "main")
+            | select(.head.sha == $head_sha)
+            | select(.mergeable == true)
+            | select(.merge_commit_sha == $merge_sha)
+          ' "$raw_path" >/dev/null
+          live_base_ref="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" \
+            --jq '.object.sha')"
+          if [[ "$live_base_ref" != "$EXPECTED_BASE_SHA" ]]; then
+            echo 'The live refs/heads/main SHA changed during verification.' >&2
+            exit 1
+          fi
+          live_merge_ref="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/pull/${PR_NUMBER}/merge" \
+            --jq '.object.sha')"
+          if [[ "$live_merge_ref" != "$EXPECTED_MERGE_SHA" ]]; then
+            echo 'The live refs/pull test merge changed during verification.' >&2
+            exit 1
+          fi
+          jq -c --arg base_sha "$EXPECTED_BASE_SHA" \
+            '.base.sha = $base_sha | { pull_request: . }' \
+            "$raw_path" > "$event_path"
+          unset GH_TOKEN
+          GITHUB_EVENT_PATH="$event_path" node scripts/release/promotion-policy.mjs
+          GITHUB_TOKEN="${{ github.token }}" \
+            PROMOTION_BASE_SHA="$EXPECTED_BASE_SHA" \
+            PROMOTION_HEAD_SHA="$EXPECTED_HEAD_SHA" \
+            PROMOTION_MERGE_SHA="$EXPECTED_MERGE_SHA" \
+            PROMOTION_MODE="${{ steps.live_pr.outputs.mode }}" \
+            node scripts/release/verify-promotion-merge.mjs
+
+      - name: Publish terminal promotion status on the GitHub test merge
+        if: always() && steps.live_pr.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.release_app.outputs.token }}
+          MERGE_SHA: ${{ steps.live_pr.outputs.merge_sha }}
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          case "$JOB_STATUS" in
+            success)
+              state='success'
+              description='Dedicated release gate passed for this exact test-merge SHA.'
+              ;;
+            cancelled)
+              state='error'
+              description='Release gate was cancelled for this test-merge SHA.'
+              ;;
+            *)
+              state='failure'
+              description='Release gate failed for this test-merge SHA.'
+              ;;
+          esac
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${MERGE_SHA}" \
+            -f state="$state" \
+            -f context='release/promotion-gate' \
+            -f description="$description" \
+            -f target_url="$STATUS_TARGET_URL" >/dev/null

--- a/.github/workflows/main-staging-sync.yml
+++ b/.github/workflows/main-staging-sync.yml
@@ -1,0 +1,172 @@
+name: Sync every main merge back to staging
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: main-staging-sync-${{ github.event.pull_request.merge_commit_sha }}
+  cancel-in-progress: false
+
+jobs:
+  sync-main:
+    name: release/main-staging-sync
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: Release Gate
+      url: ${{ github.event.pull_request.html_url }}
+    steps:
+      # The repository GITHUB_TOKEN cannot create pull requests. The dedicated App key is exposed
+      # only to this trusted main workflow after Release Gate approval.
+      - name: Mint the dedicated sync token
+        id: release_app
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ vars.RELEASE_GATE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_GATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      # actions/github-script v7, pinned. It uses only trusted base workflow and event/API data.
+      - name: Create the mandatory idempotent staging sync pull request
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          github-token: ${{ steps.release_app.outputs.token }}
+          script: |
+            const pullRequest = context.payload.pull_request;
+            const mergeSha = pullRequest?.merge_commit_sha;
+            if (!/^[0-9a-f]{40}$/.test(mergeSha ?? '')) {
+              core.setFailed('Merged main PR does not expose a full merge commit SHA.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const shortSha = mergeSha.slice(0, 12);
+            const branch = `sync/main-${shortSha}`;
+            const ref = `heads/${branch}`;
+
+            const stagingComparison = await github.rest.repos.compareCommitsWithBasehead({
+              owner,
+              repo,
+              basehead: `${mergeSha}...staging`,
+            });
+            if (['ahead', 'identical'].includes(stagingComparison.data.status)) {
+              core.info(`staging already contains exact main SHA ${mergeSha}.`);
+              await core.summary
+                .addHeading('Mandatory main to staging sync')
+                .addRaw(`\`staging\` already contains exact main SHA \`${mergeSha}\`.`)
+                .write();
+              return;
+            }
+            if (!['behind', 'diverged'].includes(stagingComparison.data.status)) {
+              core.setFailed('GitHub compare returned an unknown staging ancestry state.');
+              return;
+            }
+
+            let existingRef;
+            try {
+              existingRef = await github.rest.git.getRef({ owner, repo, ref });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+            if (existingRef) {
+              if (existingRef.data.object.sha !== mergeSha) {
+                core.setFailed(`Existing ${branch} does not point to the expected main merge SHA.`);
+                return;
+              }
+            } else {
+              await github.rest.git.createRef({
+                owner,
+                repo,
+                ref: `refs/heads/${branch}`,
+                sha: mergeSha,
+              });
+            }
+
+            const head = `${owner}:${branch}`;
+            const response = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'all',
+              head,
+              base: 'staging',
+              per_page: 100,
+            });
+            const matches = response.data.filter((candidate) =>
+              candidate.head.ref === branch && candidate.base.ref === 'staging');
+
+            if (matches.length > 1) {
+              core.setFailed(`More than one staging sync PR exists for ${branch}.`);
+              return;
+            }
+            if (matches.length === 1) {
+              const existing = matches[0];
+              if (existing.state === 'open') {
+                core.info(`Staging sync already exists: ${existing.html_url}`);
+                await core.summary
+                  .addHeading('Mandatory main to staging sync')
+                  .addLink(`PR #${existing.number}`, existing.html_url)
+                  .addRaw(` already covers exact main SHA \`${mergeSha}\`.`)
+                  .write();
+                return;
+              }
+              if (existing.merged_at) {
+                core.setFailed(
+                  `Sync PR #${existing.number} was merged without preserving exact main ancestry. `
+                  + 'Create a recovery PR and use Create a merge commit.',
+                );
+                return;
+              }
+              core.setFailed(`Existing sync PR #${existing.number} was closed without merge.`);
+              return;
+            }
+
+            let created;
+            try {
+              created = await github.rest.pulls.create({
+                owner,
+                repo,
+                head: branch,
+                base: 'staging',
+                title: `sync: main ${shortSha} back to staging`,
+                body: [
+                  `Mandatory staging sync after main PR #${pullRequest.number}.`,
+                  '',
+                  `Exact main merge SHA: \`${mergeSha}\``,
+                  `Original source branch: \`${pullRequest.head.ref}\``,
+                  '',
+                  '**Required merge method: Create a merge commit.**',
+                  'Squash or rebase would rewrite the main SHA and keep the next promotion blocked.',
+                  '',
+                  'This PR is intentionally not auto-merged. Review it and validate staging.',
+                ].join('\n'),
+                maintainer_can_modify: false,
+                draft: false,
+              });
+            } catch (error) {
+              core.setFailed(`Could not create the mandatory staging sync PR (HTTP ${error.status ?? 'unknown'}).`);
+              return;
+            }
+
+            if (!created?.data?.html_url) {
+              core.setFailed('GitHub API did not return the created staging sync PR.');
+              return;
+            }
+            core.info(`Created staging sync PR: ${created.data.html_url}`);
+            await core.summary
+              .addHeading('Mandatory main to staging sync')
+              .addLink(`PR #${created.data.number}`, created.data.html_url)
+              .addRaw(` created from exact main SHA \`${mergeSha}\` without auto-merge.`)
+              .write();

--- a/.github/workflows/staging-deploy-verify.yml
+++ b/.github/workflows/staging-deploy-verify.yml
@@ -1,0 +1,140 @@
+name: Staging deploy verification
+run-name: Staging deploy ${{ github.sha }}
+
+on:
+  push:
+    branches:
+      - staging
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: staging-deploy-verify-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-and-attest-staging:
+    name: release/staging-verify-and-attest
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    environment:
+      name: Staging
+      url: https://cukieshub.eurekand.com
+    steps:
+      # actions/create-github-app-token v2, pinned. The key is released only after approval of the
+      # protected Staging environment and cannot be read by workflows on arbitrary branches.
+      - name: Mint the dedicated release status token
+        id: release_app
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ vars.RELEASE_GATE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_GATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-statuses: write
+
+      - name: Publish pending staging statuses
+        env:
+          GH_TOKEN: ${{ steps.release_app.outputs.token }}
+          STATUS_TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          for context in release/staging-deployed release/staging-validated; do
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+              -f state='pending' \
+              -f context="$context" \
+              -f description='Protected staging verification is running.' \
+              -f target_url="$STATUS_TARGET_URL" >/dev/null
+          done
+
+      # actions/checkout v4.2.2. The push SHA is protected staging, never unreviewed PR code.
+      - name: Checkout the exact staging commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Wait for the exact staging health contract
+        env:
+          RELEASE_CANDIDATE_SHA: ${{ github.sha }}
+          STAGING_HEALTH_URL: https://cukieshub.eurekand.com/api/health
+          DEPLOYMENT_VERIFY_TIMEOUT_MS: '900000'
+          DEPLOYMENT_VERIFY_INTERVAL_MS: '15000'
+          DEPLOYMENT_REQUEST_TIMEOUT_MS: '15000'
+        run: node scripts/release/verify-deployment.mjs
+
+      - name: Run the minimum public smoke
+        env:
+          STAGING_PUBLIC_URL: https://cukieshub.eurekand.com/
+        run: |
+          set -euo pipefail
+          http_code="$(curl --silent --show-error --max-time 30 --output /dev/null --write-out '%{http_code}' "$STAGING_PUBLIC_URL")"
+          if [[ "$http_code" != '200' ]]; then
+            echo "Public staging smoke failed with HTTP ${http_code}." >&2
+            exit 1
+          fi
+          echo 'Public staging smoke returned HTTP 200.'
+
+      - name: Publish exact deployment success for internal QA
+        env:
+          GH_TOKEN: ${{ steps.release_app.outputs.token }}
+          STATUS_TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            -f state='success' \
+            -f context='release/staging-deployed' \
+            -f description='Exact staging deployment and public smoke passed.' \
+            -f target_url="$STATUS_TARGET_URL" >/dev/null
+
+      - name: Verify protected environment and current-run provenance
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_ATTESTATION_CONTEXT: staging-push-qa
+          RELEASE_CANDIDATE_SHA: ${{ github.sha }}
+          RELEASE_STATUS_CREATOR_LOGIN: ${{ steps.release_app.outputs.app-slug }}[bot]
+        run: >-
+          node scripts/release/verify-attestations.mjs
+          --repository "$GITHUB_REPOSITORY"
+          --staging-push-qa-current-run
+
+      - name: Verify the exact staging health contract again
+        env:
+          RELEASE_CANDIDATE_SHA: ${{ github.sha }}
+          STAGING_HEALTH_URL: https://cukieshub.eurekand.com/api/health
+          DEPLOYMENT_VERIFY_TIMEOUT_MS: '120000'
+          DEPLOYMENT_VERIFY_INTERVAL_MS: '10000'
+          DEPLOYMENT_REQUEST_TIMEOUT_MS: '15000'
+        run: node scripts/release/verify-deployment.mjs
+
+      - name: Publish terminal staging statuses
+        if: always() && steps.release_app.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.release_app.outputs.token }}
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          post_status() {
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+              -f state="$1" \
+              -f context="$2" \
+              -f description="$3" \
+              -f target_url="$STATUS_TARGET_URL" >/dev/null
+          }
+          case "$JOB_STATUS" in
+            success)
+              post_status success release/staging-validated 'Protected staging QA passed for this exact SHA.'
+              ;;
+            cancelled)
+              post_status error release/staging-deployed 'Protected staging verification was cancelled.'
+              post_status error release/staging-validated 'Protected staging QA was cancelled.'
+              ;;
+            *)
+              post_status failure release/staging-deployed 'Protected staging deployment verification failed.'
+              post_status failure release/staging-validated 'Protected staging QA failed.'
+              ;;
+          esac

--- a/docs/release-candidate-template.md
+++ b/docs/release-candidate-template.md
@@ -1,12 +1,14 @@
 # UKI release candidate template
 
-Estado: plantilla operativa.
-Issue: #167 `UKI-090.5`.
-Fecha: 2026-05-13.
+Estado: plantilla operativa para `staging` -> `main`.
+Issue original: #167 `UKI-090.5`. Gate actual: #232.
+Actualizado: 2026-08-08.
 
 ## Objetivo
 
-Una release candidate (RC) agrupa un conjunto cerrado de issues, PRs y commits para validarlos en staging y decidir si pueden pasar a produccion.
+Una release candidate (RC) agrupa un conjunto cerrado de issues, PRs y commits ya integrados en
+`staging`. Su identidad tecnica es el SHA completo desplegado y sirve para decidir si ese mismo SHA
+puede entrar por PR de `staging` a `main`/live.
 
 La RC no sustituye las issues. La RC coordina el paso entre entornos y deja evidencia de validacion, responsables, riesgos aceptados, rollback y cierre correcto de issues.
 
@@ -14,9 +16,9 @@ La RC no sustituye las issues. La RC coordina el paso entre entornos y deja evid
 
 Abre una RC cuando se cumpla al menos una de estas condiciones:
 
-- hay varias issues ya mergeadas en `main` que deben validarse juntas en staging,
-- se quiere fijar un punto de release mientras `main` sigue recibiendo cambios,
-- se va a promover algo hacia `production`,
+- hay varias issues ya mergeadas en `staging` que deben validarse juntas,
+- se quiere fijar un SHA mientras `staging` sigue recibiendo cambios,
+- se va a abrir el PR de promocion `staging` -> `main`,
 - hay contratos, env vars, datos o comunicacion publica que requieren go/no-go explicito.
 
 No abras una RC para una tarea docs interna que se pueda cerrar al merge sin deploy ni validacion de entorno.
@@ -30,9 +32,9 @@ No abras una RC para una tarea docs interna que se pueda cerrar al merge sin dep
 
 | Campo | Valor |
 | --- | --- |
-| Entorno objetivo | Staging / Production / Staging y despues production |
-| Source ref | `main` / `release/staging-YYYY-MM-DD` / commit SHA |
-| Target ref | `main` / `production` / tag `staging-*` / tag `prod-*` |
+| Entorno objetivo | Staging / Main-live |
+| Source ref | `staging@<SHA completo>` |
+| Target ref | `main` / tag `prod-*`, si aplica despues del merge |
 | Ventana propuesta | YYYY-MM-DD HH:mm UTC |
 | Release owner | @... |
 | Issue de coordinacion | #... |
@@ -51,18 +53,18 @@ No abras una RC para una tarea docs interna que se pueda cerrar al merge sin dep
 
 - PR #...
 - Commit `<sha>`
-- Tag `staging-YYYYMMDD.N` o `prod-YYYYMMDD.N`, si aplica.
+- Tag `staging-YYYYMMDD.N` o `prod-YYYYMMDD.N`, si aplica al mismo SHA.
 
 ## Entorno
 
-| Area | Staging | Production | Nota |
+| Area | Staging | Main/live | Nota |
 | --- | --- | --- | --- |
 | App/ref |  |  |  |
 | Coolify app |  |  |  |
 | Dominio |  |  |  |
-| DB hub |  |  | No escribir production desde staging. |
+| DB hub |  |  | No escribir live desde staging. |
 | DB legacy Cukies |  |  | Usar replica sanitizada en staging. |
-| Chain | BSC testnet / N/A | BSC mainnet / N/A |  |
+| Chain | BSC testnet / N/A | BSC mainnet / N/A | Mainnet permanece congelada hasta autorizacion. |
 | Contratos |  |  | Direcciones y BscScan si aplica. |
 
 ## Validacion requerida
@@ -81,7 +83,7 @@ No abras una RC para una tarea docs interna que se pueda cerrar al merge sin dep
 - [ ] Landing y rutas publicas criticas cargan.
 - [ ] Auth/wallet no rompe el shell.
 - [ ] Flujo afectado por la RC probado en staging.
-- [ ] APIs afectadas responden sin usar datos production por error.
+- [ ] APIs afectadas responden sin usar datos live por error.
 - [ ] Juegos afectados cargan o quedan explicitamente fuera.
 - [ ] Logs revisados tras smoke.
 
@@ -102,9 +104,11 @@ No abras una RC para una tarea docs interna que se pueda cerrar al merge sin dep
 ## Evidencias
 
 - Staging URL:
-- Health/version:
+- Health/version exacto (`status`, app, environment, SHA, ref, UUID y FQDN):
 - Deploy id / Coolify event:
 - Commit desplegado:
+- Status `release/staging-deployed`:
+- Status `release/staging-validated`:
 - Capturas:
 - Tx hashes / BscScan:
 - Logs relevantes:
@@ -136,7 +140,7 @@ Ref estable anterior:
 
 ## Go/no-go
 
-Production no avanza si falta alguna de las tres decisiones obligatorias: tech, producto/QA y ops.
+`main`/live no avanza si falta alguna de las tres decisiones obligatorias: tech, producto/QA y ops.
 
 | Rol | Responsable | Decision | Fecha/hora | Nota |
 | --- | --- | --- | --- | --- |
@@ -150,16 +154,16 @@ Decision final:
 
 - [ ] Go staging.
 - [ ] No-go staging.
-- [ ] Go production.
-- [ ] No-go production.
+- [ ] Go promocion `staging` -> `main`.
+- [ ] No-go promocion `staging` -> `main`.
 
 ## Regla de cierre de issues
 
 | Tipo de issue | Cuando se cierra |
 | --- | --- |
 | Docs interna / tooling sin deploy | Al merge del PR si acceptance criteria esta cumplido. |
-| Cambio validado solo en staging | Tras evidencia de staging si la issue no requiere production. |
-| Cambio de producto/publico | Tras deploy production y smoke post-deploy registrados. |
+| Cambio validado solo en staging | Tras evidencia de staging si la issue no requiere main/live. |
+| Cambio de producto/publico | Tras promocion a `main`, deploy live y smoke post-deploy registrados. |
 | Contratos | Tras deploy/verificacion del entorno requerido y roles/freeze documentados. |
 | Issue parcialmente cubierta | Permanece abierta con comentario de alcance pendiente. |
 | No-go o blocker | Permanece abierta con decision exacta requerida. |
@@ -172,7 +176,7 @@ Issues que se cierran tras staging validado:
 
 - #...
 
-Issues que se cierran tras production validado:
+Issues que se cierran tras `main`/live validado:
 
 - #...
 
@@ -191,6 +195,7 @@ Issues que permanecen abiertas:
 - [ ] Dominio correcto responde.
 - [ ] `/api/health` responde y expone el commit/ref esperado sin secretos.
 - [ ] Commit/ref desplegado coincide con la RC.
+- [ ] Ambos statuses release pertenecen al mismo SHA completo.
 - [ ] Smoke critico OK.
 - [ ] Logs sin errores nuevos relevantes.
 - [ ] Monitorizacion revisada.
@@ -204,11 +209,89 @@ Tambien existe la issue form `.github/ISSUE_TEMPLATE/release_candidate.yml` para
 
 Si la RC se gestiona desde una issue normal, copia la plantilla markdown anterior en la descripcion o en el primer comentario.
 
+## Metadata del PR de promocion
+
+El PR normal solo puede tener head `staging` y base `main`. El hotfix solo puede usar `hotfix/*`.
+La autorizacion no se lee del body ni de labels mutables: vive en
+`.github/release/promotion.json`, protegido por CODEOWNERS, dentro del SHA head exacto. El fichero
+se crea despues de conocer el numero del PR y debe cumplir `.github/release/promotion.schema.json`.
+En una promocion normal, se incorpora mediante un PR corto de metadata hacia `staging`; nunca se
+hace push directo a la rama protegida. Ese merge actualiza el head del PR de promocion y obliga a
+desplegar y validar de nuevo el SHA que ya contiene el manifiesto.
+
+Promocion normal:
+
+```json
+{
+  "schemaVersion": 1,
+  "mode": "normal",
+  "pullRequest": 123,
+  "baseSha": "0123456789abcdef0123456789abcdef01234567",
+  "stagingEvidence": [
+    "https://github.com/fgomezserna/cukies-hub/actions/runs/123456",
+    "https://cukieshub.eurekand.com/api/health"
+  ],
+  "rollback": "Revertir el merge de main y redesplegar la ultima imagen estable conocida."
+}
+```
+
+Hotfix:
+
+```json
+{
+  "schemaVersion": 1,
+  "mode": "hotfix",
+  "pullRequest": 124,
+  "baseSha": "0123456789abcdef0123456789abcdef01234567",
+  "incident": "INC-481 - el checkout de preventa esta bloqueado para usuarios activos.",
+  "urgency": "El impacto esta activo y requiere restaurar el servicio inmediatamente.",
+  "whyStagingCannotWait": "La causa depende del routing exclusivo de produccion y bloquea compras ahora.",
+  "rollback": "Revertir el merge del hotfix y redesplegar la ultima imagen estable conocida."
+}
+```
+
+`pullRequest` y `baseSha` evitan reutilizar el manifiesto en otro PR o contra otra base. Cualquier
+cambio del manifiesto cambia el head SHA y obliga a repetir review/gates. El hotfix no requiere las
+attestations de staging, pero nunca evita test merge, CI, Environment `Release Gate` ni revision.
+El gate resuelve `baseSha` desde el `refs/heads/main` vivo; no confia en el snapshot potencialmente
+obsoleto `pull_request.base.sha`.
+Tras cualquier merge a `main`, el workflow crea `sync/main-<sha>` -> `staging`; ese PR no se
+auto-mergea y debe usar **Create a merge commit**.
+
+## Bootstrap y freeze actual
+
+`pull_request_target` no puede proteger la primera promocion con un archivo que aun no esta en la
+base. Antes de mergear el tooling, `bootstrap-lock` deja `main` read-only e instala
+PR/reviews/CODEOWNERS/admins y prohibe force/delete en ambas ramas, sin exigir statuses
+inexistentes. `bootstrap-attested` solo desbloquea live despues de validar las attestations exactas.
+La QA no depende de
+`workflow_dispatch`: el workflow de `push` a `staging` espera la aprobacion del Environment
+protegido `Staging` antes de verificar y firmar ambas attestations con una GitHub App dedicada.
+`Staging` solo admite la rama custom `staging`; `Release Gate` solo la rama custom `main`. Ambos
+exigen revisor e impiden autoaprobacion.
+
+La App dedicada necesita `Commit statuses: write`, `Checks: write`, `Contents: write` y
+`Pull requests: write`; los permisos de contenido y PR se usan solo desde el workflow confiable de
+sync en `main`, tras aprobar `Release Gate`. El `GITHUB_TOKEN` del repositorio no crea ese PR.
+
+`bootstrap-attested` exige el SHA actual de `staging` y verifica Environment, creador, Actions run,
+workflow/ref/SHA/conclusion de los dos statuses y ancestry; no fabrica attestations. Tras la primera
+promocion y su sync con merge commit, steady-state exige `release/promotion-gate` mas el check CI
+de #235, ambos emitidos por la misma App dedicada y ligados a su `app_id`. La App global de GitHub
+Actions no es valida. El placeholder
+`__REPLACE_WITH_EXISTING_REQUIRED_CI_CONTEXT__` nunca es aplicable. Mainnet y preventa permanecen
+congeladas: esta plantilla no autoriza apply, promocion, deploy, contrato, direccion, fecha, env ni
+cambio de runtime.
+
+`CODEOWNERS` exige revision sobre workflows, manifiestos, scripts release y la propia politica a uno de los
+tres colaboradores verificados: `@fgomezserna`, `@JairoGG-ai` o `@accesovip`. La proteccion exige
+tambien last-push approval y el autor no puede aprobar su propio PR.
+
 ## Reglas operativas
 
 - La RC debe listar explicitamente lo incluido y lo excluido.
-- La RC debe usar refs concretas: rama, tag o SHA.
-- No se publica `production` sin go de tech, producto/QA y ops.
+- La RC debe usar el SHA completo exacto desplegado desde `staging`.
+- No se promueve a `main` sin go de tech, producto/QA y ops.
 - Si la release toca contratos, el contract owner/multisig debe figurar como responsable adicional.
 - Si la release toca copy publico, claims legales o disclaimers, comms/legal debe figurar como responsable adicional.
 - Los secretos nunca se pegan en la RC; solo se documenta el nombre logico de la variable y el proveedor.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,8 +1,8 @@
 # UKI release workflow
 
-Estado: propuesta operativa inicial.
-Issue: #136 `UKI-090.3`.
-Fecha: 2026-05-13.
+Estado: flujo definido `staging` -> `main`; bootstrap pendiente.
+Issue original: #136 `UKI-090.3`. Gate actual: #232.
+Actualizado: 2026-08-08.
 
 ## Objetivo
 
@@ -27,21 +27,21 @@ La parte tecnica de desplegar debe ser mecanica. La parte importante es decidir 
 | --- | --- | --- | --- | --- |
 | Local | Desarrollo rapido. | Rama local. | Hardhat/local env. | Implementador. |
 | Preview PR | Revisar cambios aislados si el hosting lo soporta. | PR branch. | Env de preview, sin valor real. | Implementador/reviewer. |
-| Staging | Validacion integrada antes de produccion. | `main` o release candidate. | BSC testnet, envs staging. | QA, producto, ops. |
-| Production | Web/app publica. | `production` o release tag aprobado. | BSC mainnet, envs produccion. | Usuarios. |
+| Staging | Validacion integrada antes de produccion. | `staging` y SHA exacto desplegado. | BSC testnet, envs staging. | QA, producto, ops. |
+| Production/live | Web/app publica. | `main` tras promocion aprobada desde `staging`. | BSC mainnet, envs produccion. | Usuarios. |
 
-Estado actual: no se ha confirmado una rama remota `production`. Antes del primer deploy real de produccion, hay que decidir si produccion se controla por rama `production`, por tags versionados o por configuracion del proveedor. La recomendacion es rama protegida `production` mas tags de release.
+`main` es la rama live. La unica operacion `main` -> `staging` es el PR de sync obligatorio tras
+cada merge a live: conserva ancestry, pero no despliega ni sustituye la promocion `staging` ->
+`main`. No existe una rama `production` intermedia en este flujo.
 
 ## Ramas
 
 | Rama | Regla |
 | --- | --- |
-| `codex/issue-<numero>-<slug>` | Trabajo aislado de una issue. Puede tener PR draft. |
-| `main` | Integracion continua. Debe estar deployable a staging. No representa produccion por si sola. |
-| `release/staging-YYYY-MM-DD` | Opcional. Rama de estabilizacion si `main` avanza demasiado rapido. |
-| `production` | Rama protegida recomendada. Solo recibe releases aprobadas. |
-
-Si no existe `production`, crearla debe ser una tarea explicita de ops antes del primer lanzamiento publico.
+| `codex/issue-<numero>-<slug>` o feature branch | Trabajo aislado basado en `staging`; entra por PR a `staging`. |
+| `staging` | Integracion y QA. Cada candidato se identifica por su SHA completo desplegado. |
+| `main` | Live. Solo recibe PR normal desde `staging` o un `hotfix/*` formal. |
+| `hotfix/*` | Excepcion desde live: requiere manifiesto inmutable y sync posterior a `staging`. |
 
 ## Milestones
 
@@ -64,10 +64,10 @@ Cuando una issue antigua mencione `M0.5`, `M7` u otro nombre viejo, manda el mil
 | --- | --- | --- |
 | Backlog | Issue abierta sin rama activa. | Priorizar o dividir. |
 | In progress | Comentario con branch y plan. | PR draft. |
-| In review | PR abierto con validacion tecnica. | Review y ajustes. |
-| Staging candidate | PR mergeado a `main` o incluido en release branch. | Deploy/QA staging. |
-| Staging validated | Evidencia de QA en issue o release tracker. | Promocion a produccion si aplica. |
-| Production released | Release/tag/deploy de produccion registrado. | Cerrar issue si el alcance queda cumplido. |
+| In review | PR abierto contra `staging` con validacion tecnica. | Review y ajustes. |
+| Staging candidate | PR mergeado a `staging`; deploy asociado a un SHA exacto. | Health, smoke y QA. |
+| Staging validated | Los dos statuses release estan en success para el mismo SHA. | PR `staging` -> `main`. |
+| Production released | PR promovido a `main` y deploy live registrado. | Cerrar issue si el alcance queda cumplido. |
 | Blocked | Decision, legal, UX image, testnet, contrato o env pendiente. | Comentario con decision exacta requerida. |
 
 Para tareas puramente internas o docs, se pueden cerrar al merge del PR si no necesitan deploy. Para cambios de producto, se cierran cuando estan validados segun su acceptance criteria. El release tracker registra que version llego a produccion.
@@ -76,17 +76,117 @@ Para tareas puramente internas o docs, se pueden cerrar al merge del PR si no ne
 
 1. Elegir issue hoja, no epic, salvo que el trabajo sea de planificacion.
 2. Leer epic padre, checklist, labels, milestone y comentarios recientes.
-3. Crear rama `codex/issue-<numero>-<slug>` desde `main`.
+3. Crear rama `codex/issue-<numero>-<slug>` desde `staging`.
 4. Comentar en la issue: branch, plan y validacion prevista.
 5. Abrir PR draft.
 6. Implementar con scope cerrado.
 7. Ejecutar validacion minima del area tocada.
 8. Actualizar PR con resumen, validacion, riesgos y screenshots si aplica.
 9. Pasar PR a ready solo si no quedan gates pendientes.
-10. Merge a `main` cuando este aprobado.
-11. Deploy a staging.
-12. Registrar evidencia de staging.
-13. Promover a produccion solo mediante release aprobada.
+10. Merge a `staging` cuando este aprobado.
+11. El job unico del `push` espera aprobacion del Environment `Staging`, verifica `/api/health`,
+    smoke publico y procedencia, y publica `release/staging-deployed` y
+    `release/staging-validated` sobre el SHA exacto.
+12. Ambos statuses los firma una GitHub App dedicada; el `GITHUB_TOKEN` global no puede satisfacer
+    los checks `release/*` ligados al `app_id` de esa App.
+13. Abrir el PR desde `staging` a `main` para obtener su numero. Desde el SHA actual de `staging`,
+    crear una rama corta de metadata con `.github/release/promotion.json` ligado a ese numero y al
+    SHA actual de `main`; integrarla de vuelta en `staging` mediante otro PR revisado, nunca por push
+    directo. El PR de promocion se actualiza automaticamente al nuevo head de `staging`.
+14. Desplegar y validar otra vez ese nuevo SHA de `staging`, que ya contiene el manifiesto exacto.
+15. `release/promotion-gate` se publica sobre el `refs/pull/<n>/merge` exacto. Exige manifiesto,
+    health, attestations, ancestry y que el tree del test merge sea identico al tree desplegado en
+    staging. El SHA base se resuelve siempre desde `refs/heads/main`, no desde el snapshot historico
+    `pull_request.base.sha`. Un cambio de base o head produce otro merge SHA y descarta el verde
+    anterior.
+16. Cada merge a `main` crea un PR `sync/main-<sha>` -> `staging`. Debe integrarse con
+    **Create a merge commit** para conservar el SHA exacto de main como ancestro. No se auto-mergea.
+
+El carril de emergencia es `hotfix/*` -> `main`. Su manifiesto inmutable exige `incident`,
+`urgency`, `whyStagingCannotWait` y `rollback`. El hotfix evita las attestations de staging, no el
+test merge, el Environment `Release Gate`, la revision, el CI ni el sync posterior. Body y labels
+son informativos: no autorizan el merge.
+
+## Bootstrap del gate
+
+`pull_request_target` usa la version de la base. Por eso la primera promocion necesita una fase de
+bootstrap y steady-state no se activa hasta que el workflow exista en `main`.
+
+La activacion es fail-closed y no se ejecuta durante el freeze actual:
+
+1. `bootstrap-lock`: vuelve `main` read-only (`lock_branch=true`) y protege ambas ramas con PR,
+   review, code owners, last-push approval, admins, historial lineal en `main` y prohibicion de
+   force/delete. El bloqueo total de live evita cualquier merge mientras los statuses aun no
+   existen; `staging` permanece abierta solo a PRs revisados.
+2. Crear una GitHub App dedicada instalada solo en este repo, con permisos de repository
+   `Commit statuses: write`, `Checks: write`, `Contents: write` y `Pull requests: write`. Los dos
+   ultimos se usan solo para crear el PR de sync desde el workflow confiable de `main`. No sirve la
+   App global `github-actions` (ID 15368).
+3. Crear Environments `Staging` y `Release Gate`, ambos con revisores, `prevent_self_review=true`
+   y policy custom exacta: solo `staging` para el primero y solo `main` para el segundo.
+4. Guardar `RELEASE_GATE_APP_PRIVATE_KEY` como secret de ambos Environments y
+   `RELEASE_GATE_APP_ID` como variable. La clave nunca es secret de repo ni archivo.
+5. Mergear el tooling por PR a `staging`. Su `push` espera aprobacion de `Staging` y genera las dos
+   attestations firmadas por la App dedicada.
+6. `bootstrap-attested`: verifica SHA actual de staging, App, Environment/policy exacta, statuses,
+   creador, Actions run y ancestry antes de sustituir el read-only por checks obligatorios en
+   `main`. El configurador no fabrica attestations.
+7. Hacer la primera promocion revisada. El workflow llega a `main`; su merge debe volver a
+   `staging` mediante el PR de sync y **Create a merge commit**.
+8. Implementar #235: el CI requerido debe ser un check real emitido por la misma App dedicada.
+9. `steady-state`: exige `release/promotion-gate` y CI, ambos ligados al `app_id` dedicado. El
+   configurador rechaza cualquier CI de la App global de Actions.
+
+Payload base de cada Environment (solo tras go operativo):
+
+```json
+{
+  "prevent_self_review": true,
+  "reviewers": [
+    { "type": "User", "id": 219637213 },
+    { "type": "User", "id": 222592709 }
+  ],
+  "deployment_branch_policy": {
+    "protected_branches": false,
+    "custom_branch_policies": true
+  }
+}
+```
+
+Despues del `PUT /repos/fgomezserna/cukies-hub/environments/<environment>`, crear una unica policy:
+
+- `POST .../environments/Staging/deployment-branch-policies` con
+  `{ "name": "staging", "type": "branch" }`.
+- `POST .../environments/Release%20Gate/deployment-branch-policies` con
+  `{ "name": "main", "type": "branch" }`.
+
+Los reviewer IDs son `@JairoGG-ai` (219637213) y `@accesovip` (222592709), verificados el
+2026-08-08. Deben resolverse de nuevo antes del apply. El configurador exige exactamente una policy
+de rama por Environment, impide autoaprobacion y falla si aparece una rama, tag o policy adicional.
+El Environment protegido `Staging` solo puede aprobar despliegues procedentes de `staging`.
+
+Dry-run de ejemplo una vez conocida la identidad publica de la App:
+
+```bash
+node scripts/release/configure-branch-protection.mjs \
+  --phase bootstrap-attested \
+  --release-app-id <APP_ID> \
+  --release-app-slug <app-slug>
+```
+
+Validacion local determinista del tooling:
+
+```bash
+node --test --test-reporter=spec scripts/release/*.test.mjs
+```
+
+`--apply` requiere el literal `APPLY_RELEASE_GUARDS_AFTER_FREEZE`, token administrativo y los
+preflights de la fase. Conserva requirements ajenos, protege primero `main` y despues `staging`, y
+nunca acepta un `app_id` nulo, la App global de Actions ni un CI no dedicado.
+
+`CODEOWNERS` protege workflows, `.github/release/`, scripts release y su propia politica con
+`@fgomezserna`, `@JairoGG-ai` y `@accesovip`. Mainnet y preventa siguen congelados: este documento
+no autoriza apply, merge, deploy, contrato, direccion, fecha, env ni cambio de runtime.
 
 ## Release candidate
 
@@ -109,27 +209,22 @@ Plantilla operativa:
 - Markdown: `docs/release-candidate-template.md`.
 - GitHub issue form: `.github/ISSUE_TEMPLATE/release_candidate.yml`.
 
-Formato minimo:
+La fuente autoritativa de un PR a `main` es `.github/release/promotion.json`, validado contra
+`.github/release/promotion.schema.json`. Se crea despues de conocer el numero de PR y contiene el
+`baseSha` exacto de `main`. El body sirve solo como resumen humano. Ejemplo normal:
 
-```text
-Release candidate: UKI <fase> <fecha>
-
-Incluye:
-- #...
-
-No incluye:
-- #...
-
-Validacion staging:
-- ...
-
-Go/no-go:
-- Tech:
-- Producto:
-- Ops:
-
-Rollback:
-- ...
+```json
+{
+  "schemaVersion": 1,
+  "mode": "normal",
+  "pullRequest": 123,
+  "baseSha": "0123456789abcdef0123456789abcdef01234567",
+  "stagingEvidence": [
+    "https://github.com/fgomezserna/cukies-hub/actions/runs/123456",
+    "https://cukieshub.eurekand.com/api/health"
+  ],
+  "rollback": "Revertir el merge de main y redesplegar la ultima imagen estable conocida."
+}
 ```
 
 Para publicar produccion, el go/no-go debe tener al menos tres responsables con decision explicita: tech lead, producto/QA y ops. Si la release toca contratos, tambien debe figurar contract owner/multisig. Si toca copy publico sensible, tambien debe figurar comms/legal.
@@ -138,7 +233,7 @@ Regla de cierre:
 
 - docs internas o tooling sin deploy se pueden cerrar al merge si cumplen acceptance criteria;
 - cambios validados solo en staging se cierran tras evidencia de staging si la issue no exige produccion;
-- cambios publicos o de producto se cierran tras deploy production y smoke post-deploy;
+- cambios publicos o de producto se cierran tras deploy live desde `main` y smoke post-deploy;
 - issues parcialmente cubiertas permanecen abiertas con comentario del alcance pendiente;
 - cualquier no-go o blocker mantiene la issue abierta con la decision exacta requerida.
 
@@ -148,13 +243,18 @@ Staging debe ser el primer sitio donde se juntan dapp, APIs, contratos testnet, 
 
 Gates minimos para staging:
 
-- PRs incluidos mergeados o rama release creada.
+- PRs incluidos mergeados en `staging`.
 - Env staging separado de produccion.
 - BSC testnet para compras/vesting/claims on-chain.
 - Datos de prueba que no afecten usuarios reales.
 - `pnpm dapp lint`, `pnpm dapp typecheck` y tests relevantes, o fallos documentados si son preexistentes.
-- `/api/health` expone el commit/ref esperado sin secretos, cuando el endpoint este disponible.
+- `/api/health` responde HTTP 200 JSON y expone exactamente app, entorno, commit completo,
+  ref `staging`, UUID y host esperados sin secretos.
 - Smoke test de rutas criticas.
+- `release/staging-deployed` y `release/staging-validated` estan en success para el mismo SHA.
+- Ambos statuses proceden de la misma run y del bot de la App release dedicada.
+- El SHA actual de `main` es ancestro de staging; cualquier merge previo a main ya volvio mediante
+  un PR `sync/main-*` integrado con merge commit.
 
 Para contratos:
 
@@ -166,11 +266,17 @@ Para contratos:
 
 ## Produccion
 
-Produccion requiere aprobacion explicita.
+`main`/live requiere aprobacion explicita y solo recibe una promocion desde `staging` o un hotfix
+formal. Mainnet y preventa permanecen congelados; este documento no autoriza ningun deploy ni
+activacion.
 
 Gates minimos:
 
 - release candidate validada en staging,
+- manifiesto inmutable ligado al PR y al SHA actual de `main`,
+- `release/promotion-gate` verde sobre el test merge exacto,
+- tree del test merge igual al tree desplegado de staging para una promocion normal,
+- CI dedicado de #235 verde y ligado al mismo `app_id` release,
 - no issues P0 abiertas que bloqueen la fase,
 - env produccion revisado,
 - contratos mainnet verificados si la release toca on-chain,
@@ -229,11 +335,13 @@ Si hay fallo despues de mainnet, el rollback principal no es "revertir contrato"
 
 Para no parar el equipo:
 
-- `main` puede seguir recibiendo cambios que no entren en la release actual.
-- Si hay release en estabilizacion, usar `release/staging-YYYY-MM-DD`.
-- Los fixes de release se hacen contra esa rama y luego se re-aplican o mergean a `main`.
-- Produccion no sigue a `main` automaticamente.
-- Cualquier cambio no incluido en la release queda para la siguiente candidate.
+- `staging` puede seguir recibiendo features por PR mientras no haya un candidato congelado.
+- Si se congela un candidato, su identidad es el SHA completo attestated; nuevos merges generan
+  otro candidato y deben repetir deploy/QA.
+- `main` no recibe features directas: solo promocion desde `staging` o hotfix formal.
+- Todo merge de `main` vuelve a `staging` mediante `sync/main-*`; hasta integrar ese PR con merge
+  commit, ancestry y la siguiente promocion permanecen bloqueados.
+- Cualquier cambio no incluido en el SHA validado queda para la siguiente candidate.
 
 ## Rollback y pausa
 
@@ -287,10 +395,10 @@ Notas:
 - ...
 ```
 
-Produccion:
+Main/live:
 
 ```text
-Publicado en produccion `<tag/ref>`.
+Promovido a main `<sha/ref>`.
 
 Deploy:
 - commit/tag:
@@ -321,11 +429,13 @@ Siguiente paso recomendado:
 
 ## Tareas operativas pendientes
 
-Estas tareas deben existir antes del primer deploy real de produccion:
+Estas tareas deben existir antes de una promocion real a `main`:
 
-- #166 Crear/proteger rama `production` o decidir estrategia de tags de produccion.
-- #166 Configurar deploy staging separado de produccion.
-- #166 Configurar env staging y production con nombres claros.
+- #232 Completar bootstrap y aplicar steady-state con App y Environments dedicados.
+- #235 Producir el CI fail-closed con la misma App dedicada antes de steady-state.
+- #233 y #234 cerrar superficies internas y configuracion tipada antes de promocion real.
+- #166 Mantener deploy staging separado de live.
+- #166 Mantener env staging y live con nombres claros.
 - Definir quien aprueba go/no-go de cada release.
 - #167 Crear plantilla de release candidate.
 - #135 Configurar monitorizacion basica y alertas.
@@ -336,7 +446,7 @@ Estas tareas deben existir antes del primer deploy real de produccion:
 
 No se cierra una issue de launch porque "el codigo esta". Se cierra cuando su acceptance criteria queda cumplido en el entorno que corresponde:
 
-- docs/spec: merge a `main`,
+- docs/spec: merge en la rama objetivo definida por su acceptance criteria,
 - UI sin impacto publico: merge + staging si aplica,
 - feature publica: staging validado o produccion si la issue lo pide,
 - contratos: freeze/deploy/verificacion segun issue,

--- a/scripts/release/configure-branch-protection.mjs
+++ b/scripts/release/configure-branch-protection.mjs
@@ -1,0 +1,679 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  CI_CONTEXT_PLACEHOLDER,
+  RELEASE_GUARDS_CONFIRMATION,
+  RELEASE_GUARDS_REPOSITORY,
+  RELEASE_GUARD_PHASES,
+  buildReleaseGuardPlan,
+} from './release-guards.config.mjs';
+import { verifyAttestations } from './verify-attestations.mjs';
+
+const FULL_GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const REPOSITORY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]*\/[A-Za-z0-9][A-Za-z0-9_.-]*$/;
+const APP_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$/;
+const PROMOTION_WORKFLOW_PATH = '.github/workflows/main-promotion-gate.yml';
+
+export class ReleaseGuardConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ReleaseGuardConfigurationError';
+  }
+}
+
+function validateRepository(value) {
+  if (
+    typeof value !== 'string'
+    || !REPOSITORY_PATTERN.test(value)
+    || value.split('/').some((part) => part.includes('..'))
+  ) {
+    throw new ReleaseGuardConfigurationError('Repository must have the exact owner/repo form.');
+  }
+  return value;
+}
+
+function validateApiUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new ReleaseGuardConfigurationError('GitHub API URL is invalid.');
+  }
+  if (
+    parsed.protocol !== 'https:'
+    || parsed.username !== ''
+    || parsed.password !== ''
+    || parsed.search !== ''
+    || parsed.hash !== ''
+  ) {
+    throw new ReleaseGuardConfigurationError('GitHub API URL must be credential-free HTTPS.');
+  }
+  return parsed.href.replace(/\/+$/, '');
+}
+
+function validateCiContext(value) {
+  if (
+    typeof value !== 'string'
+    || value.trim() !== value
+    || value === ''
+    || value === CI_CONTEXT_PLACEHOLDER
+    || value.length > 100
+    || /[\r\n]/.test(value)
+    || value.startsWith('release/')
+  ) {
+    throw new ReleaseGuardConfigurationError(
+      'steady-state apply requires an explicit existing non-release CI context.',
+    );
+  }
+  return value;
+}
+
+function validateReleaseAppId(value) {
+  const parsed = typeof value === 'string' && /^[1-9][0-9]{0,15}$/.test(value)
+    ? Number(value)
+    : value;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed === 15368) {
+    throw new ReleaseGuardConfigurationError(
+      'A positive dedicated --release-app-id is required; GitHub Actions app id 15368 is forbidden.',
+    );
+  }
+  return parsed;
+}
+
+function validateReleaseAppSlug(value) {
+  if (
+    typeof value !== 'string'
+    || !APP_SLUG_PATTERN.test(value)
+    || value === 'github-actions'
+  ) {
+    throw new ReleaseGuardConfigurationError(
+      'A valid dedicated --release-app-slug is required; github-actions is forbidden.',
+    );
+  }
+  return value;
+}
+
+function parseArguments(argv) {
+  const parsed = { apply: false, phase: 'bootstrap-lock' };
+  const values = new Map([
+    ['--phase', 'phase'],
+    ['--repository', 'repository'],
+    ['--candidate-sha', 'candidateSha'],
+    ['--ci-context', 'ciContext'],
+    ['--release-app-id', 'releaseAppId'],
+    ['--release-app-slug', 'releaseAppSlug'],
+    ['--confirm', 'confirmation'],
+    ['--api-url', 'apiBaseUrl'],
+  ]);
+  const seen = new Set();
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--help') {
+      parsed.help = true;
+      continue;
+    }
+    if (argument === '--apply') {
+      if (parsed.apply) {
+        throw new ReleaseGuardConfigurationError('--apply cannot be repeated.');
+      }
+      parsed.apply = true;
+      continue;
+    }
+
+    const property = values.get(argument);
+    if (!property || seen.has(argument)) {
+      throw new ReleaseGuardConfigurationError(`Unknown or repeated argument: ${argument}.`);
+    }
+    const value = argv[index + 1];
+    if (typeof value !== 'string' || value.startsWith('--')) {
+      throw new ReleaseGuardConfigurationError(`Missing value for ${argument}.`);
+    }
+    parsed[property] = value;
+    seen.add(argument);
+    index += 1;
+  }
+
+  if (!Object.hasOwn(RELEASE_GUARD_PHASES, parsed.phase)) {
+    throw new ReleaseGuardConfigurationError(
+      'Phase must be bootstrap-lock, bootstrap-attested or steady-state.',
+    );
+  }
+  return parsed;
+}
+
+function headers(token) {
+  return {
+    accept: 'application/vnd.github+json',
+    authorization: `Bearer ${token}`,
+    'content-type': 'application/json',
+    'x-github-api-version': '2022-11-28',
+  };
+}
+
+async function fetchJson(url, options, { fetchFn, expectedStatus = 200, operation }) {
+  let response;
+  try {
+    response = await fetchFn(url, { ...options, redirect: 'error' });
+  } catch {
+    throw new ReleaseGuardConfigurationError(`${operation} failed with a network error.`);
+  }
+  if (!response || response.status !== expectedStatus) {
+    const status = Number.isInteger(response?.status) ? `HTTP ${response.status}` : 'invalid HTTP';
+    throw new ReleaseGuardConfigurationError(`${operation} failed with ${status}.`);
+  }
+  if (typeof response.json !== 'function') {
+    throw new ReleaseGuardConfigurationError(`${operation} returned an invalid response.`);
+  }
+  try {
+    return await response.json();
+  } catch {
+    throw new ReleaseGuardConfigurationError(`${operation} returned invalid JSON.`);
+  }
+}
+
+async function readExistingProtection({ apiBaseUrl, repository, branch, token, fetchFn }) {
+  const [owner, repo] = repository.split('/').map(encodeURIComponent);
+  const branchPayload = await fetchJson(
+    `${apiBaseUrl}/repos/${owner}/${repo}/branches/${encodeURIComponent(branch)}`,
+    { method: 'GET', headers: headers(token), cache: 'no-store' },
+    { fetchFn, operation: `Branch preflight for ${branch}` },
+  );
+  if (
+    !branchPayload
+    || branchPayload.name !== branch
+    || typeof branchPayload.commit?.sha !== 'string'
+    || !FULL_GIT_SHA_PATTERN.test(branchPayload.commit.sha)
+  ) {
+    throw new ReleaseGuardConfigurationError(`Branch preflight for ${branch} is invalid.`);
+  }
+
+  let response;
+  try {
+    response = await fetchFn(
+      `${apiBaseUrl}/repos/${owner}/${repo}/branches/${encodeURIComponent(branch)}/protection`,
+      { method: 'GET', headers: headers(token), cache: 'no-store', redirect: 'error' },
+    );
+  } catch {
+    throw new ReleaseGuardConfigurationError(
+      `Protection preflight for ${branch} failed with a network error.`,
+    );
+  }
+  if (response?.status === 404) {
+    return {
+      sha: branchPayload.commit.sha,
+      requirements: { contexts: [], checks: [] },
+    };
+  }
+  if (!response || response.status !== 200 || typeof response.json !== 'function') {
+    const status = Number.isInteger(response?.status) ? `HTTP ${response.status}` : 'invalid HTTP';
+    throw new ReleaseGuardConfigurationError(
+      `Protection preflight for ${branch} failed with ${status}.`,
+    );
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new ReleaseGuardConfigurationError(
+      `Protection preflight for ${branch} returned invalid JSON.`,
+    );
+  }
+  const requiredChecks = payload?.required_status_checks;
+  if (requiredChecks === null || requiredChecks === undefined) {
+    return {
+      sha: branchPayload.commit.sha,
+      requirements: { contexts: [], checks: [] },
+    };
+  }
+  if (typeof requiredChecks !== 'object' || Array.isArray(requiredChecks)) {
+    throw new ReleaseGuardConfigurationError(
+      `Protection preflight for ${branch} has invalid required status checks.`,
+    );
+  }
+
+  const contexts = [];
+  if (requiredChecks.contexts !== undefined) {
+    if (
+      !Array.isArray(requiredChecks.contexts)
+      || requiredChecks.contexts.some((context) => typeof context !== 'string' || context === '')
+    ) {
+      throw new ReleaseGuardConfigurationError(
+        `Protection preflight for ${branch} has invalid status contexts.`,
+      );
+    }
+    contexts.push(...requiredChecks.contexts);
+  }
+  if (requiredChecks.checks !== undefined) {
+    if (
+      !Array.isArray(requiredChecks.checks)
+      || requiredChecks.checks.some((check) =>
+        !check
+        || typeof check !== 'object'
+        || typeof check.context !== 'string'
+        || check.context === ''
+        || !Object.hasOwn(check, 'app_id')
+        || !(check.app_id === null || (Number.isSafeInteger(check.app_id) && check.app_id > 0)))
+    ) {
+      throw new ReleaseGuardConfigurationError(
+        `Protection preflight for ${branch} has invalid status checks.`,
+      );
+    }
+  }
+  const rawChecks = requiredChecks.checks ?? [];
+  const checks = rawChecks
+    .filter(({ app_id: appId }) => appId !== null)
+    .map(({ context, app_id: appId }) => ({ context, app_id: appId }));
+  contexts.push(...rawChecks
+    .filter(({ app_id: appId }) => appId === null)
+    .map(({ context }) => context));
+  const checkContexts = new Set(checks.map(({ context }) => context));
+  return {
+    sha: branchPayload.commit.sha,
+    requirements: {
+      // GitHub returns `contexts` as a compatibility view of `checks`. Keep the
+      // app-bound object authoritative so a later PUT never downgrades its app_id.
+      contexts: [...new Set(contexts.filter((context) => !checkContexts.has(context)))],
+      checks,
+    },
+  };
+}
+
+async function verifyProtectedEnvironment({
+  apiBaseUrl,
+  repository,
+  environmentName,
+  expectedBranch,
+  token,
+  fetchFn,
+}) {
+  const [owner, repo] = repository.split('/').map(encodeURIComponent);
+  const payload = await fetchJson(
+    `${apiBaseUrl}/repos/${owner}/${repo}/environments/${encodeURIComponent(environmentName)}`,
+    { method: 'GET', headers: headers(token), cache: 'no-store' },
+    { fetchFn, operation: `${environmentName} environment trust preflight` },
+  );
+  const reviewerRule = Array.isArray(payload?.protection_rules)
+    ? payload.protection_rules.find((rule) => rule?.type === 'required_reviewers')
+    : undefined;
+  const branchPolicy = payload?.deployment_branch_policy;
+  if (
+    payload?.name !== environmentName
+    || !reviewerRule
+    || reviewerRule.prevent_self_review !== true
+    || !Array.isArray(reviewerRule.reviewers)
+    || reviewerRule.reviewers.length === 0
+    || branchPolicy?.protected_branches !== false
+    || branchPolicy?.custom_branch_policies !== true
+  ) {
+    throw new ReleaseGuardConfigurationError(
+      `${environmentName} environment must require reviewers, prevent self-review, and use custom branch policies before release gates are enabled.`,
+    );
+  }
+
+  const policies = await fetchJson(
+    `${apiBaseUrl}/repos/${owner}/${repo}/environments/${encodeURIComponent(environmentName)}/deployment-branch-policies?per_page=100`,
+    { method: 'GET', headers: headers(token), cache: 'no-store' },
+    { fetchFn, operation: `${environmentName} branch policy preflight` },
+  );
+  if (
+    policies?.total_count !== 1
+    || !Array.isArray(policies.branch_policies)
+    || policies.branch_policies.length !== 1
+    || policies.branch_policies[0]?.name !== expectedBranch
+    || policies.branch_policies[0]?.type !== 'branch'
+  ) {
+    throw new ReleaseGuardConfigurationError(
+      `${environmentName} environment must allow exactly the ${expectedBranch} branch.`,
+    );
+  }
+}
+
+async function verifyDedicatedReleaseApp({
+  apiBaseUrl,
+  releaseAppId,
+  releaseAppSlug,
+  token,
+  fetchFn,
+}) {
+  const payload = await fetchJson(
+    `${apiBaseUrl}/apps/${encodeURIComponent(releaseAppSlug)}`,
+    { method: 'GET', headers: headers(token), cache: 'no-store' },
+    { fetchFn, operation: 'Dedicated release GitHub App preflight' },
+  );
+  if (
+    payload?.id !== releaseAppId
+    || payload.slug !== releaseAppSlug
+    || payload.slug === 'github-actions'
+  ) {
+    throw new ReleaseGuardConfigurationError(
+      'Dedicated release GitHub App preflight did not resolve the expected immutable identity.',
+    );
+  }
+  return payload.id;
+}
+
+async function verifyCiContextOnSha({
+  apiBaseUrl,
+  repository,
+  candidateSha,
+  ciContext,
+  token,
+  fetchFn,
+}) {
+  const [owner, repo] = repository.split('/').map(encodeURIComponent);
+  const encodedContext = encodeURIComponent(ciContext);
+  const checkRunsPayload = await fetchJson(
+    `${apiBaseUrl}/repos/${owner}/${repo}/commits/${candidateSha}/check-runs?check_name=${encodedContext}&filter=latest&per_page=100`,
+    { method: 'GET', headers: headers(token), cache: 'no-store' },
+    { fetchFn, operation: 'CI check-runs preflight' },
+  );
+  if (
+    !Number.isSafeInteger(checkRunsPayload?.total_count)
+    || checkRunsPayload.total_count < 0
+    || !Array.isArray(checkRunsPayload.check_runs)
+    || checkRunsPayload.total_count !== checkRunsPayload.check_runs.length
+    || checkRunsPayload.check_runs.length > 100
+  ) {
+    throw new ReleaseGuardConfigurationError('CI check-runs preflight returned an incomplete payload.');
+  }
+  const matchingChecks = checkRunsPayload.check_runs.filter((check) => check?.name === ciContext);
+  for (const check of matchingChecks) {
+    if (
+      !Number.isSafeInteger(check.id)
+      || check.id <= 0
+      || check.head_sha !== candidateSha
+      || !check.app
+      || !Number.isSafeInteger(check.app.id)
+      || check.app.id <= 0
+    ) {
+      throw new ReleaseGuardConfigurationError('CI check-runs preflight returned an invalid check.');
+    }
+  }
+
+  if (matchingChecks.length === 0) {
+    throw new ReleaseGuardConfigurationError(
+      'The selected CI context is not an app-bound check on current main.',
+    );
+  }
+  const appIds = new Set(matchingChecks.map((check) => check.app.id));
+  if (appIds.size !== 1) {
+    throw new ReleaseGuardConfigurationError(
+      'The selected CI check is ambiguous across multiple GitHub Apps.',
+    );
+  }
+  const latestCheck = matchingChecks.reduce((latest, check) => check.id > latest.id ? check : latest);
+  if (latestCheck.status !== 'completed' || latestCheck.conclusion !== 'success') {
+    throw new ReleaseGuardConfigurationError(
+      'The latest selected CI check is not completed successfully on current main.',
+    );
+  }
+  return { kind: 'check', context: ciContext, appId: latestCheck.app.id };
+}
+
+async function verifyPromotionWorkflowOnMain({ apiBaseUrl, repository, token, fetchFn }) {
+  const [owner, repo] = repository.split('/').map(encodeURIComponent);
+  const payload = await fetchJson(
+    `${apiBaseUrl}/repos/${owner}/${repo}/contents/${PROMOTION_WORKFLOW_PATH}?ref=main`,
+    { method: 'GET', headers: headers(token), cache: 'no-store' },
+    { fetchFn, operation: 'Promotion workflow preflight' },
+  );
+  if (
+    !payload
+    || payload.type !== 'file'
+    || payload.path !== PROMOTION_WORKFLOW_PATH
+    || typeof payload.sha !== 'string'
+    || !/^[0-9a-f]{40}$/.test(payload.sha)
+  ) {
+    throw new ReleaseGuardConfigurationError(
+      'Promotion workflow preflight did not find the expected file on main.',
+    );
+  }
+}
+
+async function putProtection({ apiBaseUrl, repository, branch, protection, token, fetchFn }) {
+  const [owner, repo] = repository.split('/').map(encodeURIComponent);
+  await fetchJson(
+    `${apiBaseUrl}/repos/${owner}/${repo}/branches/${encodeURIComponent(branch)}/protection`,
+    {
+      method: 'PUT',
+      headers: headers(token),
+      body: JSON.stringify(protection),
+    },
+    { fetchFn, operation: `Protection update for ${branch}` },
+  );
+}
+
+export async function applyReleaseGuardPlan({
+  phase,
+  repository,
+  candidateSha,
+  ciContext,
+  releaseAppId,
+  releaseAppSlug,
+  confirmation,
+  token,
+  apiBaseUrl,
+  fetchFn,
+} = {}) {
+  if (confirmation !== RELEASE_GUARDS_CONFIRMATION) {
+    throw new ReleaseGuardConfigurationError(
+      `Apply requires the literal confirmation ${RELEASE_GUARDS_CONFIRMATION}.`,
+    );
+  }
+  const validatedRepository = validateRepository(repository);
+  const validatedApiUrl = validateApiUrl(apiBaseUrl);
+  if (typeof token !== 'string' || token.trim() === '' || /[\r\n]/.test(token)) {
+    throw new ReleaseGuardConfigurationError('GITHUB_TOKEN is required for apply.');
+  }
+  if (typeof fetchFn !== 'function') {
+    throw new ReleaseGuardConfigurationError('fetch is required for apply.');
+  }
+
+  let validatedCiContext;
+  let validatedReleaseAppId;
+  let validatedReleaseAppSlug;
+  if (phase === 'bootstrap-lock') {
+    // This first bootstrap step deliberately has no release-status preflight: the workflows do
+    // not exist yet. It still installs PR/review/admin/no-force/no-delete protections.
+  } else if (phase === 'bootstrap-attested') {
+    validatedReleaseAppId = validateReleaseAppId(releaseAppId);
+    validatedReleaseAppSlug = validateReleaseAppSlug(releaseAppSlug);
+    if (typeof candidateSha !== 'string' || !FULL_GIT_SHA_PATTERN.test(candidateSha)) {
+      throw new ReleaseGuardConfigurationError(
+        'bootstrap-attested apply requires the exact full staging candidate SHA.',
+      );
+    }
+  } else if (phase === 'steady-state') {
+    validatedReleaseAppId = validateReleaseAppId(releaseAppId);
+    validatedReleaseAppSlug = validateReleaseAppSlug(releaseAppSlug);
+    validatedCiContext = validateCiContext(ciContext);
+    if (typeof candidateSha !== 'string' || !FULL_GIT_SHA_PATTERN.test(candidateSha)) {
+      throw new ReleaseGuardConfigurationError(
+        'steady-state apply requires the exact full current main SHA.',
+      );
+    }
+  } else {
+    throw new ReleaseGuardConfigurationError(
+      'Phase must be bootstrap-lock, bootstrap-attested or steady-state.',
+    );
+  }
+
+  const existingContexts = {};
+  const branchShas = {};
+  for (const branch of ['main', 'staging']) {
+    const existing = await readExistingProtection({
+      apiBaseUrl: validatedApiUrl,
+      repository: validatedRepository,
+      branch,
+      token,
+      fetchFn,
+    });
+    branchShas[branch] = existing.sha;
+    existingContexts[branch] = existing.requirements;
+  }
+
+  if (phase === 'bootstrap-attested' && candidateSha !== branchShas.staging) {
+    throw new ReleaseGuardConfigurationError(
+      '--candidate-sha must equal the SHA currently resolved for staging.',
+    );
+  }
+  if (phase === 'steady-state' && candidateSha !== branchShas.main) {
+    throw new ReleaseGuardConfigurationError(
+      '--candidate-sha must equal the SHA currently resolved for main.',
+    );
+  }
+
+  let ciRequirement;
+  if (phase !== 'bootstrap-lock') {
+    validatedReleaseAppId = await verifyDedicatedReleaseApp({
+      apiBaseUrl: validatedApiUrl,
+      releaseAppId: validatedReleaseAppId,
+      releaseAppSlug: validatedReleaseAppSlug,
+      token,
+      fetchFn,
+    });
+  }
+  if (phase === 'bootstrap-attested') {
+    await verifyAttestations({
+      repository: validatedRepository,
+      candidateSha,
+      token,
+      apiBaseUrl: validatedApiUrl,
+      fetchFn,
+      statusCreatorLogin: `${validatedReleaseAppSlug}[bot]`,
+    });
+  } else if (phase === 'steady-state') {
+    await verifyPromotionWorkflowOnMain({
+      apiBaseUrl: validatedApiUrl,
+      repository: validatedRepository,
+      token,
+      fetchFn,
+    });
+    await verifyProtectedEnvironment({
+      apiBaseUrl: validatedApiUrl,
+      repository: validatedRepository,
+      environmentName: 'Staging',
+      expectedBranch: 'staging',
+      token,
+      fetchFn,
+    });
+    await verifyProtectedEnvironment({
+      apiBaseUrl: validatedApiUrl,
+      repository: validatedRepository,
+      environmentName: 'Release Gate',
+      expectedBranch: 'main',
+      token,
+      fetchFn,
+    });
+    ciRequirement = await verifyCiContextOnSha({
+      apiBaseUrl: validatedApiUrl,
+      repository: validatedRepository,
+      candidateSha,
+      ciContext: validatedCiContext,
+      token,
+      fetchFn,
+    });
+    if (ciRequirement.appId !== validatedReleaseAppId) {
+      throw new ReleaseGuardConfigurationError(
+        'The required CI check must be emitted by the same dedicated release GitHub App.',
+      );
+    }
+  }
+
+  const plan = buildReleaseGuardPlan({
+    phase,
+    repository: validatedRepository,
+    ciContext: validatedCiContext,
+    ciRequirement,
+    releaseAppId: validatedReleaseAppId,
+    existingContexts,
+  });
+  // Protect live first. A second PUT failure may leave staging unchanged, but never main exposed.
+  for (const branch of ['main', 'staging']) {
+    await putProtection({
+      apiBaseUrl: validatedApiUrl,
+      repository: validatedRepository,
+      branch,
+      protection: plan.branches[branch],
+      token,
+      fetchFn,
+    });
+  }
+  return plan;
+}
+
+export async function runConfigureBranchProtectionCli({
+  argv = process.argv.slice(2),
+  env = process.env,
+  fetchFn = globalThis.fetch,
+  stdout = process.stdout,
+  stderr = process.stderr,
+} = {}) {
+  try {
+    const args = parseArguments(argv);
+    if (args.help) {
+      stdout.write([
+        'Dry-run (default): configure-branch-protection.mjs [--phase bootstrap-lock|bootstrap-attested|steady-state]',
+        `Apply: add --apply --confirm ${RELEASE_GUARDS_CONFIRMATION}`,
+        'bootstrap-attested/steady-state require --release-app-id <id> and --release-app-slug <slug>.',
+        'bootstrap-attested apply also requires --candidate-sha <40-hex>.',
+        'steady-state apply also requires --candidate-sha <current-main-40-hex> and --ci-context <existing-context>.',
+        '',
+      ].join('\n'));
+      return 0;
+    }
+
+    const repository = args.repository ?? env.GITHUB_REPOSITORY ?? RELEASE_GUARDS_REPOSITORY;
+    const rawReleaseAppId = args.releaseAppId ?? env.RELEASE_GATE_APP_ID;
+    const rawReleaseAppSlug = args.releaseAppSlug ?? env.RELEASE_GATE_APP_SLUG;
+    const releaseAppId = args.phase === 'bootstrap-lock'
+      ? undefined
+      : validateReleaseAppId(rawReleaseAppId);
+    const releaseAppSlug = args.phase === 'bootstrap-lock'
+      ? undefined
+      : validateReleaseAppSlug(rawReleaseAppSlug);
+    if (!args.apply) {
+      const plan = buildReleaseGuardPlan({
+        phase: args.phase,
+        repository,
+        ciContext: args.ciContext,
+        releaseAppId,
+      });
+      stdout.write(`DRY-RUN: no GitHub settings were changed.\n${JSON.stringify(plan, null, 2)}\n`);
+      return 0;
+    }
+
+    const plan = await applyReleaseGuardPlan({
+      phase: args.phase,
+      repository,
+      candidateSha: args.candidateSha,
+      ciContext: args.ciContext,
+      releaseAppId,
+      releaseAppSlug,
+      confirmation: args.confirmation,
+      token: env.GITHUB_TOKEN,
+      apiBaseUrl: args.apiBaseUrl ?? env.GITHUB_API_URL ?? 'https://api.github.com',
+      fetchFn,
+    });
+    stdout.write(`Applied ${plan.phase} release guards to main and staging.\n`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof ReleaseGuardConfigurationError
+      ? error.message
+      : 'Release guard configuration failed closed.';
+    stderr.write(`Release guards DENIED: ${message}\n`);
+    return 1;
+  }
+}
+
+const isDirectInvocation = process.argv[1]
+  && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (isDirectInvocation) {
+  process.exitCode = await runConfigureBranchProtectionCli();
+}

--- a/scripts/release/configure-branch-protection.test.mjs
+++ b/scripts/release/configure-branch-protection.test.mjs
@@ -1,0 +1,630 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CI_CONTEXT_PLACEHOLDER,
+  RELEASE_GUARDS_CONFIRMATION,
+  buildReleaseGuardPlan,
+} from './release-guards.config.mjs';
+import {
+  applyReleaseGuardPlan,
+  runConfigureBranchProtectionCli,
+} from './configure-branch-protection.mjs';
+
+const REPOSITORY = 'fgomezserna/cukies-hub';
+const CANDIDATE_SHA = '0123456789abcdef0123456789abcdef01234567';
+const MAIN_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const OTHER_SHA = '89abcdef0123456789abcdef0123456789abcdef';
+const INTERMEDIATE_SHA = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const WORKFLOW_BLOB_SHA = 'cccccccccccccccccccccccccccccccccccccccc';
+const RUN_ID = '123456789';
+const RUN_URL = `https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}`;
+const RELEASE_APP_ID = 424242;
+const RELEASE_APP_SLUG = 'cukies-release-guard';
+const RELEASE_CREATOR = Object.freeze({
+  login: `${RELEASE_APP_SLUG}[bot]`,
+  id: 9001,
+  type: 'Bot',
+});
+
+function jsonResponse(payload, status = 200) {
+  return {
+    status,
+    headers: { get: () => 'application/json' },
+    json: async () => payload,
+  };
+}
+
+function sequenceFetch(payloads, requests = []) {
+  const responses = [...payloads];
+  return async (url, options) => {
+    requests.push({ url, options });
+    const response = responses.shift();
+    assert.ok(response, `respuesta simulada ausente para ${url}`);
+    return response;
+  };
+}
+
+function validEnvironment(name = 'Staging', overrides = {}) {
+  return {
+    name,
+    protection_rules: [{
+      id: 1,
+      type: 'required_reviewers',
+      prevent_self_review: true,
+      reviewers: [{ type: 'User', reviewer: { id: 219637213, login: 'JairoGG-ai' } }],
+    }],
+    deployment_branch_policy: {
+      protected_branches: false,
+      custom_branch_policies: true,
+    },
+    ...overrides,
+  };
+}
+
+function validBranchPolicies(branch) {
+  return {
+    total_count: 1,
+    branch_policies: [{ id: 7, name: branch, type: 'branch' }],
+  };
+}
+
+function statusPayload(overrides = {}) {
+  return {
+    state: 'success',
+    sha: CANDIDATE_SHA,
+    total_count: 2,
+    statuses: ['release/staging-deployed', 'release/staging-validated'].map((context) => ({
+      context,
+      state: 'success',
+      sha: CANDIDATE_SHA,
+      creator: RELEASE_CREATOR,
+      target_url: RUN_URL,
+    })),
+    ...overrides,
+  };
+}
+
+function actionsRunPayload(overrides = {}) {
+  return {
+    id: Number(RUN_ID),
+    html_url: RUN_URL,
+    path: '.github/workflows/staging-deploy-verify.yml',
+    event: 'push',
+    head_branch: 'staging',
+    head_sha: CANDIDATE_SHA,
+    display_title: `Staging deploy ${CANDIDATE_SHA}`,
+    status: 'completed',
+    conclusion: 'success',
+    repository: { full_name: REPOSITORY },
+    head_repository: { full_name: REPOSITORY },
+    workflow_id: 42,
+    ...overrides,
+  };
+}
+
+function ancestryPayload() {
+  return {
+    status: 'ahead',
+    ahead_by: 2,
+    behind_by: 0,
+    total_commits: 2,
+    base_commit: { sha: MAIN_SHA },
+    merge_base_commit: { sha: MAIN_SHA },
+    commits: [{ sha: INTERMEDIATE_SHA }, { sha: CANDIDATE_SHA }],
+  };
+}
+
+function branchPayload(name, sha) {
+  return { name, commit: { sha } };
+}
+
+function protectionPayload({ checks = [], legacyContexts = [] } = {}) {
+  if (checks.length === 0 && legacyContexts.length === 0) {
+    return { required_status_checks: null };
+  }
+  return {
+    required_status_checks: {
+      contexts: [...legacyContexts, ...checks.map(({ context }) => context)],
+      checks: checks.map((check) => ({ ...check })),
+    },
+  };
+}
+
+function branchPreflightResponses({
+  mainProtection = protectionPayload(),
+  stagingProtection = protectionPayload(),
+} = {}) {
+  return [
+    jsonResponse(branchPayload('main', MAIN_SHA)),
+    jsonResponse(mainProtection),
+    jsonResponse(branchPayload('staging', CANDIDATE_SHA)),
+    jsonResponse(stagingProtection),
+  ];
+}
+
+function successfulCheckRuns({
+  name = 'CI Quality / Required',
+  appId = RELEASE_APP_ID,
+  sha = MAIN_SHA,
+  conclusion = 'success',
+  extra = [],
+} = {}) {
+  const checkRuns = [{
+    id: 9001,
+    name,
+    head_sha: sha,
+    status: 'completed',
+    conclusion,
+    app: { id: appId, slug: appId === RELEASE_APP_ID ? RELEASE_APP_SLUG : 'github-actions' },
+  }, ...extra];
+  return { total_count: checkRuns.length, check_runs: checkRuns };
+}
+
+function releaseApp(overrides = {}) {
+  return {
+    id: RELEASE_APP_ID,
+    slug: RELEASE_APP_SLUG,
+    name: 'Cukies Release Guard',
+    ...overrides,
+  };
+}
+
+function releaseAppOptions() {
+  return { releaseAppId: RELEASE_APP_ID, releaseAppSlug: RELEASE_APP_SLUG };
+}
+
+test('los planes mantienen main lineal y permiten merge commits de sync en staging', () => {
+  const lock = buildReleaseGuardPlan({ phase: 'bootstrap-lock' });
+  const attested = buildReleaseGuardPlan({
+    phase: 'bootstrap-attested',
+    releaseAppId: RELEASE_APP_ID,
+  });
+  const steady = buildReleaseGuardPlan({
+    phase: 'steady-state',
+    releaseAppId: RELEASE_APP_ID,
+  });
+
+  assert.equal(lock.branches.main.required_status_checks, null);
+  assert.deepEqual(attested.branches.main.required_status_checks.checks, [
+    { context: 'release/staging-deployed', app_id: RELEASE_APP_ID },
+    { context: 'release/staging-validated', app_id: RELEASE_APP_ID },
+  ]);
+  assert.deepEqual(steady.branches.main.required_status_checks.contexts, [CI_CONTEXT_PLACEHOLDER]);
+  assert.deepEqual(steady.branches.main.required_status_checks.checks, [
+    { context: 'release/promotion-gate', app_id: RELEASE_APP_ID },
+  ]);
+  assert.equal(lock.branches.main.lock_branch, true);
+  assert.equal(lock.branches.staging.lock_branch, false);
+  assert.equal(attested.branches.main.lock_branch, false);
+  assert.equal(steady.branches.main.lock_branch, false);
+  for (const plan of [lock, attested, steady]) {
+    for (const branch of ['main', 'staging']) {
+      const protection = plan.branches[branch];
+      assert.equal(protection.enforce_admins, true);
+      assert.equal(protection.required_pull_request_reviews.required_approving_review_count, 1);
+      assert.equal(protection.required_pull_request_reviews.require_code_owner_reviews, true);
+      assert.equal(protection.required_pull_request_reviews.require_last_push_approval, true);
+      assert.equal(protection.required_linear_history, branch === 'main');
+      assert.equal(protection.allow_force_pushes, false);
+      assert.equal(protection.allow_deletions, false);
+      if (protection.required_status_checks) {
+        assert.equal(protection.required_status_checks.strict, true);
+      }
+    }
+  }
+});
+
+test('rechaza usar la identidad global de GitHub Actions para contextos release', () => {
+  for (const releaseAppId of [undefined, 0, 15368]) {
+    assert.throws(
+      () => buildReleaseGuardPlan({ phase: 'steady-state', releaseAppId }),
+      /dedicated GitHub App/i,
+    );
+  }
+});
+
+test('preserva checks ajenos con app_id exacto sin degradarlos a contexts legacy', () => {
+  const plan = buildReleaseGuardPlan({
+    phase: 'steady-state',
+    releaseAppId: RELEASE_APP_ID,
+    ciRequirement: { kind: 'check', context: 'CI Quality / Required', appId: RELEASE_APP_ID },
+    existingContexts: {
+      main: {
+        contexts: ['legacy/security', 'release/staging-deployed'],
+        checks: [
+          { context: 'ci/security', app_id: 4242 },
+          { context: 'ci/legacy-any-app', app_id: null },
+        ],
+      },
+      staging: {
+        contexts: [],
+        checks: [{ context: 'ci/staging', app_id: 5252 }],
+      },
+    },
+  });
+  assert.deepEqual(plan.branches.main.required_status_checks.contexts, [
+    'legacy/security',
+    'ci/legacy-any-app',
+  ]);
+  assert.deepEqual(plan.branches.main.required_status_checks.checks, [
+    { context: 'ci/security', app_id: 4242 },
+    { context: 'release/promotion-gate', app_id: RELEASE_APP_ID },
+    { context: 'CI Quality / Required', app_id: RELEASE_APP_ID },
+  ]);
+  assert.deepEqual(plan.branches.staging.required_status_checks.checks, [
+    { context: 'ci/staging', app_id: 5252 },
+  ]);
+});
+
+test('CLI es dry-run bootstrap-lock por defecto y no llama fetch ni requiere token', async () => {
+  const output = [];
+  const exitCode = await runConfigureBranchProtectionCli({
+    argv: [],
+    env: {},
+    fetchFn: async () => assert.fail('dry-run must not call fetch'),
+    stdout: { write: (value) => output.push(value) },
+    stderr: { write: () => assert.fail('dry-run must not write stderr') },
+  });
+  assert.equal(exitCode, 0);
+  assert.match(output.join(''), /DRY-RUN: no GitHub settings were changed/);
+  assert.match(output.join(''), /bootstrap-lock/);
+});
+
+test('dry-run de fases con statuses exige identidad App dedicada explícita', async () => {
+  for (const argv of [
+    ['--phase', 'bootstrap-attested'],
+    ['--phase', 'steady-state', '--release-app-id', '15368', '--release-app-slug', 'github-actions'],
+  ]) {
+    const errors = [];
+    const exitCode = await runConfigureBranchProtectionCli({
+      argv,
+      env: {},
+      fetchFn: async () => assert.fail('dry-run denied must not call fetch'),
+      stdout: { write: () => assert.fail('denied dry-run must not report success') },
+      stderr: { write: (value) => errors.push(value) },
+    });
+    assert.equal(exitCode, 1);
+    assert.match(errors.join(''), /release-app|GitHub Actions/i);
+  }
+
+  const output = [];
+  const exitCode = await runConfigureBranchProtectionCli({
+    argv: [
+      '--phase', 'bootstrap-attested',
+      '--release-app-id', String(RELEASE_APP_ID),
+      '--release-app-slug', RELEASE_APP_SLUG,
+    ],
+    env: {},
+    fetchFn: async () => assert.fail('dry-run must not call fetch'),
+    stdout: { write: (value) => output.push(value) },
+    stderr: { write: () => assert.fail('valid dry-run must not write stderr') },
+  });
+  assert.equal(exitCode, 0);
+  assert.match(output.join(''), new RegExp(String(RELEASE_APP_ID)));
+});
+
+test('cualquier --apply sin confirmación literal falla antes de fetch', async () => {
+  for (const argv of [
+    ['--apply'],
+    ['--apply', '--confirm', 'yes'],
+    ['--apply', '--confirm', `${RELEASE_GUARDS_CONFIRMATION} `],
+  ]) {
+    let fetchCalls = 0;
+    const errors = [];
+    const exitCode = await runConfigureBranchProtectionCli({
+      argv,
+      env: { GITHUB_TOKEN: 'test-token' },
+      fetchFn: async () => {
+        fetchCalls += 1;
+        return jsonResponse({});
+      },
+      stdout: { write: () => assert.fail('denied apply must not report success') },
+      stderr: { write: (value) => errors.push(value) },
+    });
+    assert.equal(exitCode, 1);
+    assert.equal(fetchCalls, 0);
+    assert.match(errors.join(''), /DENIED/);
+  }
+});
+
+test('bootstrap-lock bloquea y aplica primero main, después staging, sin exigir statuses', async () => {
+  const requests = [];
+  const plan = await applyReleaseGuardPlan({
+    phase: 'bootstrap-lock',
+    repository: REPOSITORY,
+    confirmation: RELEASE_GUARDS_CONFIRMATION,
+    token: 'test-token',
+    apiBaseUrl: 'https://api.github.test',
+    fetchFn: sequenceFetch([
+      ...branchPreflightResponses(),
+      jsonResponse({ url: 'protected-main' }),
+      jsonResponse({ url: 'protected-staging' }),
+    ], requests),
+  });
+  assert.deepEqual(requests.map(({ options }) => options.method), [
+    'GET', 'GET', 'GET', 'GET', 'PUT', 'PUT',
+  ]);
+  assert.match(requests[4].url, /branches\/main\/protection$/);
+  assert.match(requests[5].url, /branches\/staging\/protection$/);
+  assert.equal(plan.branches.main.required_status_checks, null);
+  assert.equal(plan.branches.main.lock_branch, true);
+});
+
+test('bootstrap-lock conserva app_id positivo y convierte app_id null en legacy context', async () => {
+  const requests = [];
+  const mainProtection = protectionPayload({
+    checks: [
+      { context: 'ci/security', app_id: 4242 },
+      { context: 'ci/legacy-any-app', app_id: null },
+    ],
+  });
+  await applyReleaseGuardPlan({
+    phase: 'bootstrap-lock',
+    repository: REPOSITORY,
+    confirmation: RELEASE_GUARDS_CONFIRMATION,
+    token: 'test-token',
+    apiBaseUrl: 'https://api.github.test',
+    fetchFn: sequenceFetch([
+      ...branchPreflightResponses({ mainProtection }),
+      jsonResponse({ url: 'protected-main' }),
+      jsonResponse({ url: 'protected-staging' }),
+    ], requests),
+  });
+  const mainBody = JSON.parse(requests[4].options.body);
+  assert.deepEqual(mainBody.required_status_checks.contexts, ['ci/legacy-any-app']);
+  assert.deepEqual(mainBody.required_status_checks.checks, [
+    { context: 'ci/security', app_id: 4242 },
+  ]);
+});
+
+test('bootstrap-attested valida App dedicada, candidato, entorno, procedencia y ancestry', async () => {
+  const requests = [];
+  const plan = await applyReleaseGuardPlan({
+    phase: 'bootstrap-attested',
+    repository: REPOSITORY,
+    candidateSha: CANDIDATE_SHA,
+    ...releaseAppOptions(),
+    confirmation: RELEASE_GUARDS_CONFIRMATION,
+    token: 'test-token',
+    apiBaseUrl: 'https://api.github.test',
+    fetchFn: sequenceFetch([
+      ...branchPreflightResponses(),
+      jsonResponse(releaseApp()),
+      jsonResponse(validEnvironment()),
+      jsonResponse(validBranchPolicies('staging')),
+      jsonResponse({ sha: MAIN_SHA }),
+      jsonResponse(statusPayload()),
+      jsonResponse(actionsRunPayload()),
+      jsonResponse(ancestryPayload()),
+      jsonResponse({ url: 'protected-main' }),
+      jsonResponse({ url: 'protected-staging' }),
+    ], requests),
+  });
+  assert.equal(requests.length, 13);
+  assert.match(requests[4].url, new RegExp(`/apps/${RELEASE_APP_SLUG}$`));
+  assert.match(requests[10].url, new RegExp(`/compare/${MAIN_SHA}\\.\\.\\.${CANDIDATE_SHA}\\?per_page=100$`));
+  assert.match(requests[11].url, /branches\/main\/protection$/);
+  assert.match(requests[12].url, /branches\/staging\/protection$/);
+  assert.deepEqual(JSON.parse(requests[11].options.body).required_status_checks.checks, [
+    { context: 'release/staging-deployed', app_id: RELEASE_APP_ID },
+    { context: 'release/staging-validated', app_id: RELEASE_APP_ID },
+  ]);
+  assert.equal(plan.phase, 'bootstrap-attested');
+});
+
+test('bootstrap-attested falla sin mutar para candidato o App incorrectos', async () => {
+  const wrongCandidateRequests = [];
+  await assert.rejects(applyReleaseGuardPlan({
+    phase: 'bootstrap-attested',
+    repository: REPOSITORY,
+    candidateSha: OTHER_SHA,
+    ...releaseAppOptions(),
+    confirmation: RELEASE_GUARDS_CONFIRMATION,
+    token: 'test-token',
+    apiBaseUrl: 'https://api.github.test',
+    fetchFn: sequenceFetch(branchPreflightResponses(), wrongCandidateRequests),
+  }), /currently resolved for staging/i);
+  assert.equal(wrongCandidateRequests.some(({ options }) => options.method === 'PUT'), false);
+
+  const wrongAppRequests = [];
+  await assert.rejects(applyReleaseGuardPlan({
+    phase: 'bootstrap-attested',
+    repository: REPOSITORY,
+    candidateSha: CANDIDATE_SHA,
+    ...releaseAppOptions(),
+    confirmation: RELEASE_GUARDS_CONFIRMATION,
+    token: 'test-token',
+    apiBaseUrl: 'https://api.github.test',
+    fetchFn: sequenceFetch([
+      ...branchPreflightResponses(),
+      jsonResponse(releaseApp({ id: 999999 })),
+    ], wrongAppRequests),
+  }), /dedicated release GitHub App/i);
+  assert.equal(wrongAppRequests.some(({ options }) => options.method === 'PUT'), false);
+});
+
+test('steady-state exige SHA actual, CI e identidad release antes de configurar', async () => {
+  for (const ciContext of [undefined, '', CI_CONTEXT_PLACEHOLDER, 'release/promotion-gate']) {
+    let fetchCalls = 0;
+    await assert.rejects(applyReleaseGuardPlan({
+      phase: 'steady-state',
+      repository: REPOSITORY,
+      candidateSha: MAIN_SHA,
+      ciContext,
+      ...releaseAppOptions(),
+      confirmation: RELEASE_GUARDS_CONFIRMATION,
+      token: 'test-token',
+      apiBaseUrl: 'https://api.github.test',
+      fetchFn: async () => {
+        fetchCalls += 1;
+        return jsonResponse({});
+      },
+    }), /CI context/i);
+    assert.equal(fetchCalls, 0);
+  }
+
+  const requests = [];
+  await assert.rejects(applyReleaseGuardPlan({
+    phase: 'steady-state',
+    repository: REPOSITORY,
+    candidateSha: OTHER_SHA,
+    ciContext: 'CI Quality / Required',
+    ...releaseAppOptions(),
+    confirmation: RELEASE_GUARDS_CONFIRMATION,
+    token: 'test-token',
+    apiBaseUrl: 'https://api.github.test',
+    fetchFn: sequenceFetch(branchPreflightResponses(), requests),
+  }), /currently resolved for main/i);
+  assert.equal(requests.some(({ options }) => options.method === 'PUT'), false);
+});
+
+test('steady-state valida workflow, ambos entornos y check verde antes de PUT', async () => {
+  const requests = [];
+  const mainProtection = protectionPayload({ checks: [{ context: 'ci/security', app_id: 4242 }] });
+  const stagingProtection = protectionPayload({ checks: [{ context: 'ci/staging', app_id: 5252 }] });
+  const plan = await applyReleaseGuardPlan({
+    phase: 'steady-state',
+    repository: REPOSITORY,
+    candidateSha: MAIN_SHA,
+    ciContext: 'CI Quality / Required',
+    ...releaseAppOptions(),
+    confirmation: RELEASE_GUARDS_CONFIRMATION,
+    token: 'test-token',
+    apiBaseUrl: 'https://api.github.test',
+    fetchFn: sequenceFetch([
+      ...branchPreflightResponses({ mainProtection, stagingProtection }),
+      jsonResponse(releaseApp()),
+      jsonResponse({
+        type: 'file',
+        path: '.github/workflows/main-promotion-gate.yml',
+        sha: WORKFLOW_BLOB_SHA,
+      }),
+      jsonResponse(validEnvironment('Staging')),
+      jsonResponse(validBranchPolicies('staging')),
+      jsonResponse(validEnvironment('Release Gate')),
+      jsonResponse(validBranchPolicies('main')),
+      jsonResponse(successfulCheckRuns()),
+      jsonResponse({ url: 'protected-main' }),
+      jsonResponse({ url: 'protected-staging' }),
+    ], requests),
+  });
+  assert.equal(requests.length, 13);
+  assert.match(requests[5].url, /main-promotion-gate\.yml\?ref=main$/);
+  assert.match(requests[6].url, /environments\/Staging$/);
+  assert.match(requests[7].url, /deployment-branch-policies\?per_page=100$/);
+  assert.match(requests[8].url, /environments\/Release%20Gate$/);
+  assert.match(requests[9].url, /deployment-branch-policies\?per_page=100$/);
+  assert.match(requests[10].url, new RegExp(`/commits/${MAIN_SHA}/check-runs\\?`));
+  assert.deepEqual(plan.branches.main.required_status_checks.checks, [
+    { context: 'ci/security', app_id: 4242 },
+    { context: 'release/promotion-gate', app_id: RELEASE_APP_ID },
+    { context: 'CI Quality / Required', app_id: RELEASE_APP_ID },
+  ]);
+  assert.deepEqual(plan.branches.staging.required_status_checks.checks, [
+    { context: 'ci/staging', app_id: 5252 },
+  ]);
+});
+
+test('steady-state rechaza environment relajado o CI ambiguo sin hacer PUT', async () => {
+  const cases = [
+    {
+      staging: validEnvironment('Staging'),
+      releaseGate: validEnvironment('Release Gate', { protection_rules: [] }),
+      checks: successfulCheckRuns(),
+    },
+    {
+      staging: validEnvironment('Staging'),
+      releaseGate: validEnvironment('Release Gate'),
+      checks: successfulCheckRuns({
+        extra: [{
+          id: 9002,
+          name: 'CI Quality / Required',
+          head_sha: MAIN_SHA,
+          status: 'completed',
+          conclusion: 'success',
+          app: { id: 99999, slug: 'forged-ci' },
+        }],
+      }),
+    },
+    {
+      staging: validEnvironment('Staging'),
+      releaseGate: validEnvironment('Release Gate'),
+      checks: successfulCheckRuns({ appId: 15368 }),
+    },
+  ];
+  for (const testCase of cases) {
+    const requests = [];
+    await assert.rejects(applyReleaseGuardPlan({
+      phase: 'steady-state',
+      repository: REPOSITORY,
+      candidateSha: MAIN_SHA,
+      ciContext: 'CI Quality / Required',
+      ...releaseAppOptions(),
+      confirmation: RELEASE_GUARDS_CONFIRMATION,
+      token: 'test-token',
+      apiBaseUrl: 'https://api.github.test',
+      fetchFn: sequenceFetch([
+        ...branchPreflightResponses(),
+        jsonResponse(releaseApp()),
+        jsonResponse({
+          type: 'file',
+          path: '.github/workflows/main-promotion-gate.yml',
+          sha: WORKFLOW_BLOB_SHA,
+        }),
+        jsonResponse(testCase.staging),
+        jsonResponse(validBranchPolicies('staging')),
+        jsonResponse(testCase.releaseGate),
+        ...(testCase.releaseGate.protection_rules.length === 0
+          ? []
+          : [
+              jsonResponse(validBranchPolicies('main')),
+              jsonResponse(testCase.checks),
+            ]),
+      ], requests),
+    }));
+    assert.equal(requests.some(({ options }) => options.method === 'PUT'), false);
+  }
+});
+
+test('steady-state falla sin mutar si el workflow no existe todavía en main', async () => {
+  const requests = [];
+  await assert.rejects(applyReleaseGuardPlan({
+    phase: 'steady-state',
+    repository: REPOSITORY,
+    candidateSha: MAIN_SHA,
+    ciContext: 'CI Quality / Required',
+    ...releaseAppOptions(),
+    confirmation: RELEASE_GUARDS_CONFIRMATION,
+    token: 'test-token',
+    apiBaseUrl: 'https://api.github.test',
+    fetchFn: sequenceFetch([
+      ...branchPreflightResponses(),
+      jsonResponse(releaseApp()),
+      jsonResponse({ message: 'Not Found' }, 404),
+    ], requests),
+  }), /preflight/i);
+  assert.equal(requests.some(({ options }) => options.method === 'PUT'), false);
+});
+
+test('si falla el segundo PUT main ya queda protegido aunque staging siga pendiente', async () => {
+  const putUrls = [];
+  const responses = [
+    ...branchPreflightResponses(),
+    jsonResponse({ url: 'protected-main' }),
+    jsonResponse({ message: 'denied' }, 500),
+  ];
+  await assert.rejects(applyReleaseGuardPlan({
+    phase: 'bootstrap-lock',
+    repository: REPOSITORY,
+    confirmation: RELEASE_GUARDS_CONFIRMATION,
+    token: 'test-token',
+    apiBaseUrl: 'https://api.github.test',
+    fetchFn: async (url, options) => {
+      if (options.method === 'PUT') putUrls.push(url);
+      return responses.shift();
+    },
+  }), /staging.*HTTP 500/i);
+  assert.match(putUrls[0], /branches\/main\/protection$/);
+  assert.match(putUrls[1], /branches\/staging\/protection$/);
+});

--- a/scripts/release/promotion-policy.mjs
+++ b/scripts/release/promotion-policy.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const PROMOTION_MANIFEST_SCHEMA_VERSION = 1;
+export const PROMOTION_MANIFEST_REPOSITORY_PATH = '.github/release/promotion.json';
+
+const FULL_GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const HOTFIX_REF_PATTERN = /^hotfix\/(?!\/)(?!.*\/\/)[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*$/;
+const MAX_MANIFEST_BYTES = 32 * 1024;
+const MAX_EVIDENCE_ITEMS = 10;
+const MAX_TEXT_LENGTH = 4_000;
+const COMMON_MANIFEST_KEYS = Object.freeze([
+  'schemaVersion',
+  'mode',
+  'pullRequest',
+  'baseSha',
+]);
+const NORMAL_MANIFEST_KEYS = Object.freeze([
+  ...COMMON_MANIFEST_KEYS,
+  'stagingEvidence',
+  'rollback',
+]);
+const HOTFIX_MANIFEST_KEYS = Object.freeze([
+  ...COMMON_MANIFEST_KEYS,
+  'incident',
+  'urgency',
+  'whyStagingCannotWait',
+  'rollback',
+]);
+
+export class PromotionPolicyError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'PromotionPolicyError';
+  }
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function isFullGitSha(value) {
+  return typeof value === 'string' && FULL_GIT_SHA_PATTERN.test(value);
+}
+
+export function isPlaceholderValue(value) {
+  if (typeof value !== 'string') {
+    return true;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === '' || /^[?.!_\-–—]+$/.test(normalized)) {
+    return true;
+  }
+
+  return (
+    /^(?:<[^>]+>|\[[^\]]+\]|\{[^}]+\})$/.test(normalized)
+    || /\b(?:tbd|todo|pending|placeholder|changeme|fixme|none|null|unknown|later)\b/.test(normalized)
+    || /(?:pendiente|por\s+completar|rellenar|añadir|describir)/.test(normalized)
+    || /\b(?:fill|insert|add|describe|provide|replace)\s+(?:this|me|the|an?|your|evidence|details?|plan|value|sha)\b/.test(normalized)
+    || /\b(?:n\s*\/?\s*a|not\s+applicable|to\s+be\s+(?:decided|determined|defined|confirmed|completed))\b/.test(normalized)
+  );
+}
+
+function validateExactKeys(manifest, expectedKeys) {
+  const actualKeys = Object.keys(manifest).sort();
+  const sortedExpected = [...expectedKeys].sort();
+  if (
+    actualKeys.length !== sortedExpected.length
+    || actualKeys.some((key, index) => key !== sortedExpected[index])
+  ) {
+    throw new PromotionPolicyError(
+      `El manifiesto ${manifest.mode ?? 'desconocido'} no contiene exactamente los campos permitidos.`,
+    );
+  }
+}
+
+function validateText(value, field) {
+  if (
+    typeof value !== 'string'
+    || value.trim() !== value
+    || value.length < 16
+    || value.length > MAX_TEXT_LENGTH
+    || isPlaceholderValue(value)
+  ) {
+    throw new PromotionPolicyError(
+      `El campo ${field} del manifiesto está vacío, es un placeholder o tiene una longitud inválida.`,
+    );
+  }
+  return value;
+}
+
+function validateEvidence(value) {
+  if (
+    !Array.isArray(value)
+    || value.length === 0
+    || value.length > MAX_EVIDENCE_ITEMS
+    || new Set(value).size !== value.length
+  ) {
+    throw new PromotionPolicyError(
+      'stagingEvidence debe contener entre 1 y 10 URLs HTTPS únicas.',
+    );
+  }
+
+  for (const evidenceUrl of value) {
+    let parsed;
+    try {
+      parsed = new URL(evidenceUrl);
+    } catch {
+      throw new PromotionPolicyError('stagingEvidence contiene una URL inválida.');
+    }
+    if (
+      typeof evidenceUrl !== 'string'
+      || evidenceUrl.length > 2_048
+      || parsed.protocol !== 'https:'
+      || parsed.username !== ''
+      || parsed.password !== ''
+      || parsed.hostname === ''
+    ) {
+      throw new PromotionPolicyError(
+        'stagingEvidence solo admite URLs HTTPS absolutas y sin credenciales.',
+      );
+    }
+  }
+  return [...value];
+}
+
+function validateManifestBinding(pullRequest, manifest) {
+  if (!isRecord(manifest)) {
+    throw new PromotionPolicyError('Se requiere un manifiesto de promoción JSON válido.');
+  }
+  if (manifest.schemaVersion !== PROMOTION_MANIFEST_SCHEMA_VERSION) {
+    throw new PromotionPolicyError(
+      `schemaVersion debe ser exactamente ${PROMOTION_MANIFEST_SCHEMA_VERSION}.`,
+    );
+  }
+  if (!Number.isSafeInteger(pullRequest.number) || pullRequest.number <= 0) {
+    throw new PromotionPolicyError('El número de pull request no es válido.');
+  }
+  if (manifest.pullRequest !== pullRequest.number) {
+    throw new PromotionPolicyError(
+      'El manifiesto no está ligado al número exacto de esta pull request.',
+    );
+  }
+  if (!isFullGitSha(pullRequest.base.sha)) {
+    throw new PromotionPolicyError('El SHA de base debe ser un SHA Git completo de 40 caracteres.');
+  }
+  if (!isFullGitSha(manifest.baseSha) || manifest.baseSha !== pullRequest.base.sha) {
+    throw new PromotionPolicyError(
+      'El manifiesto no está ligado al SHA exacto actual de main.',
+    );
+  }
+}
+
+export function evaluatePromotionPolicy(event, manifest) {
+  if (!isRecord(event) || !isRecord(event.pull_request)) {
+    throw new PromotionPolicyError('Promotion policy: se requiere un evento de pull request válido.');
+  }
+
+  const pullRequest = event.pull_request;
+  if (!isRecord(pullRequest.base) || pullRequest.base.ref !== 'main') {
+    throw new PromotionPolicyError('La rama base debe ser exactamente main.');
+  }
+  if (!isRecord(pullRequest.head) || typeof pullRequest.head.ref !== 'string') {
+    throw new PromotionPolicyError('La rama de origen de la pull request no es válida.');
+  }
+  if (
+    !isRecord(pullRequest.base.repo)
+    || !isRecord(pullRequest.head.repo)
+    || typeof pullRequest.base.repo.full_name !== 'string'
+    || pullRequest.base.repo.full_name === ''
+    || pullRequest.head.repo.full_name !== pullRequest.base.repo.full_name
+  ) {
+    throw new PromotionPolicyError(
+      'La promoción y los hotfixes deben originarse en una rama del mismo repositorio.',
+    );
+  }
+  if (!isFullGitSha(pullRequest.head.sha)) {
+    throw new PromotionPolicyError('El SHA de head debe ser un SHA Git completo de 40 caracteres.');
+  }
+
+  validateManifestBinding(pullRequest, manifest);
+
+  const headRef = pullRequest.head.ref;
+  const candidateSha = pullRequest.head.sha;
+  let mode;
+
+  if (headRef === 'staging') {
+    mode = 'normal';
+    if (manifest.mode !== mode) {
+      throw new PromotionPolicyError('Una promoción desde staging requiere mode normal.');
+    }
+    validateExactKeys(manifest, NORMAL_MANIFEST_KEYS);
+    validateEvidence(manifest.stagingEvidence);
+    validateText(manifest.rollback, 'rollback');
+  } else if (HOTFIX_REF_PATTERN.test(headRef)) {
+    mode = 'hotfix';
+    if (manifest.mode !== mode) {
+      throw new PromotionPolicyError('Una rama hotfix/* requiere mode hotfix.');
+    }
+    validateExactKeys(manifest, HOTFIX_MANIFEST_KEYS);
+    validateText(manifest.incident, 'incident');
+    validateText(manifest.urgency, 'urgency');
+    validateText(manifest.whyStagingCannotWait, 'whyStagingCannotWait');
+    validateText(manifest.rollback, 'rollback');
+  } else {
+    throw new PromotionPolicyError(
+      'Rama de origen no autorizada: use staging o una rama hotfix/* formal.',
+    );
+  }
+
+  return {
+    mode,
+    pullRequest: pullRequest.number,
+    baseRef: 'main',
+    baseSha: pullRequest.base.sha,
+    headRef,
+    candidateSha,
+  };
+}
+
+async function readJsonFile({ filePath, label, readFileFn }) {
+  let raw;
+  try {
+    raw = await readFileFn(filePath, 'utf8');
+  } catch {
+    throw new PromotionPolicyError(`No se pudo leer ${label}.`);
+  }
+  if (typeof raw !== 'string' || Buffer.byteLength(raw, 'utf8') > MAX_MANIFEST_BYTES) {
+    throw new PromotionPolicyError(`${label} excede el tamaño permitido.`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new PromotionPolicyError(`${label} no contiene JSON válido.`);
+  }
+}
+
+export async function runPromotionPolicyCli({
+  env = process.env,
+  readFileFn = readFile,
+  stdout = process.stdout,
+  stderr = process.stderr,
+} = {}) {
+  try {
+    if (typeof env.GITHUB_EVENT_PATH !== 'string' || env.GITHUB_EVENT_PATH.trim() === '') {
+      throw new PromotionPolicyError('GITHUB_EVENT_PATH no está definido.');
+    }
+    if (
+      typeof env.PROMOTION_MANIFEST_PATH !== 'string'
+      || env.PROMOTION_MANIFEST_PATH.trim() === ''
+    ) {
+      throw new PromotionPolicyError('PROMOTION_MANIFEST_PATH no está definido.');
+    }
+
+    const event = await readJsonFile({
+      filePath: env.GITHUB_EVENT_PATH,
+      label: 'GITHUB_EVENT_PATH',
+      readFileFn,
+    });
+    const manifest = await readJsonFile({
+      filePath: env.PROMOTION_MANIFEST_PATH,
+      label: 'PROMOTION_MANIFEST_PATH',
+      readFileFn,
+    });
+    const result = evaluatePromotionPolicy(event, manifest);
+    stdout.write(
+      `Promotion policy: promoción ${result.mode} permitida para ${result.headRef} -> main (${result.candidateSha}).\n`,
+    );
+    return 0;
+  } catch (error) {
+    const message = error instanceof PromotionPolicyError
+      ? error.message
+      : 'Error interno al evaluar la política.';
+    stderr.write(`Promotion policy: DENEGADA. ${message}\n`);
+    return 1;
+  }
+}
+
+const isDirectInvocation = process.argv[1]
+  && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (isDirectInvocation) {
+  process.exitCode = await runPromotionPolicyCli();
+}

--- a/scripts/release/promotion-policy.test.mjs
+++ b/scripts/release/promotion-policy.test.mjs
@@ -1,0 +1,362 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  PROMOTION_MANIFEST_REPOSITORY_PATH,
+  PROMOTION_MANIFEST_SCHEMA_VERSION,
+  PromotionPolicyError,
+  evaluatePromotionPolicy,
+  isPlaceholderValue,
+  runPromotionPolicyCli,
+} from './promotion-policy.mjs';
+
+const CANDIDATE_SHA = '0123456789abcdef0123456789abcdef01234567';
+const BASE_SHA = '89abcdef0123456789abcdef0123456789abcdef';
+const OTHER_SHA = 'fedcba9876543210fedcba9876543210fedcba98';
+const PR_NUMBER = 232;
+
+function normalManifest(overrides = {}) {
+  return {
+    schemaVersion: PROMOTION_MANIFEST_SCHEMA_VERSION,
+    mode: 'normal',
+    pullRequest: PR_NUMBER,
+    baseSha: BASE_SHA,
+    stagingEvidence: [
+      'https://github.com/fgomezserna/cukies-hub/actions/runs/481',
+      'https://cukieshub.eurekand.com/api/health',
+    ],
+    rollback: 'Revert the main merge commit and redeploy the previous known-good image.',
+    ...overrides,
+  };
+}
+
+function hotfixManifest(overrides = {}) {
+  return {
+    schemaVersion: PROMOTION_MANIFEST_SCHEMA_VERSION,
+    mode: 'hotfix',
+    pullRequest: PR_NUMBER,
+    baseSha: BASE_SHA,
+    incident: 'INC-481 - production checkout is unavailable for active customers.',
+    urgency: 'Active production impact requires immediate restoration of checkout.',
+    whyStagingCannotWait: 'The failure depends on production-only routing and blocks presale purchases now.',
+    rollback: 'Revert the hotfix merge commit and redeploy the last known-good image.',
+    ...overrides,
+  };
+}
+
+function pullRequestEvent(overrides = {}) {
+  const pullRequestOverrides = overrides.pullRequest ?? {};
+  const pullRequest = {
+    number: PR_NUMBER,
+    base: {
+      ref: 'main',
+      sha: BASE_SHA,
+      repo: { full_name: 'fgomezserna/cukies-hub' },
+      ...pullRequestOverrides.base,
+    },
+    head: {
+      ref: 'staging',
+      sha: CANDIDATE_SHA,
+      repo: { full_name: 'fgomezserna/cukies-hub' },
+      ...pullRequestOverrides.head,
+    },
+    body: 'Informational only and intentionally mutable.',
+    labels: [],
+    ...pullRequestOverrides,
+  };
+  pullRequest.base = {
+    ref: 'main',
+    sha: BASE_SHA,
+    repo: { full_name: 'fgomezserna/cukies-hub' },
+    ...pullRequestOverrides.base,
+  };
+  pullRequest.head = {
+    ref: 'staging',
+    sha: CANDIDATE_SHA,
+    repo: { full_name: 'fgomezserna/cukies-hub' },
+    ...pullRequestOverrides.head,
+  };
+
+  return {
+    action: 'synchronize',
+    pull_request: pullRequest,
+    ...overrides.event,
+  };
+}
+
+test('permite staging -> main solo con manifiesto inmutable ligado a PR y base SHA', () => {
+  assert.deepEqual(evaluatePromotionPolicy(pullRequestEvent(), normalManifest()), {
+    mode: 'normal',
+    pullRequest: PR_NUMBER,
+    baseRef: 'main',
+    baseSha: BASE_SHA,
+    headRef: 'staging',
+    candidateSha: CANDIDATE_SHA,
+  });
+});
+
+test('permite hotfix/* -> main con manifiesto formal e inmutable', () => {
+  const event = pullRequestEvent({
+    pullRequest: {
+      head: { ref: 'hotfix/restore-checkout', sha: CANDIDATE_SHA },
+      body: '',
+      labels: [],
+    },
+  });
+
+  assert.deepEqual(evaluatePromotionPolicy(event, hotfixManifest()), {
+    mode: 'hotfix',
+    pullRequest: PR_NUMBER,
+    baseRef: 'main',
+    baseSha: BASE_SHA,
+    headRef: 'hotfix/restore-checkout',
+    candidateSha: CANDIDATE_SHA,
+  });
+});
+
+test('body y labels mutables no forman parte de la autorización', () => {
+  const event = pullRequestEvent({
+    pullRequest: {
+      head: { ref: 'hotfix/restore-checkout', sha: CANDIDATE_SHA },
+      body: 'edited after the run',
+      labels: [{ name: 'anything' }],
+    },
+  });
+  assert.equal(evaluatePromotionPolicy(event, hotfixManifest()).mode, 'hotfix');
+});
+
+test('rechaza eventos que no sean de pull request', () => {
+  assert.throws(() => evaluatePromotionPolicy({ action: 'push' }, normalManifest()), PromotionPolicyError);
+});
+
+test('rechaza una base distinta de main', () => {
+  assert.throws(
+    () => evaluatePromotionPolicy(
+      pullRequestEvent({ pullRequest: { base: { ref: 'develop' } } }),
+      normalManifest(),
+    ),
+    /base.*main/i,
+  );
+});
+
+test('rechaza staging o hotfix desde un fork aunque el nombre de rama parezca válido', () => {
+  for (const [headRef, manifest] of [
+    ['staging', normalManifest()],
+    ['hotfix/forged', hotfixManifest()],
+  ]) {
+    assert.throws(
+      () => evaluatePromotionPolicy(pullRequestEvent({
+        pullRequest: {
+          head: {
+            ref: headRef,
+            sha: CANDIDATE_SHA,
+            repo: { full_name: 'attacker/cukies-hub' },
+          },
+        },
+      }), manifest),
+      /mismo repositorio/i,
+    );
+  }
+});
+
+for (const headRef of ['feature/new-gate', 'develop', 'main', 'staging-copy', 'hotfix/']) {
+  test(`rechaza la rama de origen no autorizada: ${headRef}`, () => {
+    assert.throws(
+      () => evaluatePromotionPolicy(
+        pullRequestEvent({ pullRequest: { head: { ref: headRef, sha: CANDIDATE_SHA } } }),
+        normalManifest(),
+      ),
+      /rama de origen/i,
+    );
+  });
+}
+
+test('rechaza SHA de head o de base ausente, abreviado o mal formado', () => {
+  for (const sha of [undefined, '', CANDIDATE_SHA.slice(0, 7), `${CANDIDATE_SHA}00`, 'z'.repeat(40)]) {
+    assert.throws(
+      () => evaluatePromotionPolicy(
+        pullRequestEvent({ pullRequest: { head: { ref: 'staging', sha } } }),
+        normalManifest(),
+      ),
+      /sha.*completo/i,
+    );
+    assert.throws(
+      () => evaluatePromotionPolicy(
+        pullRequestEvent({ pullRequest: { base: { sha } } }),
+        normalManifest(),
+      ),
+      /sha.*base|base.*sha/i,
+    );
+  }
+});
+
+test('rechaza manifiesto sin objeto o con schemaVersion distinto', () => {
+  for (const manifest of [undefined, null, [], normalManifest({ schemaVersion: 2 })]) {
+    assert.throws(
+      () => evaluatePromotionPolicy(pullRequestEvent(), manifest),
+      /manifiesto|schemaversion/i,
+    );
+  }
+});
+
+test('rechaza manifiesto reutilizado en otro PR o tras avanzar main', () => {
+  assert.throws(
+    () => evaluatePromotionPolicy(
+      pullRequestEvent({ pullRequest: { number: PR_NUMBER + 1 } }),
+      normalManifest(),
+    ),
+    /número exacto/i,
+  );
+  assert.throws(
+    () => evaluatePromotionPolicy(
+      pullRequestEvent({ pullRequest: { base: { sha: OTHER_SHA } } }),
+      normalManifest(),
+    ),
+    /sha exacto actual/i,
+  );
+});
+
+test('rechaza un mode que no coincide con la rama de origen', () => {
+  assert.throws(
+    () => evaluatePromotionPolicy(pullRequestEvent(), normalManifest({ mode: 'hotfix' })),
+    /mode normal/i,
+  );
+  assert.throws(
+    () => evaluatePromotionPolicy(
+      pullRequestEvent({ pullRequest: { head: { ref: 'hotfix/fix', sha: CANDIDATE_SHA } } }),
+      hotfixManifest({ mode: 'normal' }),
+    ),
+    /mode hotfix/i,
+  );
+});
+
+test('rechaza campos extra y campos faltantes de forma fail-closed', () => {
+  const normalExtra = normalManifest({ arbitraryApproval: true });
+  assert.throws(
+    () => evaluatePromotionPolicy(pullRequestEvent(), normalExtra),
+    /exactamente.*campos/i,
+  );
+
+  const hotfixMissing = hotfixManifest();
+  delete hotfixMissing.incident;
+  assert.throws(
+    () => evaluatePromotionPolicy(
+      pullRequestEvent({ pullRequest: { head: { ref: 'hotfix/fix', sha: CANDIDATE_SHA } } }),
+      hotfixMissing,
+    ),
+    /exactamente.*campos/i,
+  );
+});
+
+for (const evidence of [
+  [],
+  ['http://cukieshub.eurekand.com/api/health'],
+  ['https://user:secret@example.com/evidence'],
+  ['not-a-url'],
+  Array.from({ length: 11 }, (_, index) => `https://example.com/${index}`),
+  ['https://example.com/evidence', 'https://example.com/evidence'],
+]) {
+  test(`rechaza stagingEvidence inválida: ${JSON.stringify(evidence)}`, () => {
+    assert.throws(
+      () => evaluatePromotionPolicy(pullRequestEvent(), normalManifest({ stagingEvidence: evidence })),
+      /stagingevidence/i,
+    );
+  });
+}
+
+for (const placeholder of [
+  '',
+  'TBD',
+  'TODO: fill this in',
+  'pending',
+  'N/A',
+  'none',
+  '<add evidence here>',
+  '[INSERT ROLLBACK PLAN]',
+  '???',
+  '...',
+  'pendiente',
+  'por completar',
+  'rellenar',
+  'añadir evidencia',
+  'describir rollback',
+]) {
+  test(`detecta el placeholder ${JSON.stringify(placeholder)}`, () => {
+    assert.equal(isPlaceholderValue(placeholder), true);
+  });
+}
+
+for (const field of ['incident', 'urgency', 'whyStagingCannotWait', 'rollback']) {
+  test(`rechaza hotfix con ${field} vacío o placeholder`, () => {
+    assert.throws(
+      () => evaluatePromotionPolicy(
+        pullRequestEvent({ pullRequest: { head: { ref: 'hotfix/fix', sha: CANDIDATE_SHA } } }),
+        hotfixManifest({ [field]: 'TODO' }),
+      ),
+      new RegExp(field, 'i'),
+    );
+  });
+}
+
+test('CLI lee evento y manifiesto desde dos rutas explícitas', async () => {
+  const output = [];
+  const errors = [];
+  const readPaths = [];
+  const exitCode = await runPromotionPolicyCli({
+    env: {
+      GITHUB_EVENT_PATH: '/tmp/event.json',
+      PROMOTION_MANIFEST_PATH: '/tmp/promotion.json',
+    },
+    readFileFn: async (filePath) => {
+      readPaths.push(filePath);
+      return JSON.stringify(
+        filePath === '/tmp/event.json' ? pullRequestEvent() : normalManifest(),
+      );
+    },
+    stdout: { write: (value) => output.push(value) },
+    stderr: { write: (value) => errors.push(value) },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.deepEqual(readPaths, ['/tmp/event.json', '/tmp/promotion.json']);
+  assert.match(output.join(''), /normal.*permitida/i);
+  assert.equal(errors.length, 0);
+  assert.equal(PROMOTION_MANIFEST_REPOSITORY_PATH, '.github/release/promotion.json');
+});
+
+test('CLI falla cerrado si falta una ruta, el JSON es inválido o el manifiesto es excesivo', async () => {
+  const cases = [
+    { env: {}, readFileFn: async () => assert.fail('no debe leer') },
+    {
+      env: { GITHUB_EVENT_PATH: '/tmp/event.json' },
+      readFileFn: async () => assert.fail('no debe leer'),
+    },
+    {
+      env: {
+        GITHUB_EVENT_PATH: '/tmp/event.json',
+        PROMOTION_MANIFEST_PATH: '/tmp/promotion.json',
+      },
+      readFileFn: async (filePath) => filePath.endsWith('event.json') ? '{' : '{}',
+    },
+    {
+      env: {
+        GITHUB_EVENT_PATH: '/tmp/event.json',
+        PROMOTION_MANIFEST_PATH: '/tmp/promotion.json',
+      },
+      readFileFn: async (filePath) => filePath.endsWith('event.json')
+        ? JSON.stringify(pullRequestEvent())
+        : 'x'.repeat(33 * 1024),
+    },
+  ];
+
+  for (const testCase of cases) {
+    const errors = [];
+    const exitCode = await runPromotionPolicyCli({
+      ...testCase,
+      stdout: { write: () => assert.fail('no debe escribir éxito') },
+      stderr: { write: (value) => errors.push(value) },
+    });
+    assert.equal(exitCode, 1);
+    assert.match(errors.join(''), /promotion policy/i);
+  }
+});

--- a/scripts/release/release-documentation.test.mjs
+++ b/scripts/release/release-documentation.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const ROOT = new URL('../../', import.meta.url);
+
+async function read(relativePath) {
+  return readFile(new URL(relativePath, ROOT), 'utf8');
+}
+
+test('release docs usan staging -> main, manifiesto inmutable y test merge exacto', async () => {
+  const [workflow, candidate, issueForm, pullRequestTemplate] = await Promise.all([
+    read('docs/release-workflow.md'),
+    read('docs/release-candidate-template.md'),
+    read('.github/ISSUE_TEMPLATE/release_candidate.yml'),
+    read('.github/pull_request_template.md'),
+  ]);
+  const combined = `${workflow}\n${candidate}\n${issueForm}\n${pullRequestTemplate}`;
+
+  assert.match(workflow, /PR desde `staging` a `main`/);
+  assert.match(combined, /\.github\/release\/promotion\.json/);
+  assert.match(combined, /promotion\.schema\.json/);
+  assert.match(workflow, /refs\/pull\/<n>\/merge/);
+  assert.match(workflow, /tree del test merge/i);
+  assert.match(candidate, /"mode": "normal"/);
+  assert.match(candidate, /"mode": "hotfix"/);
+  assert.match(issueForm, /Main\/live \(promocion desde staging\)/);
+
+  for (const obsolete of [
+    'label exacta `hotfix`',
+    'sync/hotfix-',
+    'El PR normal solo puede tener head `staging` y base `main`. Su body debe contener',
+  ]) {
+    assert.doesNotMatch(combined, new RegExp(obsolete.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});
+
+test('bootstrap queda fail-closed con App dedicada, custom branches, sync y freeze', async () => {
+  const [workflow, candidate] = await Promise.all([
+    read('docs/release-workflow.md'),
+    read('docs/release-candidate-template.md'),
+  ]);
+  for (const source of [workflow, candidate]) {
+    assert.match(source, /Environment\s+protegido `Staging`/);
+    assert.match(source, /pull_request_target/);
+    assert.match(source, /no\s+fabrica attestations/i);
+    assert.match(source, /impid(?:e|en|ir) autoaprobacion/);
+    assert.match(source, /app_id/);
+    assert.match(source, /App dedicada/i);
+    assert.match(source, /sync\/main-/);
+    assert.match(source, /Create a merge commit/);
+    assert.match(source, /Mainnet y preventa.*congelad/is);
+  }
+  assert.match(workflow, /custom.*`staging`/is);
+  assert.match(workflow, /custom.*`main`/is);
+  assert.match(workflow, /#235/);
+  assert.doesNotMatch(workflow, /actor autorizado crea manualmente/);
+});

--- a/scripts/release/release-guards.config.mjs
+++ b/scripts/release/release-guards.config.mjs
@@ -1,0 +1,191 @@
+export const RELEASE_GUARDS_REPOSITORY = 'fgomezserna/cukies-hub';
+export const RELEASE_GUARDS_CONFIRMATION = 'APPLY_RELEASE_GUARDS_AFTER_FREEZE';
+export const CI_CONTEXT_PLACEHOLDER = '__REPLACE_WITH_EXISTING_REQUIRED_CI_CONTEXT__';
+export const MANAGED_RELEASE_CONTEXTS = Object.freeze([
+  'release/staging-deployed',
+  'release/staging-validated',
+  'release/promotion-gate',
+]);
+
+export const RELEASE_GUARD_PHASES = Object.freeze({
+  'bootstrap-lock': Object.freeze({
+    description: 'Freeze main read-only and lock direct pushes before release tooling exists.',
+    mainContexts: Object.freeze([]),
+    preconditions: Object.freeze([
+      'Run this read-only main freeze plus PR/review/admin lock before merging tooling to staging.',
+      'No new release status is required because those workflows do not exist yet.',
+      'Inspect the dry-run and preserve any existing CI policy operationally.',
+    ]),
+  }),
+  'bootstrap-attested': Object.freeze({
+    description: 'Replace the main freeze with verified staging attestations for the first promotion.',
+    mainContexts: Object.freeze([
+      'release/staging-deployed',
+      'release/staging-validated',
+    ]),
+    preconditions: Object.freeze([
+      'The release tooling is already merged and deployed from staging.',
+      'A dedicated release GitHub App is installed and its key is scoped to protected environments.',
+      'Both staging attestations exist on the exact candidate SHA.',
+      'main is an ancestor of that candidate SHA.',
+      'The first staging -> main PR is reviewed manually because pull_request_target is not active yet.',
+    ]),
+  }),
+  'steady-state': Object.freeze({
+    description: 'Enable the permanent promotion gate after the first promotion reaches main.',
+    mainContexts: Object.freeze([
+      'release/promotion-gate',
+      CI_CONTEXT_PLACEHOLDER,
+    ]),
+    preconditions: Object.freeze([
+      'The main-promotion-gate workflow exists on the default main branch.',
+      'The dedicated release GitHub App is bound to every release/* requirement.',
+      'Staging and Release Gate require review plus exact staging/main custom branch policies.',
+      'The CI placeholder is replaced by an existing required CI context.',
+      'The bootstrap-protected first promotion has already completed.',
+    ]),
+  }),
+});
+
+function normalizeExistingRequirements(value) {
+  if (Array.isArray(value)) {
+    return { contexts: [...value], checks: [] };
+  }
+  const rawChecks = [...(value?.checks ?? [])].map((check) => ({ ...check }));
+  return {
+    contexts: [
+      ...(value?.contexts ?? []),
+      ...rawChecks.filter(({ app_id: appId }) => appId === null).map(({ context }) => context),
+    ],
+    checks: rawChecks.filter(({ app_id: appId }) => appId !== null),
+  };
+}
+
+function uniqueContexts(contexts) {
+  return [...new Set(contexts)];
+}
+
+function uniqueChecks(checks) {
+  const seen = new Set();
+  return checks.filter((check) => {
+    const key = `${check.context}\0${String(check.app_id)}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function protection({ contexts, checks, linearHistory, lockBranch = false }) {
+  const hasRequirements = contexts.length > 0 || checks.length > 0;
+  return {
+    required_status_checks: hasRequirements
+      ? {
+          strict: true,
+          contexts: [...contexts],
+          checks: checks.map((check) => ({ ...check })),
+        }
+      : null,
+    enforce_admins: true,
+    required_pull_request_reviews: {
+      dismiss_stale_reviews: true,
+      require_code_owner_reviews: true,
+      required_approving_review_count: 1,
+      require_last_push_approval: true,
+    },
+    restrictions: null,
+    required_linear_history: linearHistory,
+    allow_force_pushes: false,
+    allow_deletions: false,
+    block_creations: false,
+    required_conversation_resolution: true,
+    lock_branch: lockBranch,
+    allow_fork_syncing: false,
+  };
+}
+
+export function buildReleaseGuardPlan({
+  phase = 'bootstrap-lock',
+  repository = RELEASE_GUARDS_REPOSITORY,
+  ciContext,
+  ciRequirement,
+  releaseAppId,
+  existingContexts = { main: { contexts: [], checks: [] }, staging: { contexts: [], checks: [] } },
+} = {}) {
+  const phaseConfig = RELEASE_GUARD_PHASES[phase];
+  if (!phaseConfig) {
+    throw new Error(`Unknown release guard phase: ${phase}.`);
+  }
+  if (
+    ciRequirement !== undefined
+    && (
+      ciRequirement?.kind !== 'check'
+      || typeof ciRequirement.context !== 'string'
+      || ciRequirement.context === ''
+      || !Number.isSafeInteger(ciRequirement.appId)
+      || ciRequirement.appId <= 0
+    )
+  ) {
+    throw new Error('ciRequirement must be an app-bound check resolved by the apply preflight.');
+  }
+
+  const existingMain = normalizeExistingRequirements(existingContexts.main);
+  const existingStaging = normalizeExistingRequirements(existingContexts.staging);
+  const ciRequirementContext = ciRequirement?.context;
+  const preservedMainContexts = existingMain.contexts
+    .filter((context) => !MANAGED_RELEASE_CONTEXTS.includes(context));
+  const preservedMainChecks = existingMain.checks
+    .filter((check) => !MANAGED_RELEASE_CONTEXTS.includes(check.context));
+  const managedPhaseContexts = phaseConfig.mainContexts
+    .filter((context) => context.startsWith('release/'));
+  if (
+    managedPhaseContexts.length > 0
+    && (!Number.isSafeInteger(releaseAppId) || releaseAppId <= 0 || releaseAppId === 15368)
+  ) {
+    throw new Error('releaseAppId must identify a dedicated GitHub App, never GitHub Actions.');
+  }
+  if (phase === 'steady-state' && ciRequirement && ciRequirement.appId !== releaseAppId) {
+    throw new Error('The required CI check must use the dedicated release GitHub App.');
+  }
+  const plainPhaseContexts = phaseConfig.mainContexts
+    .filter((context) => !context.startsWith('release/'));
+  let mainContexts = [...preservedMainContexts, ...plainPhaseContexts];
+  let mainChecks = [
+    ...preservedMainChecks,
+    ...managedPhaseContexts.map((context) => ({ context, app_id: releaseAppId })),
+  ];
+  if (phase === 'steady-state' && ciRequirementContext) {
+    const resolvedCiContext = ciRequirementContext;
+    mainContexts = mainContexts
+      .filter((context) => context !== resolvedCiContext)
+      .map((context) => context === CI_CONTEXT_PLACEHOLDER ? resolvedCiContext : context);
+    mainChecks = mainChecks.filter((check) => check.context !== resolvedCiContext);
+    mainContexts = mainContexts.filter((context) => context !== resolvedCiContext);
+    mainChecks.push({ context: resolvedCiContext, app_id: ciRequirement.appId });
+  }
+  mainContexts = uniqueContexts(mainContexts);
+  mainChecks = uniqueChecks(mainChecks);
+  const mainCheckContexts = new Set(mainChecks.map(({ context }) => context));
+  mainContexts = mainContexts.filter((context) => !mainCheckContexts.has(context));
+  const stagingChecks = uniqueChecks(existingStaging.checks);
+  const stagingCheckContexts = new Set(stagingChecks.map(({ context }) => context));
+  const stagingContexts = uniqueContexts(existingStaging.contexts)
+    .filter((context) => !stagingCheckContexts.has(context));
+
+  return {
+    mode: 'dry-run-by-default',
+    phase,
+    repository,
+    requestedCiContext: ciContext ?? null,
+    description: phaseConfig.description,
+    preconditions: [...phaseConfig.preconditions],
+    branches: {
+      main: protection({
+        contexts: mainContexts,
+        checks: mainChecks,
+        linearHistory: true,
+        lockBranch: phase === 'bootstrap-lock',
+      }),
+      staging: protection({ contexts: stagingContexts, checks: stagingChecks, linearHistory: false }),
+    },
+  };
+}

--- a/scripts/release/verify-attestations.mjs
+++ b/scripts/release/verify-attestations.mjs
@@ -1,0 +1,712 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const REQUIRED_STATUS_CONTEXTS = Object.freeze([
+  'release/staging-deployed',
+  'release/staging-validated',
+]);
+export const DEFAULT_GITHUB_API_URL = 'https://api.github.com';
+export const STAGING_QA_CURRENT_RUN_CONTEXT = 'staging-push-qa';
+
+const ATTESTATION_RUN_RULES = Object.freeze({
+  'release/staging-deployed': Object.freeze({
+    workflowPath: '.github/workflows/staging-deploy-verify.yml',
+    event: 'push',
+    headBranch: 'staging',
+    displayTitle: (candidateSha) => `Staging deploy ${candidateSha}`,
+    expectedHeadSha: ({ candidateSha }) => candidateSha,
+  }),
+  'release/staging-validated': Object.freeze({
+    workflowPath: '.github/workflows/staging-deploy-verify.yml',
+    event: 'push',
+    headBranch: 'staging',
+    displayTitle: (candidateSha) => `Staging deploy ${candidateSha}`,
+    expectedHeadSha: ({ candidateSha }) => candidateSha,
+  }),
+});
+
+const FULL_GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const REPOSITORY_PATTERN = /^([A-Za-z0-9][A-Za-z0-9_.-]*)\/([A-Za-z0-9][A-Za-z0-9_.-]*)$/;
+const APP_BOT_LOGIN_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,98}[A-Za-z0-9])?\[bot\]$/;
+const VALID_STATUS_STATES = new Set(['error', 'failure', 'pending', 'success']);
+const MAX_COMPARE_COMMITS = 100;
+
+export class AttestationVerificationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'AttestationVerificationError';
+  }
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isFullGitSha(value) {
+  return typeof value === 'string' && FULL_GIT_SHA_PATTERN.test(value);
+}
+
+function assertCandidateSha(candidateSha) {
+  if (!isFullGitSha(candidateSha)) {
+    throw new AttestationVerificationError(
+      'Candidate SHA debe ser un SHA Git completo en minúsculas de 40 caracteres.',
+    );
+  }
+}
+
+function parseActionsRunTarget(targetUrl, repository) {
+  if (typeof targetUrl !== 'string') {
+    throw new AttestationVerificationError(
+      'El commit status requerido no enlaza un Actions run auditable.',
+    );
+  }
+  const match = targetUrl.match(
+    /^https:\/\/github\.com\/([A-Za-z0-9][A-Za-z0-9_.-]*)\/([A-Za-z0-9][A-Za-z0-9_.-]*)\/actions\/runs\/([1-9][0-9]{0,15})$/,
+  );
+  if (!match || `${match[1]}/${match[2]}` !== repository) {
+    throw new AttestationVerificationError(
+      'El target_url del commit status no es un Actions run canónico del repositorio.',
+    );
+  }
+  return match[3];
+}
+
+function validateStatusCreatorLogin(value) {
+  if (
+    typeof value !== 'string'
+    || !APP_BOT_LOGIN_PATTERN.test(value)
+    || value === 'github-actions[bot]'
+  ) {
+    throw new AttestationVerificationError(
+      'RELEASE_STATUS_CREATOR_LOGIN debe identificar el bot de una GitHub App dedicada.',
+    );
+  }
+  return value;
+}
+
+function validateStatusCreator(status, context, expectedCreatorLogin) {
+  const creator = status.creator;
+  if (
+    !isRecord(creator)
+    || creator.login !== expectedCreatorLogin
+    || !Number.isSafeInteger(creator.id)
+    || creator.id <= 0
+    || creator.type !== 'Bot'
+  ) {
+    throw new AttestationVerificationError(
+      `El contexto ${context} no fue emitido por la GitHub App de release dedicada.`,
+    );
+  }
+}
+
+export function validateActionsRunPayload(payload, {
+  repository,
+  candidateSha,
+  mainSha,
+  context,
+  runId,
+  targetUrl,
+  allowCurrentRunInProgress = false,
+} = {}) {
+  assertCandidateSha(candidateSha);
+  const rule = ATTESTATION_RUN_RULES[context];
+  if (!rule || typeof repository !== 'string' || !/^\d+$/.test(runId ?? '')) {
+    throw new AttestationVerificationError('La regla de procedencia del Actions run no es válida.');
+  }
+  const expectedHeadSha = rule.expectedHeadSha({ candidateSha, mainSha });
+  if (!isFullGitSha(expectedHeadSha)) {
+    throw new AttestationVerificationError(
+      `No se puede anclar ${context} a un head SHA confiable.`,
+    );
+  }
+  const hasTerminalSuccess = payload?.status === 'completed' && payload?.conclusion === 'success';
+  const isExpectedCurrentRun = allowCurrentRunInProgress
+    && payload?.status === 'in_progress'
+    && payload?.conclusion === null;
+  if (
+    !isRecord(payload)
+    || String(payload.id) !== runId
+    || payload.html_url !== targetUrl
+    || payload.path !== rule.workflowPath
+    || payload.event !== rule.event
+    || payload.head_branch !== rule.headBranch
+    || payload.head_sha !== expectedHeadSha
+    || payload.display_title !== rule.displayTitle(candidateSha)
+    || (!hasTerminalSuccess && !isExpectedCurrentRun)
+    || !isRecord(payload.repository)
+    || payload.repository.full_name !== repository
+    || !isRecord(payload.head_repository)
+    || payload.head_repository.full_name !== repository
+    || !Number.isSafeInteger(payload.workflow_id)
+    || payload.workflow_id <= 0
+  ) {
+    throw new AttestationVerificationError(
+      `El Actions run enlazado por ${context} no demuestra workflow, ref, SHA y conclusion esperados.`,
+    );
+  }
+  return {
+    context,
+    runId,
+    workflowPath: rule.workflowPath,
+    event: rule.event,
+    headBranch: rule.headBranch,
+    headSha: expectedHeadSha,
+  };
+}
+
+export function validateStagingEnvironmentPayload(payload) {
+  const reviewerRule = Array.isArray(payload?.protection_rules)
+    ? payload.protection_rules.find((rule) => rule?.type === 'required_reviewers')
+    : undefined;
+  const branchPolicy = payload?.deployment_branch_policy;
+  if (
+    !isRecord(payload)
+    || payload.name !== 'Staging'
+    || !isRecord(reviewerRule)
+    || reviewerRule.prevent_self_review !== true
+    || !Array.isArray(reviewerRule.reviewers)
+    || reviewerRule.reviewers.length === 0
+    || reviewerRule.reviewers.some(({ type, reviewer } = {}) =>
+      !['User', 'Team'].includes(type)
+      || !isRecord(reviewer)
+      || !Number.isSafeInteger(reviewer.id)
+      || reviewer.id <= 0)
+    || branchPolicy?.protected_branches !== false
+    || branchPolicy?.custom_branch_policies !== true
+  ) {
+    throw new AttestationVerificationError(
+      'El entorno Staging debe exigir revisores, impedir autoaprobación y usar políticas custom.',
+    );
+  }
+  return {
+    name: 'Staging',
+    preventSelfReview: true,
+    reviewerIds: reviewerRule.reviewers.map(({ reviewer }) => reviewer.id),
+    customBranchPolicies: true,
+  };
+}
+
+export function validateDeploymentBranchPoliciesPayload(payload, expectedBranch, environmentName) {
+  if (
+    !isRecord(payload)
+    || payload.total_count !== 1
+    || !Array.isArray(payload.branch_policies)
+    || payload.branch_policies.length !== 1
+    || !isRecord(payload.branch_policies[0])
+    || payload.branch_policies[0].name !== expectedBranch
+    || payload.branch_policies[0].type !== 'branch'
+  ) {
+    throw new AttestationVerificationError(
+      `El entorno ${environmentName} debe permitir exclusivamente la rama ${expectedBranch}.`,
+    );
+  }
+  return { environmentName, branches: [expectedBranch] };
+}
+
+export function validateCommitStatusPayload(payload, candidateSha, {
+  requiredContexts = REQUIRED_STATUS_CONTEXTS,
+  requireCombinedSuccess = true,
+} = {}) {
+  assertCandidateSha(candidateSha);
+  if (
+    !Array.isArray(requiredContexts)
+    || requiredContexts.length === 0
+    || new Set(requiredContexts).size !== requiredContexts.length
+    || requiredContexts.some((context) => !REQUIRED_STATUS_CONTEXTS.includes(context))
+    || typeof requireCombinedSuccess !== 'boolean'
+  ) {
+    throw new AttestationVerificationError('La configuración de contextos requeridos no es válida.');
+  }
+  if (!isRecord(payload)) {
+    throw new AttestationVerificationError('La respuesta de commit status no es un objeto JSON válido.');
+  }
+  if (!isFullGitSha(payload.sha) || payload.sha !== candidateSha) {
+    throw new AttestationVerificationError(
+      'El SHA del commit status combinado no coincide exactamente con el candidato.',
+    );
+  }
+  if (requireCombinedSuccess && payload.state !== 'success') {
+    throw new AttestationVerificationError('El estado combinado de commit statuses debe ser success.');
+  }
+  if (!requireCombinedSuccess && !VALID_STATUS_STATES.has(payload.state)) {
+    throw new AttestationVerificationError('El estado combinado de commit statuses no es válido.');
+  }
+  if (!Array.isArray(payload.statuses)) {
+    throw new AttestationVerificationError('La API no devolvió un array statuses válido.');
+  }
+  if (
+    !Number.isSafeInteger(payload.total_count)
+    || payload.total_count < 0
+    || payload.total_count !== payload.statuses.length
+    || payload.total_count > 100
+  ) {
+    throw new AttestationVerificationError('total_count de commit statuses no es válido.');
+  }
+
+  for (const status of payload.statuses) {
+    if (
+      !isRecord(status)
+      || typeof status.context !== 'string'
+      || status.context === ''
+      || !VALID_STATUS_STATES.has(status.state)
+    ) {
+      throw new AttestationVerificationError('La API devolvió un commit status con forma inválida.');
+    }
+    if (
+      Object.hasOwn(status, 'sha')
+      && (!isFullGitSha(status.sha) || status.sha !== candidateSha)
+    ) {
+      throw new AttestationVerificationError(
+        `El contexto ${status.context} declara un SHA distinto del candidato.`,
+      );
+    }
+  }
+
+  for (const context of requiredContexts) {
+    const matches = payload.statuses.filter((status) => status.context === context);
+    if (matches.length === 0) {
+      throw new AttestationVerificationError(`Falta el contexto requerido ${context}.`);
+    }
+    if (matches.length > 1) {
+      throw new AttestationVerificationError(`El contexto requerido ${context} está duplicado.`);
+    }
+    if (matches[0].state !== 'success') {
+      throw new AttestationVerificationError(`El contexto ${context} debe estar en success.`);
+    }
+  }
+
+  return {
+    candidateSha,
+    contexts: [...requiredContexts],
+    matchedStatuses: requiredContexts.map((context) =>
+      payload.statuses.find((status) => status.context === context)),
+  };
+}
+
+function assertNonNegativeInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new AttestationVerificationError(`${name} de compare no es un entero válido.`);
+  }
+}
+
+export function validateAncestryPayload(payload, { mainSha, candidateSha } = {}) {
+  assertCandidateSha(candidateSha);
+  if (!isFullGitSha(mainSha)) {
+    throw new AttestationVerificationError('El SHA resuelto de main no es un SHA Git completo.');
+  }
+  if (!isRecord(payload) || !['ahead', 'identical'].includes(payload.status)) {
+    throw new AttestationVerificationError('main no consta como ancestro del candidato.');
+  }
+
+  assertNonNegativeInteger(payload.ahead_by, 'ahead_by');
+  assertNonNegativeInteger(payload.behind_by, 'behind_by');
+  assertNonNegativeInteger(payload.total_commits, 'total_commits');
+  if (
+    payload.behind_by !== 0
+    || !isRecord(payload.base_commit)
+    || payload.base_commit.sha !== mainSha
+    || !isRecord(payload.merge_base_commit)
+    || payload.merge_base_commit.sha !== mainSha
+    || !Array.isArray(payload.commits)
+    || payload.total_commits !== payload.ahead_by
+    || payload.total_commits !== payload.commits.length
+    || payload.total_commits > MAX_COMPARE_COMMITS
+    || payload.commits.some((commit) => !isRecord(commit) || !isFullGitSha(commit.sha))
+  ) {
+    throw new AttestationVerificationError(
+      'La relación main -> staging es inconsistente, diverge o excede el límite verificable.',
+    );
+  }
+
+  if (payload.status === 'identical') {
+    if (mainSha !== candidateSha || payload.ahead_by !== 0 || payload.commits.length !== 0) {
+      throw new AttestationVerificationError('La relación identical de compare es inconsistente.');
+    }
+  } else if (
+    mainSha === candidateSha
+    || payload.ahead_by === 0
+    || payload.commits.at(-1)?.sha !== candidateSha
+  ) {
+    throw new AttestationVerificationError(
+      'La relación ahead no termina exactamente en el Candidate SHA.',
+    );
+  }
+
+  return {
+    mainSha,
+    candidateSha,
+    relation: payload.status,
+    commitsAhead: payload.ahead_by,
+  };
+}
+
+function validateRepository(repository) {
+  if (typeof repository !== 'string') {
+    throw new AttestationVerificationError('GITHUB_REPOSITORY no es válido.');
+  }
+  const match = repository.match(REPOSITORY_PATTERN);
+  if (!match || match[1].includes('..') || match[2].includes('..')) {
+    throw new AttestationVerificationError('GITHUB_REPOSITORY debe tener la forma owner/repo.');
+  }
+  return { owner: match[1], repo: match[2], fullName: repository };
+}
+
+function validateApiBaseUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new AttestationVerificationError('La URL base de GitHub API no es válida.');
+  }
+  if (
+    parsed.protocol !== 'https:'
+    || parsed.username !== ''
+    || parsed.password !== ''
+    || parsed.search !== ''
+    || parsed.hash !== ''
+  ) {
+    throw new AttestationVerificationError('GitHub API debe usar una URL HTTPS sin credenciales.');
+  }
+  return parsed.href.replace(/\/+$/, '');
+}
+
+function contentTypeIsJson(response) {
+  if (typeof response.headers?.get !== 'function') {
+    return false;
+  }
+  const value = response.headers.get('content-type');
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const mediaType = value.split(';', 1)[0].trim().toLowerCase();
+  return mediaType === 'application/json' || mediaType.endsWith('+json');
+}
+
+async function fetchGitHubJson(url, { token, fetchFn }) {
+  let response;
+  try {
+    response = await fetchFn(url, {
+      method: 'GET',
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'x-github-api-version': '2022-11-28',
+      },
+      cache: 'no-store',
+      redirect: 'error',
+    });
+  } catch {
+    throw new AttestationVerificationError('Error de red al consultar GitHub API.');
+  }
+
+  if (!isRecord(response) || response.status !== 200) {
+    const status = isRecord(response) && Number.isInteger(response.status)
+      ? `HTTP ${response.status}`
+      : 'respuesta HTTP inválida';
+    throw new AttestationVerificationError(`GitHub API devolvió ${status}.`);
+  }
+  if (!contentTypeIsJson(response)) {
+    throw new AttestationVerificationError('GitHub API no devolvió content-type JSON.');
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    throw new AttestationVerificationError('GitHub API devolvió JSON inválido.');
+  }
+}
+
+async function verifyRunProvenance({
+  apiUrl,
+  repoPath,
+  repository,
+  candidateSha,
+  mainSha,
+  statuses,
+  token,
+  fetchFn,
+  currentRunId,
+  allowCurrentRunInProgress = false,
+  statusCreatorLogin,
+}) {
+  const runs = [];
+  const payloadsByRunId = new Map();
+  for (const status of statuses) {
+    validateStatusCreator(status, status.context, statusCreatorLogin);
+    const runId = parseActionsRunTarget(status.target_url, repository);
+    if (currentRunId !== undefined && runId !== currentRunId) {
+      throw new AttestationVerificationError(
+        'El status deployed no procede de la ejecución QA actual de staging.',
+      );
+    }
+    const targetUrl = `https://github.com/${repository}/actions/runs/${runId}`;
+    let payload = payloadsByRunId.get(runId);
+    if (!payload) {
+      payload = await fetchGitHubJson(
+        `${apiUrl}${repoPath}/actions/runs/${runId}`,
+        { token, fetchFn },
+      );
+      payloadsByRunId.set(runId, payload);
+    }
+    const mayUseInProgressRun = allowCurrentRunInProgress && runId === currentRunId;
+    runs.push(validateActionsRunPayload(payload, {
+      repository,
+      candidateSha,
+      mainSha,
+      context: status.context,
+      runId,
+      targetUrl,
+      allowCurrentRunInProgress: mayUseInProgressRun,
+    }));
+  }
+  if (statuses.length > 1 && new Set(runs.map(({ runId }) => runId)).size !== 1) {
+    throw new AttestationVerificationError(
+      'Los dos contextos de staging deben proceder de una única ejecución protegida.',
+    );
+  }
+  return runs;
+}
+
+export async function verifyAttestations({
+  repository,
+  candidateSha,
+  token,
+  apiBaseUrl = DEFAULT_GITHUB_API_URL,
+  fetchFn = globalThis.fetch,
+  deployedOnly = false,
+  currentRunId,
+  statusCreatorLogin,
+} = {}) {
+  const parsedRepository = validateRepository(repository);
+  assertCandidateSha(candidateSha);
+  if (typeof token !== 'string' || token.trim() === '' || /[\r\n]/.test(token)) {
+    throw new AttestationVerificationError('GITHUB_TOKEN es obligatorio y debe tener una forma válida.');
+  }
+  if (typeof fetchFn !== 'function') {
+    throw new AttestationVerificationError('La dependencia fetch no es válida.');
+  }
+  const validatedStatusCreatorLogin = validateStatusCreatorLogin(statusCreatorLogin);
+  if (typeof deployedOnly !== 'boolean') {
+    throw new AttestationVerificationError('deployedOnly debe ser booleano.');
+  }
+  if (
+    deployedOnly
+    && (typeof currentRunId !== 'string' || !/^[1-9][0-9]{0,15}$/.test(currentRunId))
+  ) {
+    throw new AttestationVerificationError(
+      'La validación QA interna exige el GITHUB_RUN_ID exacto de la ejecución actual.',
+    );
+  }
+  const apiUrl = validateApiBaseUrl(apiBaseUrl);
+  const repoPath = `/repos/${encodeURIComponent(parsedRepository.owner)}/${encodeURIComponent(parsedRepository.repo)}`;
+  const environmentPayload = await fetchGitHubJson(
+    `${apiUrl}${repoPath}/environments/Staging`,
+    { token, fetchFn },
+  );
+  const environment = validateStagingEnvironmentPayload(environmentPayload);
+  const branchPoliciesPayload = await fetchGitHubJson(
+    `${apiUrl}${repoPath}/environments/Staging/deployment-branch-policies?per_page=100`,
+    { token, fetchFn },
+  );
+  environment.branches = validateDeploymentBranchPoliciesPayload(
+    branchPoliciesPayload,
+    'staging',
+    'Staging',
+  ).branches;
+
+  if (deployedOnly) {
+    const statusPayload = await fetchGitHubJson(
+      `${apiUrl}${repoPath}/commits/${candidateSha}/status?per_page=100`,
+      { token, fetchFn },
+    );
+    const statuses = validateCommitStatusPayload(statusPayload, candidateSha, {
+      requiredContexts: ['release/staging-deployed'],
+      requireCombinedSuccess: false,
+    });
+    const runs = await verifyRunProvenance({
+      apiUrl,
+      repoPath,
+      repository: parsedRepository.fullName,
+      candidateSha,
+      statuses: statuses.matchedStatuses,
+      token,
+      fetchFn,
+      currentRunId,
+      allowCurrentRunInProgress: true,
+      statusCreatorLogin: validatedStatusCreatorLogin,
+    });
+    return {
+      repository: parsedRepository.fullName,
+      candidateSha,
+      contexts: statuses.contexts,
+      runs,
+      environment,
+      mode: 'deployed-only',
+    };
+  }
+
+  const mainPayload = await fetchGitHubJson(
+    `${apiUrl}${repoPath}/commits/main`,
+    { token, fetchFn },
+  );
+  if (!isRecord(mainPayload) || !isFullGitSha(mainPayload.sha)) {
+    throw new AttestationVerificationError('GitHub API no pudo resolver main a un SHA completo.');
+  }
+  const mainSha = mainPayload.sha;
+
+  const statusPayload = await fetchGitHubJson(
+    `${apiUrl}${repoPath}/commits/${candidateSha}/status?per_page=100`,
+    { token, fetchFn },
+  );
+  const statuses = validateCommitStatusPayload(statusPayload, candidateSha);
+
+  const runs = await verifyRunProvenance({
+    apiUrl,
+    repoPath,
+    repository: parsedRepository.fullName,
+    candidateSha,
+    mainSha,
+    statuses: statuses.matchedStatuses,
+    token,
+    fetchFn,
+    statusCreatorLogin: validatedStatusCreatorLogin,
+  });
+
+  const ancestryPayload = await fetchGitHubJson(
+    `${apiUrl}${repoPath}/compare/${mainSha}...${candidateSha}?per_page=${MAX_COMPARE_COMMITS}`,
+    { token, fetchFn },
+  );
+  const ancestry = validateAncestryPayload(ancestryPayload, { mainSha, candidateSha });
+
+  return {
+    repository: parsedRepository.fullName,
+    candidateSha,
+    mainSha,
+    contexts: statuses.contexts,
+    runs,
+    environment,
+    relation: ancestry.relation,
+  };
+}
+
+export function verifyDeployedAttestation(options = {}) {
+  return verifyAttestations({ ...options, deployedOnly: true });
+}
+
+function parseCliArguments(argv) {
+  const values = {};
+  const names = new Map([
+    ['--sha', 'candidateSha'],
+    ['--repository', 'repository'],
+    ['--api-url', 'apiBaseUrl'],
+  ]);
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--help') {
+      values.help = true;
+      continue;
+    }
+    if (argument === '--staging-push-qa-current-run') {
+      if (values.stagingPushQaCurrentRun) {
+        throw new AttestationVerificationError(
+          '--staging-push-qa-current-run no puede repetirse.',
+        );
+      }
+      values.stagingPushQaCurrentRun = true;
+      continue;
+    }
+    const property = names.get(argument);
+    if (!property) {
+      throw new AttestationVerificationError(`Argumento no reconocido: ${argument}.`);
+    }
+    const value = argv[index + 1];
+    if (typeof value !== 'string' || value.startsWith('--')) {
+      throw new AttestationVerificationError(`Falta el valor de ${argument}.`);
+    }
+    values[property] = value;
+    index += 1;
+  }
+  return values;
+}
+
+export async function runVerifyAttestationsCli({
+  argv = process.argv.slice(2),
+  env = process.env,
+  fetchFn = globalThis.fetch,
+  stdout = process.stdout,
+  stderr = process.stderr,
+} = {}) {
+  try {
+    const args = parseCliArguments(argv);
+    if (args.help) {
+      stdout.write(
+        'Uso: verify-attestations.mjs --sha <40-hex> --repository <owner/repo> [--staging-push-qa-current-run]\n',
+      );
+      return 0;
+    }
+    if (
+      args.stagingPushQaCurrentRun
+      && env.RELEASE_ATTESTATION_CONTEXT !== STAGING_QA_CURRENT_RUN_CONTEXT
+    ) {
+      throw new AttestationVerificationError(
+        `RELEASE_ATTESTATION_CONTEXT debe ser exactamente ${STAGING_QA_CURRENT_RUN_CONTEXT} para usar --staging-push-qa-current-run.`,
+      );
+    }
+
+    const repository = args.repository ?? env.GITHUB_REPOSITORY;
+    const candidateSha = args.candidateSha
+      ?? env.RELEASE_CANDIDATE_SHA
+      ?? env.CANDIDATE_SHA
+      ?? env.GITHUB_HEAD_SHA;
+    if (args.stagingPushQaCurrentRun) {
+      const expectedWorkflowRef = `${repository}/.github/workflows/staging-deploy-verify.yml@refs/heads/staging`;
+      if (
+        env.GITHUB_REF !== 'refs/heads/staging'
+        || env.GITHUB_SHA !== candidateSha
+        || env.GITHUB_WORKFLOW_REF !== expectedWorkflowRef
+      ) {
+        throw new AttestationVerificationError(
+          'La validación QA interna solo puede ejecutarse desde el workflow protegido de staging.',
+        );
+      }
+    }
+
+    const result = await verifyAttestations({
+      repository,
+      candidateSha,
+      token: env.GITHUB_TOKEN,
+      apiBaseUrl: args.apiBaseUrl ?? env.GITHUB_API_URL ?? DEFAULT_GITHUB_API_URL,
+      fetchFn,
+      deployedOnly: args.stagingPushQaCurrentRun === true,
+      currentRunId: args.stagingPushQaCurrentRun ? env.GITHUB_RUN_ID : undefined,
+      statusCreatorLogin: env.RELEASE_STATUS_CREATOR_LOGIN,
+    });
+
+    if (result.mode === 'deployed-only') {
+      stdout.write(
+        `Attestation release/staging-deployed validada para ${result.candidateSha}.\n`,
+      );
+    } else {
+      stdout.write(
+        `Attestations validadas para ${result.candidateSha}; main es ancestro (${result.relation}).\n`,
+      );
+    }
+    return 0;
+  } catch (error) {
+    const message = error instanceof AttestationVerificationError
+      ? error.message
+      : 'Error interno durante la verificación.';
+    stderr.write(`Attestations DENEGADAS: ${message}\n`);
+    return 1;
+  }
+}
+
+const isDirectInvocation = process.argv[1]
+  && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (isDirectInvocation) {
+  process.exitCode = await runVerifyAttestationsCli();
+}

--- a/scripts/release/verify-attestations.test.mjs
+++ b/scripts/release/verify-attestations.test.mjs
@@ -1,0 +1,605 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  AttestationVerificationError,
+  REQUIRED_STATUS_CONTEXTS,
+  runVerifyAttestationsCli,
+  validateActionsRunPayload,
+  validateAncestryPayload,
+  validateCommitStatusPayload,
+  validateDeploymentBranchPoliciesPayload,
+  validateStagingEnvironmentPayload,
+  verifyAttestations,
+} from './verify-attestations.mjs';
+
+const REPOSITORY = 'fgomezserna/cukies-hub';
+const CANDIDATE_SHA = '0123456789abcdef0123456789abcdef01234567';
+const OTHER_SHA = '89abcdef0123456789abcdef0123456789abcdef';
+const MAIN_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const INTERMEDIATE_SHA = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const RUN_ID = '123456789';
+const OTHER_RUN_ID = '987654321';
+const RELEASE_STATUS_CREATOR_LOGIN = 'cukies-release-guard[bot]';
+const RELEASE_APP_CREATOR = Object.freeze({
+  login: RELEASE_STATUS_CREATOR_LOGIN,
+  id: 9001,
+  type: 'Bot',
+});
+
+function runUrl(runId = RUN_ID) {
+  return `https://github.com/${REPOSITORY}/actions/runs/${runId}`;
+}
+
+function releaseStatus(context, {
+  sha = CANDIDATE_SHA,
+  state = 'success',
+  runId = RUN_ID,
+  creator = RELEASE_APP_CREATOR,
+} = {}) {
+  return {
+    context,
+    state,
+    sha,
+    target_url: runUrl(runId),
+    creator,
+  };
+}
+
+function validStatuses(overrides = {}) {
+  return {
+    state: 'success',
+    sha: CANDIDATE_SHA,
+    total_count: 2,
+    statuses: REQUIRED_STATUS_CONTEXTS.map((context) => releaseStatus(context)),
+    ...overrides,
+  };
+}
+
+function deployedStatusPayload(overrides = {}) {
+  return validStatuses({
+    state: 'pending',
+    total_count: 1,
+    statuses: [releaseStatus('release/staging-deployed')],
+    ...overrides,
+  });
+}
+
+function validEnvironment(overrides = {}) {
+  return {
+    name: 'Staging',
+    protection_rules: [{
+      id: 1,
+      type: 'required_reviewers',
+      prevent_self_review: true,
+      reviewers: [{ type: 'User', reviewer: { id: 219637213, login: 'JairoGG-ai' } }],
+    }],
+    deployment_branch_policy: {
+      protected_branches: false,
+      custom_branch_policies: true,
+    },
+    ...overrides,
+  };
+}
+
+function validBranchPolicies(branch = 'staging') {
+  return {
+    total_count: 1,
+    branch_policies: [{ id: 7, name: branch, type: 'branch' }],
+  };
+}
+
+function validAncestry(overrides = {}) {
+  return {
+    status: 'ahead',
+    ahead_by: 2,
+    behind_by: 0,
+    total_commits: 2,
+    base_commit: { sha: MAIN_SHA },
+    merge_base_commit: { sha: MAIN_SHA },
+    commits: [{ sha: INTERMEDIATE_SHA }, { sha: CANDIDATE_SHA }],
+    ...overrides,
+  };
+}
+
+function validRun(overrides = {}) {
+  return {
+    id: Number(RUN_ID),
+    html_url: runUrl(),
+    path: '.github/workflows/staging-deploy-verify.yml',
+    event: 'push',
+    head_branch: 'staging',
+    head_sha: CANDIDATE_SHA,
+    display_title: `Staging deploy ${CANDIDATE_SHA}`,
+    status: 'completed',
+    conclusion: 'success',
+    repository: { full_name: REPOSITORY },
+    head_repository: { full_name: REPOSITORY },
+    workflow_id: 42,
+    ...overrides,
+  };
+}
+
+function jsonResponse(payload, status = 200) {
+  return {
+    status,
+    headers: { get: (name) => name.toLowerCase() === 'content-type' ? 'application/json' : null },
+    json: async () => payload,
+  };
+}
+
+function sequenceFetch(payloads, requests = []) {
+  const responses = [...payloads];
+  return async (url, options) => {
+    requests.push({ url, options });
+    const response = responses.shift();
+    assert.ok(response, `respuesta simulada ausente para ${url}`);
+    return response;
+  };
+}
+
+test('acepta los dos contextos release en success sobre el candidate SHA', () => {
+  const result = validateCommitStatusPayload(validStatuses(), CANDIDATE_SHA);
+  assert.equal(result.candidateSha, CANDIDATE_SHA);
+  assert.deepEqual(result.contexts, [...REQUIRED_STATUS_CONTEXTS]);
+  assert.deepEqual(result.matchedStatuses.map(({ context }) => context), [...REQUIRED_STATUS_CONTEXTS]);
+});
+
+test('acepta status items sin sha propio cuando el payload combinado está anclado al candidato', () => {
+  const payload = validStatuses();
+  payload.statuses = payload.statuses.map(({ sha: _sha, ...status }) => status);
+  assert.equal(validateCommitStatusPayload(payload, CANDIDATE_SHA).candidateSha, CANDIDATE_SHA);
+});
+
+test('rechaza SHA ajeno, contextos ausentes, duplicados, incompletos o no exitosos', () => {
+  assert.throws(
+    () => validateCommitStatusPayload(validStatuses({ sha: OTHER_SHA }), CANDIDATE_SHA),
+    /SHA.*candidato/i,
+  );
+  const wrongItemSha = validStatuses();
+  wrongItemSha.statuses[0] = releaseStatus('release/staging-deployed', { sha: OTHER_SHA });
+  assert.throws(() => validateCommitStatusPayload(wrongItemSha, CANDIDATE_SHA), /SHA.*distinto/i);
+
+  for (const context of REQUIRED_STATUS_CONTEXTS) {
+    const payload = validStatuses();
+    payload.statuses = payload.statuses.filter((status) => status.context !== context);
+    payload.total_count = payload.statuses.length;
+    assert.throws(
+      () => validateCommitStatusPayload(payload, CANDIDATE_SHA),
+      new RegExp(context.replace('/', '\\/')),
+    );
+  }
+
+  for (const state of ['error', 'failure', 'pending']) {
+    const payload = validStatuses({ state });
+    payload.statuses[1] = releaseStatus('release/staging-validated', { state });
+    assert.throws(() => validateCommitStatusPayload(payload, CANDIDATE_SHA), /success/i);
+  }
+
+  const duplicate = validStatuses();
+  duplicate.statuses.push(releaseStatus('release/staging-deployed'));
+  duplicate.total_count = 3;
+  assert.throws(() => validateCommitStatusPayload(duplicate, CANDIDATE_SHA), /duplicado/i);
+  assert.throws(
+    () => validateCommitStatusPayload(validStatuses({ total_count: 3 }), CANDIDATE_SHA),
+    /total_count/i,
+  );
+});
+
+test('rechaza formas inválidas de la API de commit statuses', () => {
+  const malformedPayloads = [
+    null,
+    [],
+    validStatuses({ sha: CANDIDATE_SHA.slice(0, 12) }),
+    validStatuses({ total_count: '2' }),
+    validStatuses({ statuses: null }),
+    validStatuses({ statuses: [{ context: '', state: 'success' }], total_count: 1 }),
+    validStatuses({
+      statuses: [{ context: 'release/staging-deployed', state: 'unknown' }],
+      total_count: 1,
+    }),
+  ];
+  for (const payload of malformedPayloads) {
+    assert.throws(
+      () => validateCommitStatusPayload(payload, CANDIDATE_SHA),
+      AttestationVerificationError,
+    );
+  }
+});
+
+test('valida el entorno Staging protegido y falla cerrado ante cualquier relajación', () => {
+  assert.deepEqual(validateStagingEnvironmentPayload(validEnvironment()), {
+    name: 'Staging',
+    preventSelfReview: true,
+    reviewerIds: [219637213],
+    customBranchPolicies: true,
+  });
+  for (const payload of [
+    validEnvironment({ name: 'staging' }),
+    validEnvironment({ protection_rules: [] }),
+    validEnvironment({ protection_rules: [{
+      type: 'required_reviewers',
+      prevent_self_review: false,
+      reviewers: [{ type: 'User', reviewer: { id: 1 } }],
+    }] }),
+    validEnvironment({ deployment_branch_policy: null }),
+  ]) {
+    assert.throws(() => validateStagingEnvironmentPayload(payload), /entorno Staging/i);
+  }
+  assert.deepEqual(
+    validateDeploymentBranchPoliciesPayload(validBranchPolicies(), 'staging', 'Staging'),
+    { environmentName: 'Staging', branches: ['staging'] },
+  );
+  for (const payload of [
+    { total_count: 0, branch_policies: [] },
+    validBranchPolicies('main'),
+    { total_count: 1, branch_policies: [{ name: 'staging', type: 'tag' }] },
+  ]) {
+    assert.throws(
+      () => validateDeploymentBranchPoliciesPayload(payload, 'staging', 'Staging'),
+      /exclusivamente.*staging/i,
+    );
+  }
+});
+
+test('valida procedencia exacta de una ejecución terminal de staging', () => {
+  assert.equal(validateActionsRunPayload(validRun(), {
+    repository: REPOSITORY,
+    candidateSha: CANDIDATE_SHA,
+    context: 'release/staging-deployed',
+    runId: RUN_ID,
+    targetUrl: runUrl(),
+  }).headSha, CANDIDATE_SHA);
+  for (const payload of [
+    validRun({ head_branch: 'feature/forge-status' }),
+    validRun({ path: '.github/workflows/forged.yml' }),
+    validRun({ head_sha: OTHER_SHA }),
+    validRun({ conclusion: 'failure' }),
+  ]) {
+    assert.throws(() => validateActionsRunPayload(payload, {
+      repository: REPOSITORY,
+      candidateSha: CANDIDATE_SHA,
+      context: 'release/staging-deployed',
+      runId: RUN_ID,
+      targetUrl: runUrl(),
+    }), /Actions run/i);
+  }
+});
+
+test('confirma que main es ancestro exacto de staging', () => {
+  assert.deepEqual(validateAncestryPayload(validAncestry(), {
+    mainSha: MAIN_SHA,
+    candidateSha: CANDIDATE_SHA,
+  }), {
+    mainSha: MAIN_SHA,
+    candidateSha: CANDIDATE_SHA,
+    relation: 'ahead',
+    commitsAhead: 2,
+  });
+
+  for (const override of [
+    { status: 'behind', ahead_by: 0, behind_by: 2, total_commits: 0, commits: [] },
+    { status: 'diverged', behind_by: 1 },
+    { merge_base_commit: { sha: OTHER_SHA } },
+    { commits: [{ sha: INTERMEDIATE_SHA }, { sha: OTHER_SHA }] },
+    { total_commits: 3 },
+  ]) {
+    assert.throws(() => validateAncestryPayload(validAncestry(override), {
+      mainSha: MAIN_SHA,
+      candidateSha: CANDIDATE_SHA,
+    }), AttestationVerificationError);
+  }
+});
+
+test('verifyAttestations exige environment, statuses y una ejecución confiable', async () => {
+  const requests = [];
+  const result = await verifyAttestations({
+    repository: REPOSITORY,
+    candidateSha: CANDIDATE_SHA,
+    token: 'test-token',
+    statusCreatorLogin: RELEASE_STATUS_CREATOR_LOGIN,
+    fetchFn: sequenceFetch([
+      jsonResponse(validEnvironment()),
+      jsonResponse(validBranchPolicies()),
+      jsonResponse({ sha: MAIN_SHA }),
+      jsonResponse(validStatuses()),
+      jsonResponse(validRun()),
+      jsonResponse(validAncestry()),
+    ], requests),
+  });
+
+  assert.equal(result.repository, REPOSITORY);
+  assert.equal(result.mainSha, MAIN_SHA);
+  assert.equal(result.relation, 'ahead');
+  assert.deepEqual(result.contexts, [...REQUIRED_STATUS_CONTEXTS]);
+  assert.equal(result.runs.length, 2);
+  assert.equal(new Set(result.runs.map(({ runId }) => runId)).size, 1);
+  assert.equal(requests.length, 6, 'la misma Actions run se consulta una sola vez');
+  assert.match(requests[0].url, /\/environments\/Staging$/);
+  assert.match(requests[1].url, /deployment-branch-policies\?per_page=100$/);
+  assert.match(requests[2].url, /\/commits\/main$/);
+  assert.match(requests[3].url, new RegExp(`/commits/${CANDIDATE_SHA}/status\\?per_page=100$`));
+  assert.match(requests[4].url, new RegExp(`/actions/runs/${RUN_ID}$`));
+  assert.match(requests[5].url, new RegExp(`/compare/${MAIN_SHA}\\.\\.\\.${CANDIDATE_SHA}\\?per_page=100$`));
+});
+
+test('rechaza status no emitido por la GitHub App dedicada y ejecución de otra rama', async () => {
+  const forgedCreator = validStatuses();
+  forgedCreator.statuses[0] = releaseStatus('release/staging-deployed', {
+    creator: { login: 'attacker', id: 99, type: 'User' },
+  });
+  await assert.rejects(verifyAttestations({
+    repository: REPOSITORY,
+    candidateSha: CANDIDATE_SHA,
+    token: 'test-token',
+    statusCreatorLogin: RELEASE_STATUS_CREATOR_LOGIN,
+    fetchFn: sequenceFetch([
+      jsonResponse(validEnvironment()),
+      jsonResponse(validBranchPolicies()),
+      jsonResponse({ sha: MAIN_SHA }),
+      jsonResponse(forgedCreator),
+    ]),
+  }), /GitHub App de release dedicada/i);
+
+  await assert.rejects(verifyAttestations({
+    repository: REPOSITORY,
+    candidateSha: CANDIDATE_SHA,
+    token: 'test-token',
+    statusCreatorLogin: RELEASE_STATUS_CREATOR_LOGIN,
+    fetchFn: sequenceFetch([
+      jsonResponse(validEnvironment()),
+      jsonResponse(validBranchPolicies()),
+      jsonResponse({ sha: MAIN_SHA }),
+      jsonResponse(validStatuses()),
+      jsonResponse(validRun({ head_branch: 'feature/forge-status' })),
+    ]),
+  }), /workflow, ref, SHA/i);
+});
+
+test('rechaza que deployed y validated procedan de ejecuciones distintas', async () => {
+  const statuses = validStatuses();
+  statuses.statuses[1] = releaseStatus('release/staging-validated', { runId: OTHER_RUN_ID });
+  await assert.rejects(verifyAttestations({
+    repository: REPOSITORY,
+    candidateSha: CANDIDATE_SHA,
+    token: 'test-token',
+    statusCreatorLogin: RELEASE_STATUS_CREATOR_LOGIN,
+    fetchFn: sequenceFetch([
+      jsonResponse(validEnvironment()),
+      jsonResponse(validBranchPolicies()),
+      jsonResponse({ sha: MAIN_SHA }),
+      jsonResponse(statuses),
+      jsonResponse(validRun()),
+      jsonResponse(validRun({ id: Number(OTHER_RUN_ID), html_url: runUrl(OTHER_RUN_ID) })),
+    ]),
+  }), /única ejecución protegida/i);
+});
+
+test('QA interna acepta deployed de la ejecución actual aún en progreso y omite main/compare', async () => {
+  const requests = [];
+  const result = await verifyAttestations({
+    repository: REPOSITORY,
+    candidateSha: CANDIDATE_SHA,
+    token: 'test-token',
+    statusCreatorLogin: RELEASE_STATUS_CREATOR_LOGIN,
+    deployedOnly: true,
+    currentRunId: RUN_ID,
+    fetchFn: sequenceFetch([
+      jsonResponse(validEnvironment()),
+      jsonResponse(validBranchPolicies()),
+      jsonResponse(deployedStatusPayload()),
+      jsonResponse(validRun({ status: 'in_progress', conclusion: null })),
+    ], requests),
+  });
+  assert.equal(result.mode, 'deployed-only');
+  assert.deepEqual(result.contexts, ['release/staging-deployed']);
+  assert.equal(requests.length, 4);
+  assert.equal(requests.some(({ url }) => url.includes('/commits/main')), false);
+  assert.equal(requests.some(({ url }) => url.includes('/compare/')), false);
+});
+
+test('QA interna exige run actual exacta, staging-deployed y SHA candidato', async () => {
+  await assert.rejects(verifyAttestations({
+    repository: REPOSITORY,
+    candidateSha: CANDIDATE_SHA,
+    token: 'test-token',
+    statusCreatorLogin: RELEASE_STATUS_CREATOR_LOGIN,
+    deployedOnly: true,
+    currentRunId: OTHER_RUN_ID,
+    fetchFn: sequenceFetch([
+      jsonResponse(validEnvironment()),
+      jsonResponse(validBranchPolicies()),
+      jsonResponse(deployedStatusPayload()),
+    ]),
+  }), /ejecución QA actual/i);
+
+  const validatedOnly = deployedStatusPayload({
+    statuses: [releaseStatus('release/staging-validated')],
+  });
+  await assert.rejects(verifyAttestations({
+    repository: REPOSITORY,
+    candidateSha: CANDIDATE_SHA,
+    token: 'test-token',
+    statusCreatorLogin: RELEASE_STATUS_CREATOR_LOGIN,
+    deployedOnly: true,
+    currentRunId: RUN_ID,
+    fetchFn: sequenceFetch([
+      jsonResponse(validEnvironment()),
+      jsonResponse(validBranchPolicies()),
+      jsonResponse(validatedOnly),
+    ]),
+  }), /release\/staging-deployed/);
+
+  await assert.rejects(verifyAttestations({
+    repository: REPOSITORY,
+    candidateSha: CANDIDATE_SHA,
+    token: 'test-token',
+    statusCreatorLogin: RELEASE_STATUS_CREATOR_LOGIN,
+    deployedOnly: true,
+    currentRunId: RUN_ID,
+    fetchFn: sequenceFetch([
+      jsonResponse(validEnvironment()),
+      jsonResponse(validBranchPolicies()),
+      jsonResponse(deployedStatusPayload({ sha: OTHER_SHA })),
+    ]),
+  }), /SHA.*candidato/i);
+});
+
+test('falla cerrado ante red, HTTP o entradas inválidas sin filtrar secretos', async () => {
+  await assert.rejects(verifyAttestations({
+    repository: REPOSITORY,
+    candidateSha: CANDIDATE_SHA,
+    token: 'test-token',
+    statusCreatorLogin: RELEASE_STATUS_CREATOR_LOGIN,
+    fetchFn: async () => { throw new Error('network token=SECRET_VALUE'); },
+  }), (error) => {
+    assert.match(error.message, /red.*GitHub/i);
+    assert.doesNotMatch(error.message, /SECRET_VALUE/);
+    return true;
+  });
+
+  for (const response of [
+    jsonResponse({}, 403),
+    { ...jsonResponse({}), json: async () => { throw new SyntaxError('SECRET_VALUE'); } },
+  ]) {
+    await assert.rejects(verifyAttestations({
+      repository: REPOSITORY,
+      candidateSha: CANDIDATE_SHA,
+      token: 'test-token',
+      statusCreatorLogin: RELEASE_STATUS_CREATOR_LOGIN,
+      fetchFn: async () => response,
+    }), (error) => {
+      assert.doesNotMatch(error.message, /SECRET_VALUE/);
+      return true;
+    });
+  }
+
+  const neverFetch = async () => assert.fail('fetch no debe ejecutarse');
+  for (const options of [
+    { repository: 'invalid', candidateSha: CANDIDATE_SHA, token: 'x' },
+    { repository: 'owner/repo', candidateSha: CANDIDATE_SHA.slice(0, 12), token: 'x' },
+    { repository: 'owner/repo', candidateSha: CANDIDATE_SHA, token: '' },
+    { repository: 'owner/repo', candidateSha: CANDIDATE_SHA, token: 'x', apiBaseUrl: 'http://api.github.com' },
+    { repository: 'owner/repo', candidateSha: CANDIDATE_SHA, token: 'x', deployedOnly: true },
+  ]) {
+    await assert.rejects(
+      verifyAttestations({ ...options, fetchFn: neverFetch }),
+      AttestationVerificationError,
+    );
+  }
+});
+
+test('CLI normal valida y solo imprime un resumen sin token ni payloads', async () => {
+  const output = [];
+  const errors = [];
+  const exitCode = await runVerifyAttestationsCli({
+    argv: ['--sha', CANDIDATE_SHA, '--repository', REPOSITORY],
+    env: {
+      GITHUB_TOKEN: 'DO_NOT_PRINT',
+      RELEASE_STATUS_CREATOR_LOGIN,
+    },
+    fetchFn: sequenceFetch([
+      jsonResponse(validEnvironment({ secret: 'DO_NOT_PRINT' })),
+      jsonResponse(validBranchPolicies()),
+      jsonResponse({ sha: MAIN_SHA, secret: 'DO_NOT_PRINT' }),
+      jsonResponse(validStatuses({ secret: 'DO_NOT_PRINT' })),
+      jsonResponse(validRun({ secret: 'DO_NOT_PRINT' })),
+      jsonResponse(validAncestry({ secret: 'DO_NOT_PRINT' })),
+    ]),
+    stdout: { write: (value) => output.push(value) },
+    stderr: { write: (value) => errors.push(value) },
+  });
+  assert.equal(exitCode, 0);
+  assert.match(output.join(''), /attestations.*validadas/i);
+  assert.doesNotMatch(output.join(''), /DO_NOT_PRINT/);
+  assert.equal(errors.length, 0);
+});
+
+test('CLI QA de staging valida solo desde el workflow/ref/run exactos', async () => {
+  const output = [];
+  const env = {
+    GITHUB_TOKEN: 'test-token',
+    RELEASE_STATUS_CREATOR_LOGIN,
+    GITHUB_REF: 'refs/heads/staging',
+    GITHUB_SHA: CANDIDATE_SHA,
+    GITHUB_RUN_ID: RUN_ID,
+    GITHUB_WORKFLOW_REF: `${REPOSITORY}/.github/workflows/staging-deploy-verify.yml@refs/heads/staging`,
+    RELEASE_ATTESTATION_CONTEXT: 'staging-push-qa',
+  };
+  const exitCode = await runVerifyAttestationsCli({
+    argv: [
+      '--sha', CANDIDATE_SHA,
+      '--repository', REPOSITORY,
+      '--staging-push-qa-current-run',
+    ],
+    env,
+    fetchFn: sequenceFetch([
+      jsonResponse(validEnvironment()),
+      jsonResponse(validBranchPolicies()),
+      jsonResponse(deployedStatusPayload()),
+      jsonResponse(validRun({ status: 'in_progress', conclusion: null })),
+    ]),
+    stdout: { write: (value) => output.push(value) },
+    stderr: { write: () => assert.fail('no debe escribir error') },
+  });
+  assert.equal(exitCode, 0);
+  assert.match(output.join(''), /staging-deployed.*validada/i);
+});
+
+test('CLI QA falla antes de fetch si guard, ref, SHA, workflow o run no son exactos', async () => {
+  const baseEnv = {
+    GITHUB_TOKEN: 'test-token',
+    RELEASE_STATUS_CREATOR_LOGIN,
+    GITHUB_REF: 'refs/heads/staging',
+    GITHUB_SHA: CANDIDATE_SHA,
+    GITHUB_RUN_ID: RUN_ID,
+    GITHUB_WORKFLOW_REF: `${REPOSITORY}/.github/workflows/staging-deploy-verify.yml@refs/heads/staging`,
+    RELEASE_ATTESTATION_CONTEXT: 'staging-push-qa',
+  };
+  const cases = [
+    { RELEASE_ATTESTATION_CONTEXT: 'staging-qa-attest' },
+    { GITHUB_REF: 'refs/heads/feature/forged' },
+    { GITHUB_SHA: OTHER_SHA },
+    { GITHUB_WORKFLOW_REF: `${REPOSITORY}/.github/workflows/forged.yml@refs/heads/staging` },
+    { GITHUB_RUN_ID: 'invalid' },
+  ];
+  for (const override of cases) {
+    let requests = 0;
+    const errors = [];
+    const exitCode = await runVerifyAttestationsCli({
+      argv: [
+        '--sha', CANDIDATE_SHA,
+        '--repository', REPOSITORY,
+        '--staging-push-qa-current-run',
+      ],
+      env: { ...baseEnv, ...override },
+      fetchFn: async () => {
+        requests += 1;
+        return jsonResponse(validEnvironment());
+      },
+      stdout: { write: () => assert.fail('no debe escribir éxito') },
+      stderr: { write: (value) => errors.push(value) },
+    });
+    assert.equal(exitCode, 1);
+    assert.equal(requests, 0);
+    assert.match(errors.join(''), /DENEGADAS/);
+  }
+});
+
+test('CLI rechaza el antiguo --deployed-only antes de fetch', async () => {
+  let requests = 0;
+  const errors = [];
+  const exitCode = await runVerifyAttestationsCli({
+    argv: ['--sha', CANDIDATE_SHA, '--repository', REPOSITORY, '--deployed-only'],
+    env: { GITHUB_TOKEN: 'test-token', RELEASE_STATUS_CREATOR_LOGIN },
+    fetchFn: async () => {
+      requests += 1;
+      return jsonResponse(validEnvironment());
+    },
+    stdout: { write: () => assert.fail('no debe escribir éxito') },
+    stderr: { write: (value) => errors.push(value) },
+  });
+  assert.equal(exitCode, 1);
+  assert.equal(requests, 0);
+  assert.match(errors.join(''), /argumento no reconocido.*--deployed-only/i);
+});

--- a/scripts/release/verify-deployment.mjs
+++ b/scripts/release/verify-deployment.mjs
@@ -1,0 +1,431 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const EXPECTED_STAGING_HOST = 'cukieshub.eurekand.com';
+export const EXPECTED_STAGING_HOSTS = Object.freeze([
+  'cukies-hub.eurekand.com',
+  EXPECTED_STAGING_HOST,
+]);
+export const EXPECTED_STAGING_RESOURCE_UUID = 'u4s804o4wwcckowgk0woo4wg';
+export const DEFAULT_STAGING_HEALTH_URL = `https://${EXPECTED_STAGING_HOST}/api/health`;
+export const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+export const DEFAULT_POLL_INTERVAL_MS = 5 * 1000;
+export const DEFAULT_REQUEST_TIMEOUT_MS = 15 * 1000;
+
+const FULL_GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const MAX_TIMER_MS = 2_147_483_647;
+
+export class DeploymentVerificationError extends Error {
+  constructor(message, { issues } = {}) {
+    super(message);
+    this.name = 'DeploymentVerificationError';
+    if (issues) {
+      this.issues = issues;
+    }
+  }
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isFullGitSha(value) {
+  return typeof value === 'string' && FULL_GIT_SHA_PATTERN.test(value);
+}
+
+export function normalizeGitRef(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.startsWith('refs/heads/')) {
+    return trimmed.slice('refs/heads/'.length);
+  }
+  if (trimmed.startsWith('origin/')) {
+    return trimmed.slice('origin/'.length);
+  }
+  return trimmed;
+}
+
+export function normalizeHost(value) {
+  for (const host of EXPECTED_STAGING_HOSTS) {
+    if (
+      value === host
+      || value === `https://${host}`
+      || value === `https://${host}/`
+    ) {
+      return host;
+    }
+  }
+  return null;
+}
+
+function normalizeHostList(value) {
+  if (typeof value !== 'string' || value === '' || /[\r\n]/.test(value)) {
+    return null;
+  }
+  const values = value.split(',');
+  if (values.some((entry) => entry === '')) {
+    return null;
+  }
+  const hosts = values.map(normalizeHost);
+  if (hosts.some((host) => host === null) || new Set(hosts).size !== hosts.length) {
+    return null;
+  }
+  return hosts;
+}
+
+function normalizeEnvironment(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : null;
+}
+
+export function validateDeploymentPayload(payload, candidateSha) {
+  if (!isFullGitSha(candidateSha)) {
+    throw new DeploymentVerificationError(
+      'Candidate SHA debe ser un SHA Git completo en minúsculas de 40 caracteres.',
+    );
+  }
+  if (!isRecord(payload)) {
+    throw new DeploymentVerificationError('El health check debe devolver un objeto JSON.');
+  }
+
+  const issues = [];
+  const environment = normalizeEnvironment(payload.environment);
+  const gitRef = normalizeGitRef(payload.gitRef);
+  const coolify = isRecord(payload.coolify) ? payload.coolify : null;
+
+  if (payload.status !== 'ok') {
+    issues.push('status debe ser exactamente ok');
+  }
+  if (payload.app !== 'cukies-hub') {
+    issues.push('app debe ser exactamente cukies-hub');
+  }
+  if (environment !== 'staging') {
+    issues.push('environment normalizado debe ser staging');
+  }
+  if (!isFullGitSha(payload.gitSha) || payload.gitSha !== candidateSha) {
+    issues.push('gitSha debe ser el Candidate SHA completo y exacto');
+  }
+  if (gitRef !== 'staging') {
+    issues.push('gitRef normalizado debe ser staging');
+  }
+  if (!coolify) {
+    issues.push('coolify debe ser un objeto JSON');
+  }
+  if (coolify?.resourceUuid !== EXPECTED_STAGING_RESOURCE_UUID) {
+    issues.push('coolify.resourceUuid no corresponde al recurso de staging');
+  }
+
+  const hostFields = coolify
+    ? ['fqdn', 'host'].filter((field) => Object.hasOwn(coolify, field))
+    : [];
+  if (hostFields.length === 0) {
+    issues.push('debe existir fqdn o host de staging');
+  }
+
+  const validatedHosts = [];
+  for (const field of hostFields) {
+    const normalized = normalizeHostList(coolify[field]);
+    if (!normalized) {
+      issues.push(`coolify.${field} no corresponde al host de staging`);
+    } else {
+      validatedHosts.push(...normalized);
+    }
+  }
+  if (!validatedHosts.includes(EXPECTED_STAGING_HOST)) {
+    issues.push('los hosts de Coolify no incluyen el dominio público canónico de staging');
+  }
+
+  if (issues.length > 0) {
+    throw new DeploymentVerificationError(
+      `Contrato de deployment inválido: ${issues.join('; ')}.`,
+      { issues },
+    );
+  }
+
+  return {
+    status: 'ok',
+    app: 'cukies-hub',
+    environment: 'staging',
+    gitSha: payload.gitSha,
+    gitRef: 'staging',
+    resourceUuid: EXPECTED_STAGING_RESOURCE_UUID,
+    host: EXPECTED_STAGING_HOST,
+    hosts: [...new Set(validatedHosts)],
+  };
+}
+
+function assertPositiveInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0 || value > MAX_TIMER_MS) {
+    throw new DeploymentVerificationError(
+      `${name} debe ser un entero positivo menor o igual a ${MAX_TIMER_MS}.`,
+    );
+  }
+}
+
+function validateEndpoint(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new DeploymentVerificationError('La URL del health check no es válida.');
+  }
+
+  if (
+    parsed.protocol !== 'https:'
+    || parsed.hostname.toLowerCase() !== EXPECTED_STAGING_HOST
+    || parsed.username !== ''
+    || parsed.password !== ''
+    || parsed.port !== ''
+    || parsed.pathname !== '/api/health'
+    || parsed.search !== ''
+    || parsed.hash !== ''
+  ) {
+    throw new DeploymentVerificationError(
+      'La URL debe ser el endpoint HTTPS exacto /api/health del host de staging.',
+    );
+  }
+  return parsed.href;
+}
+
+function contentTypeIsJson(contentType) {
+  if (typeof contentType !== 'string') {
+    return false;
+  }
+  const mediaType = contentType.split(';', 1)[0].trim().toLowerCase();
+  return mediaType === 'application/json' || mediaType.endsWith('+json');
+}
+
+async function performAttempt({ url, candidateSha, requestTimeoutMs, fetchFn }) {
+  let response;
+  try {
+    response = await fetchFn(url, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      cache: 'no-store',
+      redirect: 'error',
+      signal: AbortSignal.timeout(requestTimeoutMs),
+    });
+  } catch {
+    return { ok: false, reason: 'error de red al consultar el health check' };
+  }
+
+  if (!isRecord(response) || response.status !== 200) {
+    const status = isRecord(response) && Number.isInteger(response.status)
+      ? `HTTP ${response.status}`
+      : 'respuesta HTTP inválida';
+    return { ok: false, reason: status };
+  }
+
+  const contentType = typeof response.headers?.get === 'function'
+    ? response.headers.get('content-type')
+    : null;
+  if (!contentTypeIsJson(contentType)) {
+    return { ok: false, reason: 'content-type no es JSON' };
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    return { ok: false, reason: 'JSON inválido' };
+  }
+
+  try {
+    return {
+      ok: true,
+      deployment: validateDeploymentPayload(payload, candidateSha),
+    };
+  } catch (error) {
+    if (error instanceof DeploymentVerificationError) {
+      return { ok: false, reason: error.message };
+    }
+    return { ok: false, reason: 'error interno al validar el contrato de deployment' };
+  }
+}
+
+export async function verifyDeployment({
+  candidateSha,
+  url = DEFAULT_STAGING_HEALTH_URL,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  fetchFn = globalThis.fetch,
+  sleepFn = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  clock = Date.now,
+} = {}) {
+  if (!isFullGitSha(candidateSha)) {
+    throw new DeploymentVerificationError(
+      'Candidate SHA debe ser un SHA Git completo en minúsculas de 40 caracteres.',
+    );
+  }
+  assertPositiveInteger(timeoutMs, 'timeoutMs');
+  assertPositiveInteger(pollIntervalMs, 'pollIntervalMs');
+  assertPositiveInteger(requestTimeoutMs, 'requestTimeoutMs');
+  if (typeof fetchFn !== 'function' || typeof sleepFn !== 'function' || typeof clock !== 'function') {
+    throw new DeploymentVerificationError('Las dependencias de polling no son válidas.');
+  }
+
+  const validatedUrl = validateEndpoint(url);
+  const startedAt = clock();
+  if (!Number.isFinite(startedAt)) {
+    throw new DeploymentVerificationError('El reloj de polling no devolvió un valor válido.');
+  }
+
+  let attempts = 0;
+  let lastReason = 'sin intentos';
+
+  while (true) {
+    const beforeAttempt = clock();
+    if (!Number.isFinite(beforeAttempt) || beforeAttempt < startedAt) {
+      throw new DeploymentVerificationError('El reloj de polling no es monotónico.');
+    }
+    if (attempts > 0 && beforeAttempt - startedAt >= timeoutMs) {
+      break;
+    }
+
+    attempts += 1;
+    const remainingMs = timeoutMs - (beforeAttempt - startedAt);
+    const outcome = await performAttempt({
+      url: validatedUrl,
+      candidateSha,
+      requestTimeoutMs: Math.max(1, Math.floor(Math.min(requestTimeoutMs, remainingMs))),
+      fetchFn,
+    });
+
+    const afterAttempt = clock();
+    if (!Number.isFinite(afterAttempt) || afterAttempt < beforeAttempt) {
+      throw new DeploymentVerificationError('El reloj de polling no es monotónico.');
+    }
+    const elapsedMs = afterAttempt - startedAt;
+
+    if (outcome.ok && elapsedMs < timeoutMs) {
+      return {
+        attempts,
+        elapsedMs,
+        deployment: outcome.deployment,
+      };
+    }
+
+    lastReason = outcome.ok ? 'la respuesta llegó después del timeout' : outcome.reason;
+    if (elapsedMs >= timeoutMs) {
+      break;
+    }
+
+    const waitMs = Math.min(pollIntervalMs, timeoutMs - elapsedMs);
+    try {
+      await sleepFn(waitMs);
+    } catch {
+      throw new DeploymentVerificationError('El polling no pudo esperar antes del siguiente intento.');
+    }
+  }
+
+  throw new DeploymentVerificationError(
+    `Timeout de deployment tras ${attempts} intentos; último resultado: ${lastReason}.`,
+  );
+}
+
+function parsePositiveInteger(value, optionName) {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+    throw new DeploymentVerificationError(`${optionName} debe ser un entero positivo.`);
+  }
+  const parsed = Number(value);
+  assertPositiveInteger(parsed, optionName);
+  return parsed;
+}
+
+function parseCliArguments(argv) {
+  const values = {};
+  const names = new Map([
+    ['--sha', 'candidateSha'],
+    ['--url', 'url'],
+    ['--timeout-ms', 'timeoutMs'],
+    ['--interval-ms', 'pollIntervalMs'],
+    ['--request-timeout-ms', 'requestTimeoutMs'],
+  ]);
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--help') {
+      values.help = true;
+      continue;
+    }
+    const property = names.get(argument);
+    if (!property) {
+      throw new DeploymentVerificationError(`Argumento no reconocido: ${argument}.`);
+    }
+    const value = argv[index + 1];
+    if (typeof value !== 'string' || value.startsWith('--')) {
+      throw new DeploymentVerificationError(`Falta el valor de ${argument}.`);
+    }
+    values[property] = value;
+    index += 1;
+  }
+  return values;
+}
+
+export async function runVerifyDeploymentCli({
+  argv = process.argv.slice(2),
+  env = process.env,
+  fetchFn = globalThis.fetch,
+  sleepFn,
+  clock,
+  stdout = process.stdout,
+  stderr = process.stderr,
+} = {}) {
+  try {
+    const args = parseCliArguments(argv);
+    if (args.help) {
+      stdout.write(
+        'Uso: verify-deployment.mjs --sha <40-hex> [--timeout-ms N] [--interval-ms N] [--request-timeout-ms N]\n',
+      );
+      return 0;
+    }
+
+    const candidateSha = args.candidateSha
+      ?? env.RELEASE_CANDIDATE_SHA
+      ?? env.CANDIDATE_SHA
+      ?? env.GITHUB_HEAD_SHA;
+    const options = {
+      candidateSha,
+      url: args.url ?? env.STAGING_HEALTH_URL ?? DEFAULT_STAGING_HEALTH_URL,
+      timeoutMs: parsePositiveInteger(
+        args.timeoutMs ?? env.DEPLOYMENT_VERIFY_TIMEOUT_MS ?? String(DEFAULT_TIMEOUT_MS),
+        'timeoutMs',
+      ),
+      pollIntervalMs: parsePositiveInteger(
+        args.pollIntervalMs ?? env.DEPLOYMENT_VERIFY_INTERVAL_MS ?? String(DEFAULT_POLL_INTERVAL_MS),
+        'pollIntervalMs',
+      ),
+      requestTimeoutMs: parsePositiveInteger(
+        args.requestTimeoutMs ?? env.DEPLOYMENT_REQUEST_TIMEOUT_MS ?? String(DEFAULT_REQUEST_TIMEOUT_MS),
+        'requestTimeoutMs',
+      ),
+      fetchFn,
+    };
+    if (sleepFn) options.sleepFn = sleepFn;
+    if (clock) options.clock = clock;
+
+    const result = await verifyDeployment(options);
+    stdout.write(
+      `Deployment de staging validado para ${result.deployment.gitSha} en ${result.attempts} intento(s).\n`,
+    );
+    return 0;
+  } catch (error) {
+    const message = error instanceof DeploymentVerificationError
+      ? error.message
+      : 'Error interno durante la verificación.';
+    stderr.write(`Deployment DENEGADO: ${message}\n`);
+    return 1;
+  }
+}
+
+const isDirectInvocation = process.argv[1]
+  && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (isDirectInvocation) {
+  process.exitCode = await runVerifyDeploymentCli();
+}

--- a/scripts/release/verify-deployment.test.mjs
+++ b/scripts/release/verify-deployment.test.mjs
@@ -1,0 +1,417 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DeploymentVerificationError,
+  EXPECTED_STAGING_HOST,
+  EXPECTED_STAGING_HOSTS,
+  EXPECTED_STAGING_RESOURCE_UUID,
+  normalizeGitRef,
+  normalizeHost,
+  runVerifyDeploymentCli,
+  validateDeploymentPayload,
+  verifyDeployment,
+} from './verify-deployment.mjs';
+
+const CANDIDATE_SHA = '0123456789abcdef0123456789abcdef01234567';
+const OTHER_SHA = '89abcdef0123456789abcdef0123456789abcdef';
+
+function validPayload(overrides = {}) {
+  const { coolify: coolifyOverrides, ...rootOverrides } = overrides;
+  const payload = {
+    status: 'ok',
+    app: 'cukies-hub',
+    environment: 'staging',
+    gitSha: CANDIDATE_SHA,
+    gitRef: 'staging',
+    coolify: {
+      resourceUuid: EXPECTED_STAGING_RESOURCE_UUID,
+      fqdn: EXPECTED_STAGING_HOST,
+    },
+    ...rootOverrides,
+  };
+  if (Object.hasOwn(overrides, 'coolify')) {
+    payload.coolify = coolifyOverrides !== null
+      && typeof coolifyOverrides === 'object'
+      && !Array.isArray(coolifyOverrides)
+      ? { ...payload.coolify, ...coolifyOverrides }
+      : coolifyOverrides;
+  }
+  return payload;
+}
+
+function jsonResponse(payload, { status = 200, contentType = 'application/json; charset=utf-8' } = {}) {
+  return {
+    status,
+    headers: { get: (name) => name.toLowerCase() === 'content-type' ? contentType : null },
+    json: async () => payload,
+  };
+}
+
+function fakeTime(start = 0) {
+  let now = start;
+  return {
+    clock: () => now,
+    sleep: async (milliseconds) => {
+      now += milliseconds;
+    },
+    get now() {
+      return now;
+    },
+  };
+}
+
+test('valida el contrato exacto de un deployment de staging', () => {
+  assert.deepEqual(validateDeploymentPayload(validPayload(), CANDIDATE_SHA), {
+    status: 'ok',
+    app: 'cukies-hub',
+    environment: 'staging',
+    gitSha: CANDIDATE_SHA,
+    gitRef: 'staging',
+    resourceUuid: EXPECTED_STAGING_RESOURCE_UUID,
+    host: EXPECTED_STAGING_HOST,
+    hosts: [EXPECTED_STAGING_HOST],
+  });
+});
+
+test('acepta el fqdn múltiple exacto que expone actualmente Coolify staging', () => {
+  const result = validateDeploymentPayload(validPayload({
+    coolify: { fqdn: EXPECTED_STAGING_HOSTS.join(',') },
+  }), CANDIDATE_SHA);
+
+  assert.equal(result.host, EXPECTED_STAGING_HOST);
+  assert.deepEqual(result.hosts, [...EXPECTED_STAGING_HOSTS]);
+});
+
+test('normaliza environment, refs explícitas y FQDN URL sin abrir aliases arbitrarios', () => {
+  const result = validateDeploymentPayload(validPayload({
+    environment: '  STAGING ',
+    gitRef: 'refs/heads/staging',
+    coolify: { fqdn: `https://${EXPECTED_STAGING_HOST}/` },
+  }), CANDIDATE_SHA);
+
+  assert.equal(result.environment, 'staging');
+  assert.equal(result.gitRef, 'staging');
+  assert.equal(result.host, EXPECTED_STAGING_HOST);
+  assert.equal(normalizeGitRef('origin/staging'), 'staging');
+  assert.equal(normalizeGitRef('refs/heads/origin/staging'), 'origin/staging');
+  assert.equal(normalizeHost(EXPECTED_STAGING_HOST), EXPECTED_STAGING_HOST);
+  assert.equal(normalizeHost(`https://${EXPECTED_STAGING_HOST}`), EXPECTED_STAGING_HOST);
+  assert.equal(normalizeHost(`https://${EXPECTED_STAGING_HOST}/`), EXPECTED_STAGING_HOST);
+});
+
+test('rechaza cualquier variante no literal de fqdn/host', () => {
+  const invalidHosts = [
+    EXPECTED_STAGING_HOST.toUpperCase(),
+    `${EXPECTED_STAGING_HOST}.`,
+    ` ${EXPECTED_STAGING_HOST}`,
+    `${EXPECTED_STAGING_HOST} `,
+    `http://${EXPECTED_STAGING_HOST}`,
+    `HTTPS://${EXPECTED_STAGING_HOST}`,
+    `https://${EXPECTED_STAGING_HOST.toUpperCase()}`,
+    `https://${EXPECTED_STAGING_HOST}:443`,
+    `https://user:password@${EXPECTED_STAGING_HOST}`,
+    `https://${EXPECTED_STAGING_HOST}/api/health`,
+    `https://${EXPECTED_STAGING_HOST}/?token=x`,
+    `https://${EXPECTED_STAGING_HOST}/#fragment`,
+    `//${EXPECTED_STAGING_HOST}`,
+  ];
+
+  for (const host of invalidHosts) {
+    assert.equal(normalizeHost(host), null);
+    assert.throws(
+      () => validateDeploymentPayload(validPayload({ coolify: { fqdn: host } }), CANDIDATE_SHA),
+      /coolify\.fqdn/i,
+    );
+  }
+});
+
+test('acepta host como alternativa a fqdn', () => {
+  const payload = validPayload({ coolify: { host: EXPECTED_STAGING_HOST } });
+  delete payload.coolify.fqdn;
+
+  assert.equal(validateDeploymentPayload(payload, CANDIDATE_SHA).host, EXPECTED_STAGING_HOST);
+});
+
+test('rechaza el alias Coolify si falta el dominio público canónico de staging', () => {
+  assert.throws(
+    () => validateDeploymentPayload(validPayload({
+      coolify: { fqdn: EXPECTED_STAGING_HOSTS[0] },
+    }), CANDIDATE_SHA),
+    /dominio público canónico/i,
+  );
+});
+
+const invalidFields = [
+  ['status', { status: 'healthy' }, /status/i],
+  ['app', { app: 'another-app' }, /app/i],
+  ['environment', { environment: 'production' }, /environment/i],
+  ['gitSha distinto', { gitSha: OTHER_SHA }, /gitSha/i],
+  ['gitSha abreviado', { gitSha: CANDIDATE_SHA.slice(0, 12) }, /gitSha/i],
+  ['gitRef', { gitRef: 'feature/staging' }, /gitRef/i],
+  ['resourceUuid', { coolify: { resourceUuid: 'wrong-resource' } }, /resourceUuid/i],
+  ['fqdn', { coolify: { fqdn: 'cukieshub.eurekand.com.attacker.example' } }, /fqdn|host/i],
+];
+
+for (const [name, override, expectedError] of invalidFields) {
+  test(`rechaza el campo inválido ${name}`, () => {
+    assert.throws(
+      () => validateDeploymentPayload(validPayload(override), CANDIDATE_SHA),
+      expectedError,
+    );
+  });
+}
+
+test('rechaza payloads que no son objetos JSON', () => {
+  for (const payload of [null, [], 'ok', 42]) {
+    assert.throws(
+      () => validateDeploymentPayload(payload, CANDIDATE_SHA),
+      /objeto JSON/i,
+    );
+  }
+});
+
+test('rechaza ausencia de fqdn y host', () => {
+  const payload = validPayload();
+  delete payload.coolify.fqdn;
+
+  assert.throws(
+    () => validateDeploymentPayload(payload, CANDIDATE_SHA),
+    /fqdn.*host/i,
+  );
+});
+
+test('rechaza si uno de fqdn/host contradice al otro', () => {
+  assert.throws(
+    () => validateDeploymentPayload(validPayload({
+      coolify: { host: 'production.example.com' },
+    }), CANDIDATE_SHA),
+    /host/i,
+  );
+});
+
+test('rechaza identidad Coolify en raíz o un objeto coolify ausente/malformado', () => {
+  const rootFallback = validPayload();
+  rootFallback.resourceUuid = rootFallback.coolify.resourceUuid;
+  rootFallback.fqdn = rootFallback.coolify.fqdn;
+  delete rootFallback.coolify;
+
+  for (const payload of [rootFallback, validPayload({ coolify: null }), validPayload({ coolify: [] })]) {
+    assert.throws(
+      () => validateDeploymentPayload(payload, CANDIDATE_SHA),
+      /coolify/i,
+    );
+  }
+});
+
+test('rechaza candidate SHA ausente, abreviado, distinto de un SHA Git o con mayúsculas', () => {
+  for (const sha of [undefined, '', CANDIDATE_SHA.slice(0, 7), 'g'.repeat(40), CANDIDATE_SHA.toUpperCase()]) {
+    assert.throws(
+      () => validateDeploymentPayload(validPayload(), sha),
+      /candidate sha.*completo/i,
+    );
+  }
+});
+
+test('verifyDeployment resuelve en el primer HTTP 200 JSON válido', async () => {
+  const requests = [];
+  const result = await verifyDeployment({
+    candidateSha: CANDIDATE_SHA,
+    fetchFn: async (url, options) => {
+      requests.push({ url, options });
+      return jsonResponse(validPayload());
+    },
+  });
+
+  assert.equal(result.attempts, 1);
+  assert.equal(result.deployment.gitSha, CANDIDATE_SHA);
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, `https://${EXPECTED_STAGING_HOST}/api/health`);
+  assert.equal(requests[0].options.method, 'GET');
+  assert.equal(requests[0].options.headers.accept, 'application/json');
+  assert.ok(requests[0].options.signal instanceof AbortSignal);
+});
+
+test('hace polling hasta que aparece el SHA candidato', async () => {
+  const time = fakeTime();
+  let requests = 0;
+  const result = await verifyDeployment({
+    candidateSha: CANDIDATE_SHA,
+    timeoutMs: 500,
+    pollIntervalMs: 100,
+    clock: time.clock,
+    sleepFn: time.sleep,
+    fetchFn: async () => {
+      requests += 1;
+      return jsonResponse(validPayload({ gitSha: requests === 1 ? OTHER_SHA : CANDIDATE_SHA }));
+    },
+  });
+
+  assert.equal(result.attempts, 2);
+  assert.equal(result.elapsedMs, 100);
+  assert.equal(requests, 2);
+});
+
+test('agota el timeout de polling sin hacer una petición nueva en el deadline', async () => {
+  const time = fakeTime();
+  let requests = 0;
+
+  await assert.rejects(
+    verifyDeployment({
+      candidateSha: CANDIDATE_SHA,
+      timeoutMs: 250,
+      pollIntervalMs: 100,
+      clock: time.clock,
+      sleepFn: time.sleep,
+      fetchFn: async () => {
+        requests += 1;
+        return jsonResponse(validPayload({ gitSha: OTHER_SHA }));
+      },
+    }),
+    (error) => {
+      assert.ok(error instanceof DeploymentVerificationError);
+      assert.match(error.message, /timeout.*3 intentos/i);
+      assert.match(error.message, /gitSha/i);
+      return true;
+    },
+  );
+
+  assert.equal(requests, 3);
+  assert.equal(time.now, 250);
+});
+
+test('trata errores de red como intentos fallidos y no filtra el mensaje original', async () => {
+  const time = fakeTime();
+  const secret = 'token-super-secreto';
+
+  await assert.rejects(
+    verifyDeployment({
+      candidateSha: CANDIDATE_SHA,
+      timeoutMs: 100,
+      pollIntervalMs: 100,
+      clock: time.clock,
+      sleepFn: time.sleep,
+      fetchFn: async () => {
+        throw new Error(`network failed with ${secret}`);
+      },
+    }),
+    (error) => {
+      assert.match(error.message, /red/i);
+      assert.doesNotMatch(error.message, new RegExp(secret));
+      return true;
+    },
+  );
+});
+
+test('rechaza HTTP distinto de 200 aunque response.ok pudiera ser true', async () => {
+  const time = fakeTime();
+
+  await assert.rejects(
+    verifyDeployment({
+      candidateSha: CANDIDATE_SHA,
+      timeoutMs: 1,
+      pollIntervalMs: 1,
+      clock: time.clock,
+      sleepFn: time.sleep,
+      fetchFn: async () => jsonResponse(validPayload(), { status: 204 }),
+    }),
+    /HTTP 204/,
+  );
+});
+
+test('rechaza content-type que no sea JSON', async () => {
+  const time = fakeTime();
+
+  await assert.rejects(
+    verifyDeployment({
+      candidateSha: CANDIDATE_SHA,
+      timeoutMs: 1,
+      pollIntervalMs: 1,
+      clock: time.clock,
+      sleepFn: time.sleep,
+      fetchFn: async () => jsonResponse(validPayload(), { contentType: 'text/html' }),
+    }),
+    /content-type.*JSON/i,
+  );
+});
+
+test('rechaza JSON ilegible sin imprimir el body', async () => {
+  const time = fakeTime();
+  const response = jsonResponse(validPayload());
+  response.json = async () => {
+    throw new SyntaxError('body contains SECRET_VALUE');
+  };
+
+  await assert.rejects(
+    verifyDeployment({
+      candidateSha: CANDIDATE_SHA,
+      timeoutMs: 1,
+      pollIntervalMs: 1,
+      clock: time.clock,
+      sleepFn: time.sleep,
+      fetchFn: async () => response,
+    }),
+    (error) => {
+      assert.match(error.message, /JSON inválido/i);
+      assert.doesNotMatch(error.message, /SECRET_VALUE/);
+      return true;
+    },
+  );
+});
+
+test('falla antes de fetch con configuración inválida o endpoint ajeno a staging', async () => {
+  const neverFetch = async () => assert.fail('fetch no debe ejecutarse');
+  const cases = [
+    { candidateSha: CANDIDATE_SHA.slice(0, 12) },
+    { candidateSha: CANDIDATE_SHA, timeoutMs: 0 },
+    { candidateSha: CANDIDATE_SHA, pollIntervalMs: -1 },
+    { candidateSha: CANDIDATE_SHA, requestTimeoutMs: Number.NaN },
+    { candidateSha: CANDIDATE_SHA, url: 'https://production.example.com/api/health' },
+    { candidateSha: CANDIDATE_SHA, url: `http://${EXPECTED_STAGING_HOST}/api/health` },
+    { candidateSha: CANDIDATE_SHA, url: `https://${EXPECTED_STAGING_HOST}/` },
+    { candidateSha: CANDIDATE_SHA, url: `https://${EXPECTED_STAGING_HOST}/api/health/extra` },
+    { candidateSha: CANDIDATE_SHA, url: `https://${EXPECTED_STAGING_HOST}/api/health?token=x` },
+    { candidateSha: CANDIDATE_SHA, url: `https://${EXPECTED_STAGING_HOST}/api/health#fragment` },
+  ];
+
+  for (const options of cases) {
+    await assert.rejects(verifyDeployment({ ...options, fetchFn: neverFetch }), DeploymentVerificationError);
+  }
+});
+
+test('CLI admite configuración explícita y solo imprime un resumen seguro', async () => {
+  const output = [];
+  const errors = [];
+  const exitCode = await runVerifyDeploymentCli({
+    argv: ['--sha', CANDIDATE_SHA, '--timeout-ms', '10', '--interval-ms', '1'],
+    env: {},
+    fetchFn: async () => jsonResponse(validPayload({ internalSecret: 'DO_NOT_PRINT' })),
+    stdout: { write: (value) => output.push(value) },
+    stderr: { write: (value) => errors.push(value) },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.match(output.join(''), /deployment.*validado/i);
+  assert.doesNotMatch(output.join(''), /DO_NOT_PRINT/);
+  assert.equal(errors.length, 0);
+});
+
+test('CLI falla cerrado y no imprime un body inválido ni secretos', async () => {
+  const output = [];
+  const errors = [];
+  const time = fakeTime();
+  const exitCode = await runVerifyDeploymentCli({
+    argv: ['--sha', CANDIDATE_SHA, '--timeout-ms', '1', '--interval-ms', '1'],
+    env: {},
+    clock: time.clock,
+    sleepFn: time.sleep,
+    fetchFn: async () => jsonResponse({ secret: 'DO_NOT_PRINT' }),
+    stdout: { write: (value) => output.push(value) },
+    stderr: { write: (value) => errors.push(value) },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(output.length, 0);
+  assert.match(errors.join(''), /deployment.*denegado/i);
+  assert.doesNotMatch(errors.join(''), /DO_NOT_PRINT/);
+});

--- a/scripts/release/verify-promotion-merge.mjs
+++ b/scripts/release/verify-promotion-merge.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const FULL_GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const REPOSITORY_PATTERN = /^([A-Za-z0-9][A-Za-z0-9_.-]*)\/([A-Za-z0-9][A-Za-z0-9_.-]*)$/;
+const VALID_MODES = new Set(['normal', 'hotfix']);
+export const DEFAULT_GITHUB_API_URL = 'https://api.github.com';
+
+export class PromotionMergeVerificationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'PromotionMergeVerificationError';
+  }
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isFullGitSha(value) {
+  return typeof value === 'string' && FULL_GIT_SHA_PATTERN.test(value);
+}
+
+function validateSha(value, name) {
+  if (!isFullGitSha(value)) {
+    throw new PromotionMergeVerificationError(
+      `${name} debe ser un SHA Git completo en minúsculas de 40 caracteres.`,
+    );
+  }
+  return value;
+}
+
+function validateRepository(repository) {
+  if (typeof repository !== 'string') {
+    throw new PromotionMergeVerificationError('GITHUB_REPOSITORY no es válido.');
+  }
+  const match = repository.match(REPOSITORY_PATTERN);
+  if (!match || match[1].includes('..') || match[2].includes('..')) {
+    throw new PromotionMergeVerificationError('GITHUB_REPOSITORY debe tener la forma owner/repo.');
+  }
+  return { owner: match[1], repo: match[2], fullName: repository };
+}
+
+function validateApiBaseUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new PromotionMergeVerificationError('La URL base de GitHub API no es válida.');
+  }
+  if (
+    parsed.protocol !== 'https:'
+    || parsed.username !== ''
+    || parsed.password !== ''
+    || parsed.search !== ''
+    || parsed.hash !== ''
+  ) {
+    throw new PromotionMergeVerificationError(
+      'GitHub API debe usar una URL HTTPS sin credenciales.',
+    );
+  }
+  return parsed.href.replace(/\/+$/, '');
+}
+
+function contentTypeIsJson(response) {
+  if (typeof response?.headers?.get !== 'function') return false;
+  const value = response.headers.get('content-type');
+  if (typeof value !== 'string') return false;
+  const mediaType = value.split(';', 1)[0].trim().toLowerCase();
+  return mediaType === 'application/json' || mediaType.endsWith('+json');
+}
+
+async function fetchGitHubJson(url, { token, fetchFn }) {
+  let response;
+  try {
+    response = await fetchFn(url, {
+      method: 'GET',
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'x-github-api-version': '2022-11-28',
+      },
+      cache: 'no-store',
+      redirect: 'error',
+    });
+  } catch {
+    throw new PromotionMergeVerificationError('Error de red al consultar GitHub API.');
+  }
+  if (!isRecord(response) || response.status !== 200) {
+    const status = isRecord(response) && Number.isInteger(response.status)
+      ? `HTTP ${response.status}`
+      : 'respuesta HTTP inválida';
+    throw new PromotionMergeVerificationError(`GitHub API devolvió ${status}.`);
+  }
+  if (!contentTypeIsJson(response)) {
+    throw new PromotionMergeVerificationError('GitHub API no devolvió content-type JSON.');
+  }
+  try {
+    return await response.json();
+  } catch {
+    throw new PromotionMergeVerificationError('GitHub API devolvió JSON inválido.');
+  }
+}
+
+function validateCommitTree(payload, expectedSha, label) {
+  if (
+    !isRecord(payload)
+    || payload.sha !== expectedSha
+    || !isRecord(payload.tree)
+    || !isFullGitSha(payload.tree.sha)
+  ) {
+    throw new PromotionMergeVerificationError(
+      `${label} no coincide con el SHA exacto o no expone un tree SHA válido.`,
+    );
+  }
+  return payload.tree.sha;
+}
+
+export function validatePromotionMergePayloads({
+  mergePayload,
+  headPayload,
+  baseSha,
+  headSha,
+  mergeSha,
+  mode,
+} = {}) {
+  validateSha(baseSha, 'baseSha');
+  validateSha(headSha, 'headSha');
+  validateSha(mergeSha, 'mergeSha');
+  if (new Set([baseSha, headSha, mergeSha]).size !== 3) {
+    throw new PromotionMergeVerificationError(
+      'El test merge SHA debe ser distinto de sus SHAs base y head.',
+    );
+  }
+  if (!VALID_MODES.has(mode)) {
+    throw new PromotionMergeVerificationError('mode debe ser exactamente normal o hotfix.');
+  }
+
+  const mergeTreeSha = validateCommitTree(mergePayload, mergeSha, 'El test merge commit');
+  if (
+    !Array.isArray(mergePayload.parents)
+    || mergePayload.parents.length !== 2
+    || !isRecord(mergePayload.parents[0])
+    || mergePayload.parents[0].sha !== baseSha
+    || !isRecord(mergePayload.parents[1])
+    || mergePayload.parents[1].sha !== headSha
+  ) {
+    throw new PromotionMergeVerificationError(
+      'El test merge commit no tiene exactamente baseSha y headSha como padres ordenados.',
+    );
+  }
+
+  const headTreeSha = validateCommitTree(headPayload, headSha, 'El head commit');
+  if (mode === 'normal' && mergeTreeSha !== headTreeSha) {
+    throw new PromotionMergeVerificationError(
+      'staging no contiene todavía todo main: el tree del test merge difiere del tree desplegado.',
+    );
+  }
+
+  return {
+    mode,
+    baseSha,
+    headSha,
+    mergeSha,
+    mergeTreeSha,
+    headTreeSha,
+    stagingContainsMain: mode === 'normal' ? true : null,
+  };
+}
+
+export async function verifyPromotionMerge({
+  repository,
+  baseSha,
+  headSha,
+  mergeSha,
+  mode,
+  token,
+  apiBaseUrl = DEFAULT_GITHUB_API_URL,
+  fetchFn = globalThis.fetch,
+} = {}) {
+  const parsedRepository = validateRepository(repository);
+  validateSha(baseSha, 'baseSha');
+  validateSha(headSha, 'headSha');
+  validateSha(mergeSha, 'mergeSha');
+  if (!VALID_MODES.has(mode)) {
+    throw new PromotionMergeVerificationError('mode debe ser exactamente normal o hotfix.');
+  }
+  if (typeof token !== 'string' || token.trim() === '' || /[\r\n]/.test(token)) {
+    throw new PromotionMergeVerificationError('GITHUB_TOKEN es obligatorio y debe ser válido.');
+  }
+  if (typeof fetchFn !== 'function') {
+    throw new PromotionMergeVerificationError('La dependencia fetch no es válida.');
+  }
+  const apiUrl = validateApiBaseUrl(apiBaseUrl);
+  const repoPath = `/repos/${encodeURIComponent(parsedRepository.owner)}/${encodeURIComponent(parsedRepository.repo)}`;
+  const [mergePayload, headPayload] = await Promise.all([
+    fetchGitHubJson(`${apiUrl}${repoPath}/git/commits/${mergeSha}`, { token, fetchFn }),
+    fetchGitHubJson(`${apiUrl}${repoPath}/git/commits/${headSha}`, { token, fetchFn }),
+  ]);
+  return validatePromotionMergePayloads({
+    mergePayload,
+    headPayload,
+    baseSha,
+    headSha,
+    mergeSha,
+    mode,
+  });
+}
+
+function parseCliArguments(argv) {
+  const parsed = {};
+  const names = new Map([
+    ['--repository', 'repository'],
+    ['--base-sha', 'baseSha'],
+    ['--head-sha', 'headSha'],
+    ['--merge-sha', 'mergeSha'],
+    ['--mode', 'mode'],
+    ['--api-url', 'apiBaseUrl'],
+  ]);
+  const seen = new Set();
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--help') {
+      parsed.help = true;
+      continue;
+    }
+    const property = names.get(argument);
+    if (!property || seen.has(argument)) {
+      throw new PromotionMergeVerificationError(`Argumento no reconocido o repetido: ${argument}.`);
+    }
+    const value = argv[index + 1];
+    if (typeof value !== 'string' || value.startsWith('--')) {
+      throw new PromotionMergeVerificationError(`Falta el valor de ${argument}.`);
+    }
+    parsed[property] = value;
+    seen.add(argument);
+    index += 1;
+  }
+  return parsed;
+}
+
+export async function runVerifyPromotionMergeCli({
+  argv = process.argv.slice(2),
+  env = process.env,
+  fetchFn = globalThis.fetch,
+  stdout = process.stdout,
+  stderr = process.stderr,
+} = {}) {
+  try {
+    const args = parseCliArguments(argv);
+    if (args.help) {
+      stdout.write(
+        'Uso: verify-promotion-merge.mjs --repository <owner/repo> --base-sha <sha> --head-sha <sha> --merge-sha <sha> --mode <normal|hotfix>\n',
+      );
+      return 0;
+    }
+    const result = await verifyPromotionMerge({
+      repository: args.repository ?? env.GITHUB_REPOSITORY,
+      baseSha: args.baseSha ?? env.PROMOTION_BASE_SHA,
+      headSha: args.headSha ?? env.PROMOTION_HEAD_SHA,
+      mergeSha: args.mergeSha ?? env.PROMOTION_MERGE_SHA,
+      mode: args.mode ?? env.PROMOTION_MODE,
+      token: env.GITHUB_TOKEN,
+      apiBaseUrl: args.apiBaseUrl ?? env.GITHUB_API_URL ?? DEFAULT_GITHUB_API_URL,
+      fetchFn,
+    });
+    const parity = result.mode === 'normal'
+      ? '; staging tree contiene exactamente el resultado main+staging'
+      : '';
+    stdout.write(`Test merge ${result.mergeSha} validado (${result.mode})${parity}.\n`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof PromotionMergeVerificationError
+      ? error.message
+      : 'Error interno al verificar el test merge.';
+    stderr.write(`Test merge DENEGADO: ${message}\n`);
+    return 1;
+  }
+}
+
+const isDirectInvocation = process.argv[1]
+  && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (isDirectInvocation) {
+  process.exitCode = await runVerifyPromotionMergeCli();
+}

--- a/scripts/release/verify-promotion-merge.test.mjs
+++ b/scripts/release/verify-promotion-merge.test.mjs
@@ -1,0 +1,215 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  PromotionMergeVerificationError,
+  runVerifyPromotionMergeCli,
+  validatePromotionMergePayloads,
+  verifyPromotionMerge,
+} from './verify-promotion-merge.mjs';
+
+const REPOSITORY = 'fgomezserna/cukies-hub';
+const BASE_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const HEAD_SHA = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const MERGE_SHA = 'cccccccccccccccccccccccccccccccccccccccc';
+const TREE_SHA = 'dddddddddddddddddddddddddddddddddddddddd';
+const OTHER_TREE_SHA = 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+
+function mergePayload(overrides = {}) {
+  return {
+    sha: MERGE_SHA,
+    tree: { sha: TREE_SHA },
+    parents: [{ sha: BASE_SHA }, { sha: HEAD_SHA }],
+    ...overrides,
+  };
+}
+
+function headPayload(overrides = {}) {
+  return {
+    sha: HEAD_SHA,
+    tree: { sha: TREE_SHA },
+    parents: [{ sha: BASE_SHA }],
+    ...overrides,
+  };
+}
+
+function validOptions(overrides = {}) {
+  return {
+    mergePayload: mergePayload(),
+    headPayload: headPayload(),
+    baseSha: BASE_SHA,
+    headSha: HEAD_SHA,
+    mergeSha: MERGE_SHA,
+    mode: 'normal',
+    ...overrides,
+  };
+}
+
+function jsonResponse(payload, status = 200, contentType = 'application/json') {
+  return {
+    status,
+    headers: { get: () => contentType },
+    json: async () => payload,
+  };
+}
+
+test('normal acepta test merge con padres exactos y tree idéntico al staging desplegado', () => {
+  assert.deepEqual(validatePromotionMergePayloads(validOptions()), {
+    mode: 'normal',
+    baseSha: BASE_SHA,
+    headSha: HEAD_SHA,
+    mergeSha: MERGE_SHA,
+    mergeTreeSha: TREE_SHA,
+    headTreeSha: TREE_SHA,
+    stagingContainsMain: true,
+  });
+});
+
+test('normal falla si incorporar main cambia el tree de staging', () => {
+  assert.throws(
+    () => validatePromotionMergePayloads(validOptions({
+      mergePayload: mergePayload({ tree: { sha: OTHER_TREE_SHA } }),
+    })),
+    /staging no contiene todavía todo main/i,
+  );
+});
+
+test('hotfix valida padres pero permite que el test merge cambie el tree', () => {
+  const result = validatePromotionMergePayloads(validOptions({
+    mode: 'hotfix',
+    mergePayload: mergePayload({ tree: { sha: OTHER_TREE_SHA } }),
+  }));
+  assert.equal(result.stagingContainsMain, null);
+  assert.equal(result.mergeTreeSha, OTHER_TREE_SHA);
+});
+
+test('rechaza padres invertidos, ausentes o SHAs que no coinciden', () => {
+  for (const payload of [
+    mergePayload({ parents: [{ sha: HEAD_SHA }, { sha: BASE_SHA }] }),
+    mergePayload({ parents: [{ sha: BASE_SHA }] }),
+    mergePayload({ sha: HEAD_SHA }),
+    mergePayload({ tree: { sha: 'short' } }),
+  ]) {
+    assert.throws(
+      () => validatePromotionMergePayloads(validOptions({ mergePayload: payload })),
+      PromotionMergeVerificationError,
+    );
+  }
+});
+
+test('rechaza modo y SHAs de entrada inválidos', () => {
+  for (const overrides of [
+    { mode: 'release' },
+    { baseSha: 'short' },
+    { headSha: BASE_SHA },
+    { mergeSha: HEAD_SHA },
+  ]) {
+    assert.throws(
+      () => validatePromotionMergePayloads(validOptions(overrides)),
+      PromotionMergeVerificationError,
+    );
+  }
+});
+
+test('verifyPromotionMerge consulta commits exactos por API y no ramas mutables', async () => {
+  const requests = [];
+  const result = await verifyPromotionMerge({
+    repository: REPOSITORY,
+    baseSha: BASE_SHA,
+    headSha: HEAD_SHA,
+    mergeSha: MERGE_SHA,
+    mode: 'normal',
+    token: 'test-token',
+    fetchFn: async (url, options) => {
+      requests.push({ url, options });
+      return url.endsWith(MERGE_SHA)
+        ? jsonResponse(mergePayload())
+        : jsonResponse(headPayload());
+    },
+  });
+  assert.equal(result.stagingContainsMain, true);
+  assert.equal(requests.length, 2);
+  assert.match(requests[0].url, new RegExp(`/git/commits/${MERGE_SHA}$`));
+  assert.match(requests[1].url, new RegExp(`/git/commits/${HEAD_SHA}$`));
+  assert.equal(requests.every(({ options }) => options.redirect === 'error'), true);
+});
+
+test('falla cerrado ante red, HTTP, content-type o entradas inválidas sin filtrar secretos', async () => {
+  await assert.rejects(verifyPromotionMerge({
+    repository: REPOSITORY,
+    baseSha: BASE_SHA,
+    headSha: HEAD_SHA,
+    mergeSha: MERGE_SHA,
+    mode: 'normal',
+    token: 'secret-token',
+    fetchFn: async () => { throw new Error('secret-token'); },
+  }), (error) => {
+    assert.match(error.message, /red/i);
+    assert.doesNotMatch(error.message, /secret-token/);
+    return true;
+  });
+
+  for (const response of [
+    jsonResponse({}, 404),
+    jsonResponse({}, 200, 'text/html'),
+    { ...jsonResponse({}), json: async () => { throw new Error('SECRET'); } },
+  ]) {
+    await assert.rejects(verifyPromotionMerge({
+      repository: REPOSITORY,
+      baseSha: BASE_SHA,
+      headSha: HEAD_SHA,
+      mergeSha: MERGE_SHA,
+      mode: 'normal',
+      token: 'test-token',
+      fetchFn: async () => response,
+    }), (error) => {
+      assert.doesNotMatch(error.message, /SECRET/);
+      return true;
+    });
+  }
+});
+
+test('CLI usa env, devuelve resumen mínimo y falla cerrado sin token', async () => {
+  const output = [];
+  const exitCode = await runVerifyPromotionMergeCli({
+    argv: [],
+    env: {
+      GITHUB_REPOSITORY: REPOSITORY,
+      GITHUB_TOKEN: 'DO_NOT_PRINT',
+      PROMOTION_BASE_SHA: BASE_SHA,
+      PROMOTION_HEAD_SHA: HEAD_SHA,
+      PROMOTION_MERGE_SHA: MERGE_SHA,
+      PROMOTION_MODE: 'normal',
+    },
+    fetchFn: async (url) => url.endsWith(MERGE_SHA)
+      ? jsonResponse(mergePayload())
+      : jsonResponse(headPayload()),
+    stdout: { write: (value) => output.push(value) },
+    stderr: { write: () => assert.fail('no debe escribir error') },
+  });
+  assert.equal(exitCode, 0);
+  assert.match(output.join(''), /Test merge.*validado/);
+  assert.doesNotMatch(output.join(''), /DO_NOT_PRINT/);
+
+  let fetchCalls = 0;
+  const errors = [];
+  const denied = await runVerifyPromotionMergeCli({
+    argv: [],
+    env: {
+      GITHUB_REPOSITORY: REPOSITORY,
+      PROMOTION_BASE_SHA: BASE_SHA,
+      PROMOTION_HEAD_SHA: HEAD_SHA,
+      PROMOTION_MERGE_SHA: MERGE_SHA,
+      PROMOTION_MODE: 'normal',
+    },
+    fetchFn: async () => {
+      fetchCalls += 1;
+      return jsonResponse({});
+    },
+    stdout: { write: () => assert.fail('no debe escribir éxito') },
+    stderr: { write: (value) => errors.push(value) },
+  });
+  assert.equal(denied, 1);
+  assert.equal(fetchCalls, 0);
+  assert.match(errors.join(''), /DENEGADO/);
+});

--- a/scripts/release/workflows.test.mjs
+++ b/scripts/release/workflows.test.mjs
@@ -1,0 +1,263 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const SYNC_WORKFLOW_URL = new URL('../../.github/workflows/main-staging-sync.yml', import.meta.url);
+const PROMOTION_WORKFLOW_URL = new URL('../../.github/workflows/main-promotion-gate.yml', import.meta.url);
+const STAGING_WORKFLOW_URL = new URL('../../.github/workflows/staging-deploy-verify.yml', import.meta.url);
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const MERGE_SHA = '0123456789abcdef0123456789abcdef01234567';
+const APP_TOKEN_ACTION_SHA = 'fee1f7d63c2ff003460e3d139729b119787bc349';
+
+async function syncWorkflowSource() {
+  return readFile(SYNC_WORKFLOW_URL, 'utf8');
+}
+
+function extractGithubScript(source) {
+  const marker = '          script: |\n';
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, 'github-script block must exist');
+  const lines = source.slice(start + marker.length).split('\n');
+  const scriptLines = [];
+  for (const line of lines) {
+    if (line === '' || line.startsWith('            ')) {
+      scriptLines.push(line.startsWith('            ') ? line.slice(12) : line);
+      continue;
+    }
+    break;
+  }
+  return scriptLines.join('\n');
+}
+
+function testCore() {
+  const failures = [];
+  const info = [];
+  const summary = {
+    addHeading: () => summary,
+    addLink: () => summary,
+    addRaw: () => summary,
+    write: async () => undefined,
+  };
+  return {
+    core: {
+      setFailed: (message) => failures.push(message),
+      info: (message) => info.push(message),
+      summary,
+    },
+    failures,
+    info,
+  };
+}
+
+function context(overrides = {}) {
+  return {
+    repo: { owner: 'fgomezserna', repo: 'cukies-hub' },
+    payload: {
+      pull_request: {
+        number: 232,
+        merge_commit_sha: MERGE_SHA,
+        head: { ref: 'staging' },
+        ...overrides,
+      },
+    },
+  };
+}
+
+async function executeSyncScript({ comparisonStatus = 'ahead', pullRequest = {}, overrides = {} } = {}) {
+  const source = await syncWorkflowSource();
+  const script = extractGithubScript(source);
+  const calls = [];
+  const { core, failures, info } = testCore();
+  const github = {
+    rest: {
+      repos: {
+        compareCommitsWithBasehead: async (args) => {
+          calls.push(['compare', args]);
+          return { data: { status: comparisonStatus } };
+        },
+      },
+      git: {
+        getRef: async () => {
+          calls.push(['getRef']);
+          const error = new Error('not found');
+          error.status = 404;
+          throw error;
+        },
+        createRef: async (args) => {
+          calls.push(['createRef', args]);
+          return { data: {} };
+        },
+      },
+      pulls: {
+        list: async () => {
+          calls.push(['listPulls']);
+          return { data: [] };
+        },
+        create: async (args) => {
+          calls.push(['createPull', args]);
+          return { data: { number: 99, html_url: 'https://github.test/pr/99' } };
+        },
+      },
+      ...overrides,
+    },
+  };
+  await new AsyncFunction('context', 'github', 'core', script)(
+    context(pullRequest),
+    github,
+    core,
+  );
+  return { calls, failures, info, script, source };
+}
+
+function syncPullsOverride(pullRequests) {
+  return {
+    pulls: {
+      list: async () => ({ data: pullRequests }),
+      create: async () => assert.fail('an existing sync PR must never be recreated'),
+    },
+  };
+}
+
+test('todo PR merged en main activa sync sin depender de label o rama original', async () => {
+  const source = await syncWorkflowSource();
+  const jobCondition = source.match(/    if: ([^\n]+)/)?.[1] ?? '';
+  assert.match(jobCondition, /merged == true/);
+  assert.doesNotMatch(jobCondition, /hotfix|head\.ref|label/i);
+
+  for (const headRef of ['staging', 'hotfix/restore-checkout', 'unexpected/admin-bypass']) {
+    const result = await executeSyncScript({
+      comparisonStatus: 'diverged',
+      pullRequest: { head: { ref: headRef } },
+    });
+    assert.deepEqual(result.failures, []);
+    assert.equal(result.calls.some(([name]) => name === 'createPull'), true);
+  }
+});
+
+for (const comparisonStatus of ['ahead', 'identical']) {
+  test(`sync es idempotente cuando staging ya contiene main: ${comparisonStatus}`, async () => {
+    const result = await executeSyncScript({ comparisonStatus });
+    assert.deepEqual(result.failures, []);
+    assert.deepEqual(result.calls.map(([name]) => name), ['compare']);
+    assert.match(result.info.join(''), /already contains exact main SHA/i);
+  });
+}
+
+test('sync crea rama en SHA exacto y exige merge commit para restaurar ancestry', async () => {
+  const result = await executeSyncScript({ comparisonStatus: 'diverged' });
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(result.calls.map(([name]) => name), [
+    'compare',
+    'getRef',
+    'createRef',
+    'listPulls',
+    'createPull',
+  ]);
+  const createRef = result.calls.find(([name]) => name === 'createRef')[1];
+  assert.equal(createRef.sha, MERGE_SHA);
+  const createPull = result.calls.find(([name]) => name === 'createPull')[1];
+  assert.equal(createPull.base, 'staging');
+  assert.match(createPull.head, /sync\/main-/);
+  assert.match(createPull.body, /Required merge method: Create a merge commit/);
+  assert.match(createPull.body, /next promotion blocked/);
+  assert.match(createPull.body, /not auto-merged/);
+});
+
+test('sync fail-closed si el evento no contiene merge SHA completo', async () => {
+  const result = await executeSyncScript({ pullRequest: { merge_commit_sha: 'abc' } });
+  assert.deepEqual(result.calls, []);
+  assert.match(result.failures.join(''), /full merge commit SHA/i);
+});
+
+test('sync falla cerrado si un PR previo se fusionó sin conservar ancestry', async () => {
+  const branch = `sync/main-${MERGE_SHA.slice(0, 12)}`;
+  const result = await executeSyncScript({
+    comparisonStatus: 'diverged',
+    overrides: syncPullsOverride([{
+      number: 77,
+      state: 'closed',
+      merged_at: '2026-08-08T00:00:00Z',
+      html_url: 'https://github.test/pr/77',
+      head: { ref: branch },
+      base: { ref: 'staging' },
+    }]),
+  });
+  assert.match(result.failures.join(''), /merged without preserving exact main ancestry/i);
+  assert.match(result.failures.join(''), /Create a merge commit/);
+});
+
+test('workflow con token write nunca hace checkout ni referencia código del PR head', async () => {
+  const source = await syncWorkflowSource();
+  assert.doesNotMatch(source, /actions\/checkout/);
+  assert.doesNotMatch(source, /pull_request\.head\.sha/);
+  assert.doesNotMatch(source, /^  contents: write$/m);
+  assert.doesNotMatch(source, /^  pull-requests: write$/m);
+  assert.match(source, /environment:\n\s+name: Release Gate/);
+  assert.match(source, new RegExp(`actions/create-github-app-token@${APP_TOKEN_ACTION_SHA}`));
+  assert.match(source, /permission-contents: write/);
+  assert.match(source, /permission-pull-requests: write/);
+  assert.match(source, /github-token: \$\{\{ steps\.release_app\.outputs\.token \}\}/);
+  assert.doesNotMatch(source, /github-token: \$\{\{ github\.token \}\}/);
+  assert.match(source, /actions\/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea/);
+});
+
+test('promotion gate usa App dedicada protegida y publica sobre el test merge', async () => {
+  const source = await readFile(PROMOTION_WORKFLOW_URL, 'utf8');
+  assert.doesNotMatch(source, /^\s+statuses: write$/m);
+  assert.match(source, /environment:\n\s+name: Release Gate/);
+  assert.match(source, /name: release\/promotion-gate-runner/);
+  assert.match(source, new RegExp(`actions/create-github-app-token@${APP_TOKEN_ACTION_SHA}`));
+  assert.match(source, /app-id: \$\{\{ vars\.RELEASE_GATE_APP_ID \}\}/);
+  assert.match(source, /secrets\.RELEASE_GATE_APP_PRIVATE_KEY/);
+  assert.equal((source.match(/GH_TOKEN: \$\{\{ steps\.release_app\.outputs\.token \}\}/g) ?? []).length, 2);
+  assert.match(source, /MERGE_SHA: \$\{\{ steps\.live_pr\.outputs\.merge_sha \}\}/);
+  assert.equal((source.match(/statuses\/\$\{MERGE_SHA\}/g) ?? []).length, 2);
+  assert.equal((source.match(/context='release\/promotion-gate'/g) ?? []).length, 2);
+});
+
+test('promotion gate carga manifiesto desde el head SHA sin ejecutar ese checkout', async () => {
+  const source = await readFile(PROMOTION_WORKFLOW_URL, 'utf8');
+  assert.match(source, /contents\/\.github\/release\/promotion\.json\?ref=\$\{head_sha\}/);
+  assert.match(source, /Accept: application\/vnd\.github\.raw\+json/);
+  assert.match(source, /PROMOTION_MANIFEST_PATH: \$\{\{ steps\.live_pr\.outputs\.manifest_path \}\}/);
+  assert.match(source, /ref: \$\{\{ steps\.live_pr\.outputs\.base_sha \}\}/);
+  assert.doesNotMatch(source, /ref: \$\{\{[^\n]*head_sha/);
+  assert.equal((source.match(/git\/ref\/heads\/main/g) ?? []).length, 2);
+  assert.match(source, /\.base\.sha = \$base_sha \| \{ pull_request: \. \}/);
+  assert.doesNotMatch(source, /\n\s+- edited\n|\n\s+- labeled\n|\n\s+- unlabeled\n/);
+  assert.match(source, /verify-promotion-merge\.mjs/);
+  assert.match(source, /select\(\.merge_commit_sha == \$merge_sha\)/);
+});
+
+test('staging push combina deploy y QA tras Environment y firma con la App dedicada', async () => {
+  const source = await readFile(STAGING_WORKFLOW_URL, 'utf8');
+  assert.match(source, /run-name: Staging deploy \$\{\{ github\.sha \}\}/);
+  assert.match(source, /push:\n\s+branches:\n\s+- staging/);
+  assert.doesNotMatch(source, /workflow_dispatch/);
+  assert.doesNotMatch(source, /^\s+statuses: write$/m);
+  assert.match(source, /environment:\n\s+name: Staging/);
+  assert.match(source, new RegExp(`actions/create-github-app-token@${APP_TOKEN_ACTION_SHA}`));
+  assert.match(source, /app-id: \$\{\{ vars\.RELEASE_GATE_APP_ID \}\}/);
+  assert.match(source, /--staging-push-qa-current-run/);
+  assert.match(source, /RELEASE_STATUS_CREATOR_LOGIN: \$\{\{ steps\.release_app\.outputs\.app-slug \}\}\[bot\]/);
+  assert.match(source, /release\/staging-deployed/);
+  assert.match(source, /release\/staging-validated/);
+});
+
+test('cada action de terceros está fijada a SHA inmutable', async () => {
+  const workflowNames = [
+    'staging-deploy-verify.yml',
+    'main-promotion-gate.yml',
+    'main-staging-sync.yml',
+  ];
+  for (const workflowName of workflowNames) {
+    const source = await readFile(new URL(`../../.github/workflows/${workflowName}`, import.meta.url), 'utf8');
+    const uses = source
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('uses: '));
+    for (const action of uses) {
+      assert.match(action, /^uses: [A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+@[0-9a-f]{40}$/);
+    }
+  }
+});


### PR DESCRIPTION
Refs #232

## Resumen

- Define el flujo normal `feature -> staging -> main` y un carril formal `hotfix/* -> main`.
- Añade un gate fail-closed sobre el test-merge exacto de GitHub, ligado a un manifiesto inmutable y al SHA vivo de `main`.
- Verifica deploy/health, smoke, attestations firmadas por una GitHub App dedicada, procedencia del Actions run, ancestry y paridad de trees.
- Crea un PR obligatorio `sync/main-* -> staging` después de todo merge a `main`, sin auto-merge y exigiendo **Create a merge commit**.
- Añade `CODEOWNERS`, plantilla de PR, esquema de promoción, bootstrap reproducible y documentación operativa.

## Hardening relevante

- `bootstrap-lock` deja `main` read-only hasta que existan attestations válidas.
- Las protecciones se aplican `main -> staging`; un fallo parcial nunca deja live expuesto.
- Los contextos `release/*` no aceptan la App global de GitHub Actions: quedan ligados por `app_id` a una App dedicada.
- Body y labels son informativos; la autorización vive en `.github/release/promotion.json` dentro del head SHA.
- El SHA base se resuelve desde `refs/heads/main`, no desde el snapshot potencialmente obsoleto del PR.
- El sync usa token limitado de la App tras el Environment `Release Gate`; no depende de que `GITHUB_TOKEN` pueda crear PRs.

## Validación

- `node --test --test-reporter=spec scripts/release/*.test.mjs` — 125/125 OK.
- Sintaxis YAML de workflows e issue forms — OK.
- `node --check scripts/release/*.mjs` — OK.
- JSON del schema de promoción — OK.
- `git diff --check origin/staging...HEAD` — OK.
- Health público de staging validado contra `staging@99065c7c4e726dbebee9b1e2b7c75fb8e585690f` — OK.
- Revisión independiente final — sin hallazgos P0/P1.

## Freeze y prerequisitos de activación

Este PR es deliberadamente **draft** y no activa nada. No se ha modificado `main`, Coolify, mainnet, contratos, bases ni parámetros de preventa.

Antes de cualquier apply/merge operativo faltan:

1. GitHub App dedicada instalada solo en este repo y sus credenciales en Environments protegidos.
2. Environments `Staging` y `Release Gate` con revisores, sin autoaprobación y ramas custom exactas.
3. Resolver #235 para producir el CI requerido con la misma App dedicada.
4. Go/no-go explícito posterior al freeze de preventa.

La etiqueta `hotfix` se mantiene como metadata informativa, pero no como autorización mutable: el manifiesto inmutable contiene incidente, urgencia, motivo de bypass y rollback.
