### PR TITLE
fix: keep closed mobile drawer out of focus

### DIFF
--- a/dapp/__tests__/components/landing-header.test.tsx
+++ b/dapp/__tests__/components/landing-header.test.tsx
@@ -85,11 +85,16 @@ describe('components/landing/LandingHeader', () => {
     );
 
     const trigger = screen.getByRole('button', { name: 'Abrir menú' });
+    const drawer = document.getElementById('uki-mobile-navigation');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(drawer).toHaveAttribute('inert');
+    expect(drawer).toHaveAttribute('aria-hidden', 'true');
     expect(screen.queryByRole('dialog', { name: 'Menú' })).not.toBeInTheDocument();
 
     fireEvent.click(trigger);
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(drawer).not.toHaveAttribute('inert');
+    expect(drawer).toHaveAttribute('aria-hidden', 'false');
     expect(screen.getByRole('dialog', { name: 'Menú' })).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Wallet' }).every((button) => (
       button.getAttribute('data-evm-only') === 'true'
@@ -97,6 +102,8 @@ describe('components/landing/LandingHeader', () => {
 
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByRole('dialog', { name: 'Menú' })).not.toBeInTheDocument();
+    expect(drawer).toHaveAttribute('inert');
+    expect(drawer).toHaveAttribute('aria-hidden', 'true');
     expect(trigger).toHaveFocus();
   });
 

--- a/dapp/src/components/landing/header.tsx
+++ b/dapp/src/components/landing/header.tsx
@@ -153,7 +153,7 @@ export function LandingHeader({ evmOnly = false }: { evmOnly?: boolean }) {
         role="dialog"
         aria-modal="true"
         aria-hidden={!isOpen}
-        inert={isOpen ? undefined : ('' as unknown as boolean)}
+        inert={isOpen ? undefined : ('inert' as unknown as boolean)}
         aria-label={copy.menuTitle}
         className={`fixed inset-y-0 right-0 z-[70] w-64 max-w-[calc(100vw-2rem)] transform border-l border-white/10 bg-[#060a12]/95 p-6 shadow-[0_0_40px_rgba(228,92,255,0.15)] backdrop-blur-md transition-transform duration-300 ease-in-out lg:hidden ${
           isOpen ? 'translate-x-0' : 'translate-x-full'


### PR DESCRIPTION
## Resumen
- serializa correctamente `inert` cuando el drawer móvil está cerrado
- evita que teclado y lectores de pantalla entren en controles fuera de pantalla
- mantiene montado el selector de wallet al cerrar el drawer

## Validación
- `pnpm dapp test -- --runInBand __tests__/components/landing-header.test.tsx`
- `pnpm dapp lint`
- `pnpm dapp typecheck`
- `pnpm dapp build`
- reproducción en staging: el foco entraba en el drawer con `aria-hidden=true`